### PR TITLE
feat: 群消息 mention gating — 对齐 Telegram/飞书/Discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/ws": "^8.5.10",
     "openclaw": "2026.2.12",
-    "typescript": "^5.4.0"
+    "typescript": "^5.9.3"
   },
   "openclaw": {
     "extensions": [

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -3,6 +3,9 @@ import {
   DEFAULT_ACCOUNT_ID,
   type ChannelOutboundContext,
   type ChannelPlugin,
+  recordPendingHistoryEntryIfEnabled,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  type HistoryEntry,
 } from "openclaw/plugin-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DmworkConfigSchema } from "./config-schema.js";
@@ -26,6 +29,72 @@ const meta = {
   blurb: "WuKongIM gateway for DMWork",
   order: 90,
 };
+
+/**
+ * Check if the bot was mentioned in a group message.
+ * Uses the structured mention.uids field from WuKongIM payload.
+ */
+function checkBotMentioned(payload: MessagePayload | undefined, botUid: string): boolean {
+  if (!payload?.mention) return false;
+  // @all
+  if (payload.mention.all === 1) return true;
+  // @specific bot
+  if (payload.mention.uids?.includes(botUid)) return true;
+  return false;
+}
+
+/**
+ * Resolve whether mention is required for a group.
+ * Checks group-specific config, then global config. Default: true.
+ */
+function resolveRequireMention(
+  dmworkConfig: Record<string, unknown> | undefined,
+  groupId: string | undefined,
+): boolean {
+  const cfg = dmworkConfig as {
+    requireMention?: boolean;
+    groups?: Record<string, { requireMention?: boolean; enabled?: boolean }>;
+  } | undefined;
+
+  // Group-specific override
+  if (groupId && cfg?.groups) {
+    const groupConfig = cfg.groups[groupId] ?? cfg.groups["*"];
+    if (typeof groupConfig?.requireMention === "boolean") {
+      return groupConfig.requireMention;
+    }
+  }
+
+  // Global default
+  if (typeof cfg?.requireMention === "boolean") {
+    return cfg.requireMention;
+  }
+
+  // Default: require mention (same as Telegram/Feishu/Discord)
+  return true;
+}
+
+/**
+ * Check if a group is allowed based on groupPolicy.
+ */
+function isGroupAllowed(
+  dmworkConfig: Record<string, unknown> | undefined,
+  groupId: string | undefined,
+): boolean {
+  const cfg = dmworkConfig as {
+    groupPolicy?: string;
+    groups?: Record<string, { enabled?: boolean }>;
+  } | undefined;
+
+  const policy = cfg?.groupPolicy ?? "open";
+
+  if (policy === "disabled") return false;
+  if (policy === "open") return true;
+
+  // allowlist mode
+  if (!groupId || !cfg?.groups) return false;
+  const groupConfig = cfg.groups[groupId] ?? cfg.groups["*"];
+  return groupConfig?.enabled !== false && groupConfig !== undefined;
+}
 
 export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
   id: "dmwork",
@@ -53,6 +122,15 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       botToken: account.config.botToken ? "[set]" : "[missing]",
       wsUrl: account.config.wsUrl ?? "[auto-detect]",
     }),
+  },
+  groups: {
+    resolveRequireMention: (params) => {
+      const dmworkConfig = params.cfg?.channels?.dmwork as Record<string, unknown> | undefined;
+      return resolveRequireMention(dmworkConfig, params.groupId ?? undefined);
+    },
+  },
+  mentions: {
+    stripPatterns: () => ["@\\S+"],
   },
   messaging: {
     normalizeTarget: (target) => target.trim(),
@@ -173,6 +251,11 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         }, account.config.heartbeatIntervalMs);
       };
 
+      // Group message history (for context when bot is not mentioned)
+      const groupHistories = new Map<string, HistoryEntry[]>();
+      const historyLimit = DEFAULT_GROUP_HISTORY_LIMIT;
+      const dmworkConfig = (ctx.cfg as OpenClawConfig)?.channels?.dmwork as Record<string, unknown> | undefined;
+
       // 4. Connect WebSocket
       const socket = new WKSocket({
         wsUrl,
@@ -185,6 +268,46 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
           // Skip non-text for now
           if (!msg.payload || msg.payload.type !== MessageType.Text) return;
 
+          const isGroup = msg.channel_type === ChannelType.Group && !!msg.channel_id;
+
+          // --- Group message filtering ---
+          if (isGroup) {
+            // Check group policy
+            if (!isGroupAllowed(dmworkConfig, msg.channel_id)) {
+              log?.info?.(
+                `dmwork: group ${msg.channel_id} not allowed by groupPolicy, skipping`,
+              );
+              return;
+            }
+
+            // Check mention requirement
+            const needsMention = resolveRequireMention(dmworkConfig, msg.channel_id);
+            const mentioned = checkBotMentioned(msg.payload, credentials.robot_id);
+
+            if (needsMention && !mentioned) {
+              // Not mentioned — record to history for context, don't trigger AI
+              log?.info?.(
+                `dmwork: group ${msg.channel_id} message from ${msg.from_uid} — no mention, storing as context`,
+              );
+              recordPendingHistoryEntryIfEnabled({
+                historyMap: groupHistories,
+                historyKey: msg.channel_id!,
+                limit: historyLimit,
+                entry: {
+                  sender: msg.from_uid,
+                  body: `${msg.from_uid}: ${msg.payload.content ?? ""}`,
+                  timestamp: Date.now(),
+                  messageId: msg.message_id,
+                },
+              });
+              return;
+            }
+
+            log?.info?.(
+              `dmwork: group ${msg.channel_id} message from ${msg.from_uid} — mentioned=${mentioned}, processing`,
+            );
+          }
+
           log?.info?.(
             `dmwork: recv message from=${msg.from_uid} channel=${msg.channel_id ?? "DM"} type=${msg.channel_type ?? 1}`,
           );
@@ -194,6 +317,8 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
             message: msg,
             log,
             statusSink,
+            groupHistories,
+            historyLimit,
           }).catch((err) => {
             log?.error?.(`dmwork: inbound handler failed: ${String(err)}`);
           });

--- a/openclaw-channel-dmwork/src/config-schema.ts
+++ b/openclaw-channel-dmwork/src/config-schema.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+const DmworkGroupSchema = z.strictObject({
+  requireMention: z.boolean().optional(),
+  enabled: z.boolean().optional(),
+}).optional();
+
 const DmworkAccountSchema = z.strictObject({
   name: z.string().optional(),
   enabled: z.boolean().optional(),
@@ -8,6 +13,9 @@ const DmworkAccountSchema = z.strictObject({
   wsUrl: z.string().optional(),
   pollIntervalMs: z.number().int().min(500).optional(),
   heartbeatIntervalMs: z.number().int().min(5000).optional(),
+  groupPolicy: z.enum(["open", "allowlist", "disabled"]).optional(),
+  requireMention: z.boolean().optional(),
+  groups: z.record(z.string(), DmworkGroupSchema).optional(),
 });
 
 export const DmworkConfigSchema = z.strictObject({
@@ -18,6 +26,9 @@ export const DmworkConfigSchema = z.strictObject({
   wsUrl: z.string().optional(),
   pollIntervalMs: z.number().int().min(500).optional(),
   heartbeatIntervalMs: z.number().int().min(5000).optional(),
+  groupPolicy: z.enum(["open", "allowlist", "disabled"]).optional(),
+  requireMention: z.boolean().optional(),
+  groups: z.record(z.string(), DmworkGroupSchema).optional(),
   accounts: z.record(z.string(), DmworkAccountSchema.optional()).optional(),
 });
 

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1,4 +1,9 @@
 import type { ChannelLogSink, OpenClawConfig } from "openclaw/plugin-sdk";
+import {
+  buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
+  type HistoryEntry,
+} from "openclaw/plugin-sdk";
 import { sendMessage, sendReadReceipt, sendTyping } from "./api-fetch.js";
 import type { ResolvedDmworkAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
@@ -23,8 +28,10 @@ export async function handleInboundMessage(params: {
   message: BotMessage;
   log?: ChannelLogSink;
   statusSink?: DmworkStatusSink;
+  groupHistories?: Map<string, HistoryEntry[]>;
+  historyLimit?: number;
 }) {
-  const { account, message, log, statusSink } = params;
+  const { account, message, log, statusSink, groupHistories, historyLimit } = params;
 
   const isGroup =
     typeof message.channel_id === "string" &&
@@ -70,13 +77,33 @@ export async function handleInboundMessage(params: {
     sessionKey: route.sessionKey,
   });
 
+  // Build group history context (messages where bot wasn't mentioned)
+  let historyContext = "";
+  if (isGroup && groupHistories && message.channel_id) {
+    historyContext = buildPendingHistoryContextFromMap({
+      historyMap: groupHistories,
+      historyKey: message.channel_id!,
+      limit: historyLimit ?? 20,
+      currentMessage: rawBody,
+      formatEntry: (entry) => entry.body,
+    });
+    // Clear consumed history
+    clearHistoryEntriesIfEnabled({
+      historyMap: groupHistories,
+      historyKey: message.channel_id!,
+      limit: historyLimit ?? 20,
+    });
+  }
+
+  const effectiveBody = historyContext ? `${historyContext}\n\n${rawBody}` : rawBody;
+
   const body = core.channel.reply.formatAgentEnvelope({
     channel: "DMWork",
     from: fromLabel,
     timestamp: message.timestamp ? message.timestamp * 1000 : undefined,
     previousTimestamp,
     envelope: envelopeOptions,
-    body: rawBody,
+    body: effectiveBody,
   });
 
   const ctxPayload = core.channel.reply.finalizeInboundContext({
@@ -113,7 +140,7 @@ export async function handleInboundMessage(params: {
   const replyChannelId = isGroup ? message.channel_id! : message.from_uid;
   const replyChannelType = isGroup ? ChannelType.Group : ChannelType.DM;
 
-  // 已读回执 + 正在输入 — fire-and-forget，失败不影响主流程
+  // 已读回执 + 正在输入 — fire-and-forget
   log?.info?.(`dmwork: sending readReceipt+typing to channel=${replyChannelId} type=${replyChannelType} apiUrl=${account.config.apiUrl}`);
   const messageIds = message.message_id ? [message.message_id] : [];
   sendReadReceipt({ apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", channelId: replyChannelId, channelType: replyChannelType, messageIds })

--- a/openclaw-channel-dmwork/src/types.ts
+++ b/openclaw-channel-dmwork/src/types.ts
@@ -55,10 +55,16 @@ export interface BotMessage {
   payload: MessagePayload;
 }
 
+export interface MentionPayload {
+  uids?: string[];
+  all?: number; // 1 = @all
+}
+
 export interface MessagePayload {
   type: MessageType;
   content?: string;
   url?: string;
+  mention?: MentionPayload;
   [key: string]: unknown;
 }
 
@@ -102,9 +108,17 @@ export enum MessageType {
 }
 
 /** Plugin config */
+export interface DMWorkGroupConfig {
+  requireMention?: boolean;
+  enabled?: boolean;
+}
+
 export interface DMWorkConfig {
   botToken: string;
   apiUrl: string;
   wsUrl?: string;
+  groupPolicy?: "open" | "allowlist" | "disabled";
+  requireMention?: boolean;
+  groups?: Record<string, DMWorkGroupConfig>;
 }
 


### PR DESCRIPTION
## 改动

### 核心：群消息默认需要 @mention 才触发 AI

参照 OpenClaw 的 Telegram/飞书/Discord 插件设计模式：

- `requireMention: true` (默认) — 群消息只有 @Bot 才触发 AI 回复
- 未 @ 的群消息存入 history context — Bot 被 @ 时能看到上文
- `groupPolicy` 配置 — open/allowlist/disabled

### 配置示例

```yaml
channels:
  dmwork:
    requireMention: true      # 默认
    groupPolicy: open         # open/allowlist/disabled
    groups:
      "group_123":
        requireMention: false  # 此群不需要@也回复
```

### 详细改动

- `types.ts`: 新增 MentionPayload 类型、DMWorkGroupConfig
- `config-schema.ts`: 新增 groupPolicy、requireMention、groups 配置
- `channel.ts`: checkBotMentioned()、resolveRequireMention()、isGroupAllowed()、history 管理
- `inbound.ts`: 接收 groupHistories，构建 history context 注入到 AI 对话

### 影响

在 1000 人群聊场景下，此改动将 AI 调用从「每条群消息都触发」降为「仅 @Bot 时触发」，大幅降低费用和负载。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added group-aware message handling with configurable mention policies (open, allowlist, disabled)
  * Introduced per-group configuration options for mention requirements
  * Added conversation history context support for group messages
  * Added mention pattern stripping capability

* **Dependencies**
  * Updated TypeScript to 5.9.3

* **Chores**
  * Updated .gitignore to exclude node_modules directory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->