### PR TITLE
chore: internationalize issue/PR templates to English

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,83 +1,83 @@
-name: 🐛 Bug 报告
-description: 报告一个 Bug
+name: 🐛 Bug Report
+description: Report a bug
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢你报告 Bug！请尽量填写完整信息，帮助我们快速定位问题。
+        Thanks for reporting! Please fill in as much detail as possible to help us diagnose the issue.
   - type: textarea
     id: summary
     attributes:
-      label: 问题描述
-      description: 简要描述遇到的问题
-      placeholder: Bot 连接 WebSocket 后频繁断线重连
+      label: Description
+      description: Briefly describe the issue
+      placeholder: Bot disconnects from WebSocket every 30 seconds
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
-      label: 复现步骤
-      description: 按顺序列出复现步骤
+      label: Steps to Reproduce
+      description: List the steps to reproduce
       placeholder: |
-        1. 配置 dmwork channel plugin
-        2. openclaw gateway restart
-        3. 观察日志：WebSocket 每 30 秒断连
+        1. Configure dmwork channel plugin
+        2. Run `openclaw gateway restart`
+        3. Observe logs: WebSocket disconnects every 30s
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
-      label: 期望行为
-      placeholder: WebSocket 保持稳定连接
+      label: Expected Behavior
+      placeholder: WebSocket maintains a stable connection
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
-      label: 实际行为
-      placeholder: 每 30 秒断连并重连，日志中有 ECONNRESET 错误
+      label: Actual Behavior
+      placeholder: Disconnects every 30s with ECONNRESET in logs
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: 适配器版本
-      placeholder: "0.2.17"
+      label: Adapter Version
+      placeholder: "0.2.18"
     validations:
       required: true
   - type: dropdown
     id: component
     attributes:
-      label: 影响组件
+      label: Affected Component
       options:
         - OpenClaw Channel Plugin
         - Claude Code Adapter
-        - 其他
+        - Other
     validations:
       required: true
   - type: dropdown
     id: severity
     attributes:
-      label: 严重程度
+      label: Severity
       options:
-        - P0 - 服务不可用 / 数据丢失
-        - P1 - 核心功能异常
-        - P2 - 非核心功能异常
-        - P3 - 体验问题
+        - P0 - Service Down / Data Loss
+        - P1 - Core Feature Broken
+        - P2 - Non-core Feature Issue
+        - P3 - UX Issue
     validations:
       required: true
   - type: checkboxes
     id: reproducible
     attributes:
-      label: 可复现性
+      label: Reproducibility
       options:
-        - label: 可稳定复现
+        - label: Consistently reproducible
   - type: textarea
     id: environment
     attributes:
-      label: 环境信息
-      description: OS、Node.js 版本、OpenClaw 版本、DMWork 服务端版本等
+      label: Environment
+      description: OS, Node.js version, OpenClaw version, DMWork server version, etc.
       placeholder: |
         - OS: macOS 15.3
         - Node.js: 22.x
@@ -88,7 +88,7 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: 日志 / 截图
-      description: 相关日志、错误信息或截图（敏感信息请脱敏）
+      label: Logs / Screenshots
+      description: Relevant logs, error messages, or screenshots (redact sensitive info)
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 🔒 安全漏洞报告
+  - name: 🔒 Security Vulnerability
     url: https://github.com/dmwork-org/dmworkim/blob/main/SECURITY.md
-    about: 安全漏洞请勿公开提 Issue，请按 SECURITY.md 流程报告
-  - name: 💬 讨论 / 提问
+    about: Do not open a public issue for security vulnerabilities. Follow the SECURITY.md process instead.
+  - name: 💬 Discussion / Questions
     url: https://github.com/dmwork-org/dmwork-adapters/discussions
-    about: 使用问题和一般性讨论请到 Discussions
+    about: For usage questions and general discussion, please use Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,46 +1,46 @@
 name: 💡 Feature Request
-description: 提出新功能建议
+description: Suggest a new feature
 labels: ["feature"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢你的建议！请描述清楚需求背景和期望方案。
+        Thanks for your suggestion! Please describe the problem and your proposed solution.
   - type: textarea
     id: problem
     attributes:
-      label: 问题 / 动机
-      description: 你遇到了什么问题，或者为什么需要这个功能？
+      label: Problem / Motivation
+      description: What problem are you facing, or why do you need this feature?
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
-      label: 期望方案
-      description: 你希望怎么解决？
+      label: Proposed Solution
+      description: How would you like this to be solved?
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: 替代方案
-      description: 你考虑过其他方案吗？
+      label: Alternatives Considered
+      description: Have you considered other approaches?
     validations:
       required: false
   - type: dropdown
     id: component
     attributes:
-      label: 涉及组件
+      label: Component
       options:
         - OpenClaw Channel Plugin
         - Claude Code Adapter
-        - 其他
+        - Other
     validations:
       required: true
   - type: textarea
     id: context
     attributes:
-      label: 补充信息
-      description: 参考链接、相关 Issue 等
+      label: Additional Context
+      description: Related links, issues, etc.
     validations:
       required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,17 @@
 ## What
-<!-- 简要描述这个 PR 做了什么 -->
+<!-- Brief description of what this PR does -->
 
 ## Why
-<!-- 为什么要做这个改动？关联 Issue：Closes #xx -->
+<!-- Why is this change needed? Related issue: Closes #xx -->
 
 ## How
-<!-- 技术方案简述（如果改动不明显） -->
+<!-- Technical approach (if not obvious from the diff) -->
 
 ## Testing
-- [ ] 本地编译通过（`npm run build`）
-- [ ] 类型检查通过（`npm run type-check`）
-- [ ] 无安全风险
-- [ ] 已在本地 OpenClaw 实例验证（如适用）
+- [ ] Local build passes (`npm run build`)
+- [ ] Type check passes (`npm run type-check`)
+- [ ] No security risks
+- [ ] Verified with local OpenClaw instance (if applicable)
 
-## AI 辅助（如适用）
-<!-- 使用了什么 AI 工具？测试程度？确认理解代码？ -->
+## AI Assistance (if applicable)
+<!-- What AI tools were used? Testing level? Do you understand the code? -->


### PR DESCRIPTION
## What
Translate all GitHub issue templates, config, and PR template from Chinese to English.

## Why
This project is open-source and targets an international community. Templates should be in English.

## How
- `bug_report.yml` — all labels, descriptions, placeholders in English
- `feature_request.yml` — all labels, descriptions in English
- `config.yml` — contact link names and descriptions in English
- `PULL_REQUEST_TEMPLATE.md` — all sections in English

## Testing
- [x] YAML syntax valid
- [x] No functional changes, only text translation
- [x] AI-assisted (OpenClaw agent, fully tested)