### PR TITLE
fix: add timeout to GET requests to prevent indefinite hanging

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.test.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.test.ts
@@ -92,4 +92,155 @@ describe("fetchBotGroups", () => {
     expect(result.length).toBe(1);
     expect(result.map((g) => g.name)).toEqual(["Group"]);
   });
+
+  it("should return empty array on abort (issue #40)", async () => {
+    // Mock fetch to throw an abort error when signal is aborted
+    global.fetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          if (options.signal.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+            return;
+          }
+          options.signal.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }
+      });
+    }) as unknown as typeof fetch;
+
+    const { fetchBotGroups } = await import("./api-fetch.js");
+
+    // Create an already-aborted signal
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await fetchBotGroups({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      signal: controller.signal,
+    });
+
+    // Should return empty array on abort, not throw
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should pass signal to fetch for timeout control", async () => {
+    const mockGroups = [{ group_no: "g1", name: "Group" }];
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(mockGroups),
+    }) as unknown as typeof fetch;
+
+    const { fetchBotGroups } = await import("./api-fetch.js");
+
+    await fetchBotGroups({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+    });
+
+    // Verify fetch was called with a signal
+    expect(global.fetch).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fetchCall = (global.fetch as any).mock.calls[0];
+    expect(fetchCall[1]).toHaveProperty("signal");
+    expect(fetchCall[1].signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("getGroupMembers", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should return members array on success", async () => {
+    const mockMembers = [
+      { uid: "user1", name: "User 1" },
+      { uid: "user2", name: "User 2" },
+    ];
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ members: mockMembers }),
+    }) as unknown as typeof fetch;
+
+    const { getGroupMembers } = await import("./api-fetch.js");
+
+    const result = await getGroupMembers({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      groupNo: "group123",
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(2);
+    expect(result[0].uid).toBe("user1");
+  });
+
+  it("should return empty array on abort (issue #40)", async () => {
+    // Mock fetch to throw an abort error when signal is aborted
+    global.fetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          if (options.signal.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+            return;
+          }
+          options.signal.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }
+      });
+    }) as unknown as typeof fetch;
+
+    const { getGroupMembers } = await import("./api-fetch.js");
+
+    const logSpy = { info: vi.fn(), error: vi.fn() };
+
+    // Create an already-aborted signal
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await getGroupMembers({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      groupNo: "group123",
+      signal: controller.signal,
+      log: logSpy,
+    });
+
+    // Should return empty array on abort, not throw
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should pass signal to fetch for timeout control", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ members: [] }),
+    }) as unknown as typeof fetch;
+
+    const { getGroupMembers } = await import("./api-fetch.js");
+
+    await getGroupMembers({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      groupNo: "group123",
+    });
+
+    // Verify fetch was called with a signal
+    expect(global.fetch).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fetchCall = (global.fetch as any).mock.calls[0];
+    expect(fetchCall[1]).toHaveProperty("signal");
+    expect(fetchCall[1].signal).toBeInstanceOf(AbortSignal);
+  });
 });

--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -9,6 +9,33 @@ const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
 };
 
+/** Default timeout for GET requests (30 seconds) */
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/**
+ * Creates an AbortSignal that will abort after the specified timeout.
+ * If an existing signal is provided, returns a combined signal that aborts
+ * when either the timeout expires or the existing signal aborts.
+ */
+function createTimeoutSignal(timeoutMs: number, existingSignal?: AbortSignal): AbortSignal {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(new Error("Request timeout")), timeoutMs);
+
+  // Clean up timeout when the controller aborts (either way)
+  controller.signal.addEventListener("abort", () => clearTimeout(timeout), { once: true });
+
+  // If there's an existing signal, abort our controller when it aborts
+  if (existingSignal) {
+    existingSignal.addEventListener("abort", () => controller.abort(existingSignal.reason), { once: true });
+    // If already aborted, abort immediately
+    if (existingSignal.aborted) {
+      controller.abort(existingSignal.reason);
+    }
+  }
+
+  return controller.signal;
+}
+
 async function postJson<T>(
   apiUrl: string,
   botToken: string,
@@ -132,19 +159,31 @@ export async function registerBot(params: {
 export async function fetchBotGroups(params: {
   apiUrl: string;
   botToken: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<Array<{ group_no: string; name: string }>> {
   const url = `${params.apiUrl}/v1/bot/groups`;
-  const resp = await fetch(url, {
-    method: "GET",
-    headers: {
-      "Authorization": `Bearer ${params.botToken}`,
-    },
-  });
-  if (!resp.ok) {
-    // Fallback: return empty if API not available
-    return [];
+  const timeoutSignal = createTimeoutSignal(params.timeoutMs ?? DEFAULT_TIMEOUT_MS, params.signal);
+  try {
+    const resp = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${params.botToken}`,
+      },
+      signal: timeoutSignal,
+    });
+    if (!resp.ok) {
+      // Fallback: return empty if API not available
+      return [];
+    }
+    return await resp.json();
+  } catch (err) {
+    // Handle timeout and abort errors gracefully
+    if (err instanceof Error && (err.name === "AbortError" || err.message === "Request timeout")) {
+      return [];
+    }
+    throw err;
   }
-  return await resp.json();
 }
 
 /**
@@ -161,17 +200,22 @@ export async function getGroupMembers(params: {
   apiUrl: string;
   botToken: string;
   groupNo: string;  // 群 ID (channel_id)
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  log?: { info?: (...args: any[]) => void; error?: (...args: any[]) => void };
 }): Promise<GroupMember[]> {
   const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${params.groupNo}/members`;
+  const timeoutSignal = createTimeoutSignal(params.timeoutMs ?? DEFAULT_TIMEOUT_MS, params.signal);
   try {
     const resp = await fetch(url, {
       method: "GET",
       headers: {
         "Authorization": `Bearer ${params.botToken}`,
       },
+      signal: timeoutSignal,
     });
     if (!resp.ok) {
-      console.log(`[dmwork] getGroupMembers failed: ${resp.status}`);
+      params.log?.info?.(`[dmwork] getGroupMembers failed: ${resp.status}`);
       return [];
     }
     const data = await resp.json();
@@ -183,7 +227,12 @@ export async function getGroupMembers(params: {
         : [];
     return members as GroupMember[];
   } catch (err) {
-    console.log(`[dmwork] getGroupMembers error: ${err}`);
+    // Handle timeout specifically
+    if (err instanceof Error && (err.name === "AbortError" || err.message === "Request timeout")) {
+      params.log?.info?.(`[dmwork] getGroupMembers timeout after ${params.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`);
+      return [];
+    }
+    params.log?.error?.(`[dmwork] getGroupMembers error: ${err}`);
     return [];
   }
 }

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -167,6 +167,7 @@ async function refreshGroupMemberCache(opts: {
       apiUrl,
       botToken,
       groupNo: sessionId,
+      log,
     });
 
     if (members.length > 0) {


### PR DESCRIPTION
## What
Add 30-second default timeout to GET requests (`fetchBotGroups` and `getGroupMembers`) using AbortController.

## Why
GET requests without timeout can hang indefinitely when the server is slow or unresponsive, blocking subsequent message processing.

Closes #40

## How
- Created `createTimeoutSignal` helper that combines timeout with optional external AbortSignal
- Updated `fetchBotGroups` to use timeout with graceful fallback to empty array
- Updated `getGroupMembers` to use timeout with proper logging via OpenClaw log sink
- Added `timeoutMs` and `signal` optional parameters for caller control
- Replaced `console.log` with `log?.info`/`log?.error` for consistent logging

## Testing
- [x] Local build passes (`npm run build`)
- [x] Type check passes (`npm run type-check`)
- [x] No security risks
- [x] Added test cases for abort handling

## AI Assistance
Used Claude Code to implement the fix. The implementation uses standard AbortController patterns for timeout handling.