### PR TITLE
refactor: 纯 WS 实时 + token 自动刷新（移除 events 轮询）

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -3,7 +3,7 @@
  * These are used by inbound/outbound where the full DMWorkAPI class is not available.
  */
 
-import { ChannelType, MessageType, type BotEventsResp } from "./types.js";
+import { ChannelType, MessageType } from "./types.js";
 
 const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
@@ -90,31 +90,12 @@ export async function sendHeartbeat(params: {
   await postJson(params.apiUrl, params.botToken, "/v1/bot/heartbeat", {}, params.signal);
 }
 
-export async function fetchEvents(params: {
-  apiUrl: string;
-  botToken: string;
-  lastEventId: number;
-  limit?: number;
-  signal?: AbortSignal;
-}): Promise<BotEventsResp> {
-  return postJson(params.apiUrl, params.botToken, "/v1/bot/events", {
-    event_id: params.lastEventId,
-    limit: params.limit ?? 50,
-  }, params.signal);
-}
 
-export async function ackEvent(params: {
-  apiUrl: string;
-  botToken: string;
-  eventId: number;
-  signal?: AbortSignal;
-}): Promise<void> {
-  await postJson(params.apiUrl, params.botToken, `/v1/bot/events/${params.eventId}/ack`, {}, params.signal);
-}
 
 export async function registerBot(params: {
   apiUrl: string;
   botToken: string;
+  forceRefresh?: boolean;
   signal?: AbortSignal;
 }): Promise<{
   robot_id: string;
@@ -124,5 +105,8 @@ export async function registerBot(params: {
   owner_uid: string;
   owner_channel_id: string;
 }> {
-  return postJson(params.apiUrl, params.botToken, "/v1/bot/register", {}, params.signal);
+  const path = params.forceRefresh
+    ? "/v1/bot/register?force_refresh=true"
+    : "/v1/bot/register";
+  return postJson(params.apiUrl, params.botToken, path, {}, params.signal);
 }

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -12,7 +12,7 @@ import {
   resolveDmworkAccount,
   type ResolvedDmworkAccount,
 } from "./accounts.js";
-import { registerBot, sendMessage, sendHeartbeat, fetchEvents, ackEvent } from "./api-fetch.js";
+import { registerBot, sendMessage, sendHeartbeat } from "./api-fetch.js";
 import { WKSocket } from "./socket.js";
 import { handleInboundMessage, type DmworkStatusSink } from "./inbound.js";
 import { ChannelType, MessageType, type BotMessage, type MessagePayload } from "./types.js";
@@ -27,6 +27,13 @@ const meta = {
   blurb: "WuKongIM gateway for DMWork",
   order: 90,
 };
+
+/**
+ * Token refresh delay — if no WS message (including CMD) is received within
+ * this window after connect, we assume the cached IM token is stale and
+ * re-register with force_refresh=true to obtain a fresh token from WuKongIM.
+ */
+const TOKEN_REFRESH_TIMEOUT_MS = 10_000;
 
 export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
   id: "dmwork",
@@ -125,7 +132,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
 
       log?.info?.(`[${account.accountId}] registering DMWork bot...`);
 
-      // 1. Register bot
+      // 1. Register bot (first attempt uses cached token)
       let credentials: {
         robot_id: string;
         im_token: string;
@@ -163,7 +170,6 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       let stopped = false;
 
       const startHeartbeat = () => {
-        // Clear existing heartbeat to prevent duplicates on reconnect
         if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
         heartbeatTimer = setInterval(() => {
           if (stopped) return;
@@ -179,13 +185,20 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       // 4. Group history map for mention gating context
       const groupHistories = new Map<string, HistoryEntry[]>();
 
-      // 5. Connect WebSocket
+      // 5. Token refresh state — detect stale cached token
+      let receivedAnyWsMessage = false;
+      let tokenRefreshTimer: NodeJS.Timeout | null = null;
+      let hasRefreshedToken = false;
+
+      // 6. Connect WebSocket — pure real-time via WuKongIM SDK
       const socket = new WKSocket({
         wsUrl,
         uid: credentials.robot_id,
         token: credentials.im_token,
 
         onMessage: (msg: BotMessage) => {
+          receivedAnyWsMessage = true;
+
           // Skip self messages
           if (msg.from_uid === credentials.robot_id) return;
           // Skip non-text for now
@@ -212,7 +225,37 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
           statusSink({ lastError: null });
           startHeartbeat();
 
-          // No greeting on connect — bot stays silent until user sends a message
+          // Start token freshness check — if no WS messages arrive within
+          // TOKEN_REFRESH_TIMEOUT_MS, the cached IM token is likely stale
+          // (e.g. after WuKongIM restart). Re-register with force_refresh
+          // to get a new token and reconnect.
+          if (!hasRefreshedToken) {
+            tokenRefreshTimer = setTimeout(async () => {
+              if (stopped || receivedAnyWsMessage || hasRefreshedToken) return;
+              log?.warn?.(
+                "dmwork: no WS messages received — cached IM token may be stale, refreshing...",
+              );
+              hasRefreshedToken = true;
+              try {
+                const fresh = await registerBot({
+                  apiUrl: account.config.apiUrl,
+                  botToken: account.config.botToken!,
+                  forceRefresh: true,
+                });
+                credentials = fresh;
+                log?.info?.(
+                  `dmwork: got fresh IM token, reconnecting WS...`,
+                );
+                socket.disconnect();
+                socket.updateCredentials(fresh.robot_id, fresh.im_token);
+                socket.connect();
+              } catch (err) {
+                log?.error?.(
+                  `dmwork: token refresh failed: ${String(err)}`,
+                );
+              }
+            }, TOKEN_REFRESH_TIMEOUT_MS);
+          }
         },
 
         onDisconnected: () => {
@@ -228,89 +271,12 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
 
       socket.connect();
 
-      // 6. Events polling fallback for reliable message delivery
-      let lastEventId = 0;
-      const seenMessageIds = new Set<string>();
-      let pollTimer: NodeJS.Timeout | null = null;
-      let pollInFlight = false;
-
-      const pollEvents = async () => {
-        if (stopped || pollInFlight) return;
-        pollInFlight = true;
-        try {
-          const resp = await fetchEvents({
-            apiUrl: account.config.apiUrl,
-            botToken: account.config.botToken!,
-            lastEventId,
-            limit: 50,
-          });
-          for (const event of resp.results ?? []) {
-            if (event.event_id > lastEventId) {
-              lastEventId = event.event_id;
-            }
-            const msg = event.message;
-            if (!msg) continue;
-            // Always ack the event regardless of dedup
-            ackEvent({
-              apiUrl: account.config.apiUrl,
-              botToken: account.config.botToken!,
-              eventId: event.event_id,
-            }).catch((err) => {
-              log?.error?.(`dmwork: ack event ${event.event_id} failed: ${String(err)}`);
-            });
-            // Dedup by message_id
-            if (seenMessageIds.has(msg.message_id)) continue;
-            seenMessageIds.add(msg.message_id);
-            if (seenMessageIds.size > 1000) {
-              const oldest = seenMessageIds.values().next().value!;
-              seenMessageIds.delete(oldest);
-            }
-            // Skip self and non-text
-            if (msg.from_uid === credentials.robot_id) continue;
-            if (!msg.payload || msg.payload.type !== MessageType.Text) continue;
-            // DM events may omit channel_id — default to sender uid
-            const normalizedMsg: BotMessage = {
-              ...msg,
-              channel_id: msg.channel_id ?? msg.from_uid,
-              channel_type: msg.channel_type ?? ChannelType.DM,
-            };
-            log?.info?.(
-              `dmwork: poll recv message_id=${msg.message_id} from=${msg.from_uid} channel=${normalizedMsg.channel_id} type=${normalizedMsg.channel_type}`,
-            );
-            handleInboundMessage({
-              account,
-              message: normalizedMsg,
-              botUid: credentials.robot_id,
-              groupHistories,
-              log,
-              statusSink,
-            }).catch((err) => {
-              log?.error?.(`dmwork: poll inbound handler failed: ${String(err)}`);
-            });
-          }
-        } catch (err) {
-          if (!stopped) {
-            log?.warn?.(`dmwork: events poll failed: ${String(err)}`);
-          }
-        } finally {
-          pollInFlight = false;
-        }
-      };
-
-      pollTimer = setInterval(() => { pollEvents(); }, 2000);
-
       // Handle abort signal
       const onAbort = () => {
         stopped = true;
         socket.disconnect();
-        if (heartbeatTimer) {
-          clearInterval(heartbeatTimer);
-          heartbeatTimer = null;
-        }
-        if (pollTimer) {
-          clearInterval(pollTimer);
-          pollTimer = null;
-        }
+        if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
+        if (tokenRefreshTimer) { clearTimeout(tokenRefreshTimer); tokenRefreshTimer = null; }
       };
 
       if (ctx.abortSignal.aborted) {
@@ -323,14 +289,8 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         stop: () => {
           stopped = true;
           socket.disconnect();
-          if (heartbeatTimer) {
-            clearInterval(heartbeatTimer);
-            heartbeatTimer = null;
-          }
-          if (pollTimer) {
-            clearInterval(pollTimer);
-            pollTimer = null;
-          }
+          if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
+          if (tokenRefreshTimer) { clearTimeout(tokenRefreshTimer); tokenRefreshTimer = null; }
           ctx.abortSignal.removeEventListener("abort", onAbort);
           ctx.setStatus({
             accountId: account.accountId,

--- a/openclaw-channel-dmwork/src/socket.ts
+++ b/openclaw-channel-dmwork/src/socket.ts
@@ -103,6 +103,12 @@ export class WKSocket extends EventEmitter {
     im.connect();
   }
 
+  /** Update credentials for reconnection (e.g. after token refresh) */
+  updateCredentials(uid: string, token: string): void {
+    this.opts.uid = uid;
+    this.opts.token = token;
+  }
+
   /** Gracefully disconnect */
   disconnect(): void {
     const im = WKSDK.shared();

--- a/openclaw-channel-dmwork/src/types.ts
+++ b/openclaw-channel-dmwork/src/types.ts
@@ -35,11 +35,6 @@ export interface BotEventsReq {
   limit?: number;
 }
 
-export interface BotEventsResp {
-  status: number;
-  results: BotEvent[];
-}
-
 export interface BotEvent {
   event_id: number;
   message?: BotMessage;


### PR DESCRIPTION
## 变更
- 移除全部 events 轮询代码（fetchEvents/ackEvent/poll loop）
- WS onMessage 直接处理消息
- 连接后 10s 无消息 → force_refresh 刷新 IM token → 重连
- WKSocket.updateCredentials() 支持 token 热更新

## 理由
纯 WS 实时才能发挥悟空 IM 全部能力：实时状态、typing、已读回执

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic token refresh mechanism triggered on WebSocket connection when no messages arrive within timeout window.

* **Modified**
  * Bot registration API signature updated with optional force refresh parameter.
  * Bot registration response now includes additional credentials for WebSocket authentication.

* **Removed**
  * Event polling API functions removed; migrate to WebSocket-based real-time event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->