### PR TITLE
fix: handle channel_type as string or number (Closes #13)

### DIFF
--- a/openclaw-channel-dmwork/src/inbound.test.ts
+++ b/openclaw-channel-dmwork/src/inbound.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ChannelType, MessageType, type MentionPayload } from "./types.js";
+import { ChannelType, MessageType, type MentionPayload, type BotMessage } from "./types.js";
 
 /**
  * Tests for mention.all detection logic.
@@ -49,5 +49,91 @@ describe("mention.all detection", () => {
   it("should NOT detect mention.all when all is a different number", () => {
     const mention: MentionPayload = { all: 2 };
     expect(isMentionAll(mention)).toBe(false);
+  });
+});
+
+/**
+ * Tests for channel_type detection logic (isGroup determination).
+ *
+ * The channel_type can come as either:
+ * - number `2` (native SDK format)
+ * - string `"2"` (JSON serialization or older SDK versions)
+ *
+ * Both should be treated as ChannelType.Group.
+ *
+ * Bug: #13 - 纯人类成员无法创建群聊 (pure human members cannot create group chat)
+ * Root cause: strict equality (===) fails for string "2" vs number 2
+ */
+describe("channel_type detection (isGroup)", () => {
+  // Helper to simulate the detection logic from inbound.ts
+  function isGroupMessage(message: Partial<BotMessage>): boolean {
+    const channelType = Number(message.channel_type);
+    return (
+      typeof message.channel_id === "string" &&
+      message.channel_id.length > 0 &&
+      channelType === ChannelType.Group
+    );
+  }
+
+  it("should detect group when channel_type is number 2", () => {
+    const message: Partial<BotMessage> = {
+      channel_id: "group123",
+      channel_type: ChannelType.Group, // 2
+    };
+    expect(isGroupMessage(message)).toBe(true);
+  });
+
+  it("should detect group when channel_type is string '2'", () => {
+    const message: Partial<BotMessage> = {
+      channel_id: "group123",
+      channel_type: "2" as unknown as ChannelType, // string from SDK
+    };
+    expect(isGroupMessage(message)).toBe(true);
+  });
+
+  it("should NOT detect group when channel_type is DM (number 1)", () => {
+    const message: Partial<BotMessage> = {
+      channel_id: "user123",
+      channel_type: ChannelType.DM, // 1
+    };
+    expect(isGroupMessage(message)).toBe(false);
+  });
+
+  it("should NOT detect group when channel_type is DM (string '1')", () => {
+    const message: Partial<BotMessage> = {
+      channel_id: "user123",
+      channel_type: "1" as unknown as ChannelType, // string from SDK
+    };
+    expect(isGroupMessage(message)).toBe(false);
+  });
+
+  it("should NOT detect group when channel_id is empty", () => {
+    const message: Partial<BotMessage> = {
+      channel_id: "",
+      channel_type: ChannelType.Group,
+    };
+    expect(isGroupMessage(message)).toBe(false);
+  });
+
+  it("should NOT detect group when channel_id is undefined", () => {
+    const message: Partial<BotMessage> = {
+      channel_type: ChannelType.Group,
+    };
+    expect(isGroupMessage(message)).toBe(false);
+  });
+
+  it("should NOT detect group when channel_type is undefined", () => {
+    const message: Partial<BotMessage> = {
+      channel_id: "group123",
+    };
+    expect(isGroupMessage(message)).toBe(false);
+  });
+
+  it("should handle channel_type as 0 (falsy but valid)", () => {
+    const message: Partial<BotMessage> = {
+      channel_id: "channel123",
+      channel_type: 0 as unknown as ChannelType,
+    };
+    expect(isGroupMessage(message)).toBe(false);
   });
 });

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -147,10 +147,12 @@ export async function handleInboundMessage(params: {
 
   await ensureSdkLoaded();
 
+  // channel_type can come as number (2) or string ("2") depending on SDK version
+  const channelType = Number(message.channel_type);
   const isGroup =
     typeof message.channel_id === "string" &&
     message.channel_id.length > 0 &&
-    message.channel_type === ChannelType.Group;
+    channelType === ChannelType.Group;
 
   const sessionId = isGroup
     ? message.channel_id!


### PR DESCRIPTION
## Summary
- Fixed `channel_type` comparison to handle both string and number values
- Similar to issue #19 (mention.all), the WuKongIM SDK can return `channel_type` as either number `2` or string `"2"`
- Added 8 test cases covering all edge cases

## Root Cause
The strict equality check (`===`) in `isGroup` determination failed when `channel_type` came as string `"2"` instead of number `2`. This caused group messages to be treated as DM messages, leading to "群不存在" (group doesn't exist) errors.

## Changes
- `src/inbound.ts`: Convert `channel_type` to number before comparison using `Number(message.channel_type)`
- `src/inbound.test.ts`: Added test suite for `channel_type` detection with 8 test cases

## Test plan
- [x] All 15 tests pass (7 existing + 8 new)
- [x] Verified pre-existing TypeScript errors are not caused by these changes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)