### PR TITLE
fix: unify @mention regex across inbound/outbound paths

### DIFF
--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -15,6 +15,7 @@ import { registerBot, sendMessage, sendHeartbeat } from "./api-fetch.js";
 import { WKSocket } from "./socket.js";
 import { handleInboundMessage, type DmworkStatusSink } from "./inbound.js";
 import { ChannelType, MessageType, type BotMessage, type MessagePayload } from "./types.js";
+import { parseMentions } from "./mention-utils.js";
 // HistoryEntry type - compatible with any version
 type HistoryEntry = { sender: string; body: string; timestamp: number };
 const DEFAULT_GROUP_HISTORY_LIMIT = 20;
@@ -140,16 +141,13 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         }
         channelType = ChannelType.Group;
 
-        // Parse @mentions from message content (e.g., "@chenpipi_bot" -> "chenpipi_bot")
-        // Match @username where username is alphanumeric with underscores (typical uid format)
-        const contentMentions = content.match(/@([a-zA-Z0-9_]+)/g);
-        if (contentMentions) {
-          for (const mention of contentMentions) {
-            const uid = mention.slice(1); // Remove @ prefix
-            if (uid && !mentionUids.includes(uid)) {
-              mentionUids.push(uid);
-              console.log(`[dmwork] parsed @mention from content: ${uid}`);
-            }
+        // Parse @mentions from message content (e.g., "@chenpipi_bot", "@陈皮皮")
+        // Uses shared utility for consistent regex across inbound/outbound (fixes #31)
+        const contentMentionNames = parseMentions(content);
+        for (const name of contentMentionNames) {
+          if (name && !mentionUids.includes(name)) {
+            mentionUids.push(name);
+            console.log(`[dmwork] parsed @mention from content: ${name}`);
           }
         }
         if (mentionUids.length > 0) {

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -5,6 +5,7 @@ import type { BotMessage } from "./types.js";
 import { ChannelType, MessageType } from "./types.js";
 import { getDmworkRuntime } from "./runtime.js";
 import { DEFAULT_HISTORY_PROMPT_TEMPLATE } from "./config-schema.js";
+import { extractMentionMatches } from "./mention-utils.js";
 
 // Defensive imports — these may not exist in older OpenClaw versions
 // History context managed manually for cross-SDK compatibility
@@ -259,8 +260,9 @@ export async function handleInboundMessage(params: {
   // When user sends "@陈皮皮 @托马斯.福 xxx", the @ names in content correspond to mention.uids in order
   if (isGroup) {
     const allMentionUids: string[] = message.payload?.mention?.uids ?? [];
-    // Match all @xxx patterns (including Chinese characters and dots)
-    const contentMentions = rawBody.match(/@[\w\u4e00-\u9fa5.]+/g) ?? [];
+    // Match all @xxx patterns (including Chinese characters, dots, hyphens)
+    // Uses shared utility for consistent regex across inbound/outbound (fixes #31)
+    const contentMentions = extractMentionMatches(rawBody);
     
     if (contentMentions.length > 0 && allMentionUids.length > 0) {
       log?.debug?.(`dmwork: [MAPPING] content @names: ${JSON.stringify(contentMentions)}, mention.uids: ${JSON.stringify(allMentionUids)}`);
@@ -503,7 +505,8 @@ export async function handleInboundMessage(params: {
         
         if (isGroup) {
           // Parse all @mentions from content (support Chinese, English, dots, underscores, hex uids)
-          const contentMentions = content.match(/@[\w\u4e00-\u9fa5.]+/g) ?? [];
+          // Uses shared utility for consistent regex across inbound/outbound (fixes #31)
+          const contentMentions = extractMentionMatches(content);
           
           log?.debug?.(`dmwork: [REPLY] content @mentions count: ${contentMentions.length}`);
           log?.debug?.(`dmwork: [REPLY] memberMap size: ${memberMap.size}, uidToNameMap size: ${uidToNameMap.size}`);

--- a/openclaw-channel-dmwork/src/mention-utils.test.ts
+++ b/openclaw-channel-dmwork/src/mention-utils.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { parseMentions, extractMentionMatches, MENTION_PATTERN } from "./mention-utils.js";
+
+/**
+ * Tests for shared @mention parsing utilities.
+ * Verifies consistent behavior across different mention formats.
+ *
+ * Fixes: https://github.com/dmwork-org/dmwork-adapters/issues/31
+ */
+describe("parseMentions", () => {
+  it("should parse English alphanumeric mentions", () => {
+    const result = parseMentions("Hello @user123 and @test_user!");
+    expect(result).toEqual(["user123", "test_user"]);
+  });
+
+  it("should parse Chinese character mentions", () => {
+    const result = parseMentions("你好 @陈皮皮 请回复");
+    expect(result).toEqual(["陈皮皮"]);
+  });
+
+  it("should parse mixed Chinese and English mentions", () => {
+    const result = parseMentions("@陈皮皮 @bob_123 @托马斯");
+    expect(result).toEqual(["陈皮皮", "bob_123", "托马斯"]);
+  });
+
+  it("should parse mentions with dots", () => {
+    const result = parseMentions("Hi @thomas.ford how are you?");
+    expect(result).toEqual(["thomas.ford"]);
+  });
+
+  it("should parse mentions with hyphens", () => {
+    const result = parseMentions("CC @user-name please");
+    expect(result).toEqual(["user-name"]);
+  });
+
+  it("should parse complex mixed mentions", () => {
+    const result = parseMentions("@陈皮皮_test @user.name-123 @普通用户");
+    expect(result).toEqual(["陈皮皮_test", "user.name-123", "普通用户"]);
+  });
+
+  it("should return empty array for no mentions", () => {
+    const result = parseMentions("Hello world! No mentions here.");
+    expect(result).toEqual([]);
+  });
+
+  it("should handle @all-like patterns", () => {
+    const result = parseMentions("@all please check @everyone");
+    expect(result).toEqual(["all", "everyone"]);
+  });
+
+  it("should handle mentions at start and end", () => {
+    const result = parseMentions("@start middle @end");
+    expect(result).toEqual(["start", "end"]);
+  });
+
+  it("should handle consecutive mentions", () => {
+    const result = parseMentions("@user1@user2@user3");
+    expect(result).toEqual(["user1", "user2", "user3"]);
+  });
+});
+
+describe("extractMentionMatches", () => {
+  it("should return matches with @ prefix", () => {
+    const result = extractMentionMatches("Hello @陈皮皮 and @bob!");
+    expect(result).toEqual(["@陈皮皮", "@bob"]);
+  });
+
+  it("should return empty array for no mentions", () => {
+    const result = extractMentionMatches("No mentions");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("MENTION_PATTERN", () => {
+  it("should be a valid regex", () => {
+    expect(MENTION_PATTERN).toBeInstanceOf(RegExp);
+  });
+
+  it("should have global flag", () => {
+    expect(MENTION_PATTERN.flags).toContain("g");
+  });
+
+  it("should match Chinese characters (CJK range)", () => {
+    // Test the pattern directly
+    const testStr = "@中文名字";
+    const regex = new RegExp(MENTION_PATTERN.source, "g");
+    const match = testStr.match(regex);
+    expect(match).toEqual(["@中文名字"]);
+  });
+
+  it("should match underscores", () => {
+    const testStr = "@user_name_123";
+    const regex = new RegExp(MENTION_PATTERN.source, "g");
+    const match = testStr.match(regex);
+    expect(match).toEqual(["@user_name_123"]);
+  });
+});

--- a/openclaw-channel-dmwork/src/mention-utils.ts
+++ b/openclaw-channel-dmwork/src/mention-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared @mention parsing utilities.
+ * Ensures consistent mention detection across inbound and outbound code paths.
+ *
+ * Fixes: https://github.com/dmwork-org/dmwork-adapters/issues/31
+ */
+
+/**
+ * Regex pattern for matching @mentions in message content.
+ * Supports:
+ * - English alphanumeric with underscores: @user_123
+ * - Chinese characters: @陈皮皮
+ * - Dots and hyphens: @thomas.ford, @user-name
+ * - Mixed: @陈皮皮_test
+ */
+export const MENTION_PATTERN = /@[\w\u4e00-\u9fa5.\-]+/g;
+
+/**
+ * Parse @mentions from message content.
+ * Returns an array of mentioned names (without the @ prefix).
+ *
+ * @example
+ * parseMentions("Hello @陈皮皮 and @bob_123!")
+ * // Returns: ["陈皮皮", "bob_123"]
+ */
+export function parseMentions(content: string): string[] {
+  // Create a new RegExp instance to reset lastIndex for global matching
+  const regex = new RegExp(MENTION_PATTERN.source, "g");
+  const matches = content.match(regex) ?? [];
+  return matches.map((m) => m.slice(1)); // Remove @ prefix
+}
+
+/**
+ * Extract raw @mention matches including the @ prefix.
+ * Useful when you need to know the exact position or full match.
+ *
+ * @example
+ * extractMentionMatches("Hello @陈皮皮!")
+ * // Returns: ["@陈皮皮"]
+ */
+export function extractMentionMatches(content: string): string[] {
+  const regex = new RegExp(MENTION_PATTERN.source, "g");
+  return content.match(regex) ?? [];
+}


### PR DESCRIPTION
## What

Extract shared mention parsing utilities to ensure consistent @mention regex behavior across inbound (WebSocket message handling) and outbound (sendText API) code paths.

## Why

The previous implementation used different regex patterns:
- **inbound.ts**: `/@[\w\u4e00-\u9fa5.]+/g` (supports Chinese characters)
- **channel.ts**: `/@([a-zA-Z0-9_]+)/g` (ASCII only)

This caused Chinese @mentions like `@陈皮皮` to work correctly when receiving messages but fail silently when sending replies via the outbound path.

Closes #31

## How

1. Created `mention-utils.ts` with shared `MENTION_PATTERN` regex and utility functions:
   - `parseMentions(content)` - returns mention names without @ prefix
   - `extractMentionMatches(content)` - returns full matches with @ prefix

2. Updated `channel.ts` and `inbound.ts` to import and use these shared utilities

3. Added comprehensive tests in `mention-utils.test.ts` covering:
   - English alphanumeric mentions
   - Chinese character mentions
   - Mixed mentions with dots, hyphens, underscores
   - Edge cases (no mentions, consecutive mentions)

## Testing

- [x] Local build passes (`npm run build`)
- [x] Type check passes (`npm run type-check`)
- [x] No security risks
- [x] All tests pass (34 tests, including 16 new tests for mention-utils)

```
 Test Files  3 passed (3)
      Tests  34 passed (34)
```

## AI Assistance (if applicable)

Code review and fix implemented with Claude Code assistance. All changes have been reviewed and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)