### PR TITLE
fix: align plugin id with npm package name to resolve OpenClaw config warning

### DIFF
--- a/openclaw-channel-dmwork/openclaw.plugin.json
+++ b/openclaw-channel-dmwork/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "dmwork",
+  "id": "openclaw-channel-dmwork",
   "channels": [
     "dmwork"
   ],

--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -27,7 +27,7 @@
     "typescript": "^5.9.3"
   },
   "openclaw": {
-    "id": "dmwork",
+    "id": "openclaw-channel-dmwork",
     "type": "channel",
     "extensions": [
       "index.ts"


### PR DESCRIPTION
## Problem

OpenClaw's manifest registry compares the plugin manifest `id` (from `openclaw.plugin.json`) against the npm package name as `idHint`. When they differ, it emits a config warning at every startup:

```
plugins.entries.dmwork: plugin dmwork: plugin id mismatch (manifest uses "dmwork", entry hints "openclaw-channel-dmwork")
```

### Root Cause

- `openclaw.plugin.json` declares `"id": "dmwork"`
- `package.json` declares `"name": "openclaw-channel-dmwork"`
- OpenClaw uses the npm package name (`openclaw-channel-dmwork`) as `idHint` and compares it against the manifest id (`dmwork`) — mismatch triggers the warning

### Relevant OpenClaw source (manifest-registry):
```js
if (candidate.idHint && candidate.idHint !== manifest.id)
  diagnostics.push({ level: 'warn', message: \`plugin id mismatch ...\` });
```

## Fix

Align the plugin id in both `openclaw.plugin.json` and `package.json` `openclaw.id` to `"openclaw-channel-dmwork"`, matching the npm package name.

## Changes

- `openclaw-channel-dmwork/openclaw.plugin.json`: `id` → `"openclaw-channel-dmwork"`
- `openclaw-channel-dmwork/package.json`: `openclaw.id` → `"openclaw-channel-dmwork"`

## Migration Note

Users upgrading from older versions need to update their `openclaw.json`:

```diff
  "plugins": {
    "entries": {
-     "dmwork": {
+     "openclaw-channel-dmwork": {
        "enabled": true
      }
    }
  }
```

Channel config key (`channels.dmwork`) remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin identifier configuration to align with consistent naming standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->