### PR TITLE
fix: log disconnect errors instead of silently ignoring them

### DIFF
--- a/openclaw-channel-dmwork/src/socket.ts
+++ b/openclaw-channel-dmwork/src/socket.ts
@@ -47,7 +47,7 @@ export class WKSocket extends EventEmitter {
     const im = WKSDK.shared();
 
     // Ensure clean state — disconnect any prior SDK session
-    try { im.disconnect(); } catch { /* ignore */ }
+    try { im.disconnect(); } catch (err) { console.debug("[WKSocket] disconnect error (ignored):", err); }
 
     im.config.addr = this.opts.wsUrl;
     im.config.uid = this.opts.uid;
@@ -143,6 +143,6 @@ export class WKSocket extends EventEmitter {
       im.chatManager.removeMessageListener(this.messageListener);
       this.messageListener = null;
     }
-    try { im.disconnect(); } catch { /* ignore */ }
+    try { im.disconnect(); } catch (err) { console.debug("[WKSocket] disconnect error (ignored):", err); }
   }
 }


### PR DESCRIPTION
## What

Replace empty catch blocks in `socket.ts` with `console.debug` logging.

## Why

Empty catch blocks (line 50 and 146) completely swallow `im.disconnect()` errors, making it impossible to diagnose disconnect-related issues. While these errors are typically non-fatal, logging them at debug level provides visibility without noise.

## Changes

- `socket.ts:50` — pre-connect cleanup: log error at debug level
- `socket.ts:146` — graceful disconnect: log error at debug level

## Testing

- Minimal change, no behavior difference in happy path
- Errors are logged but not propagated (non-breaking)

Closes #33