### PR TITLE
fix: align log parameter type with ChannelLogSink from OpenClaw SDK

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.test.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.test.ts
@@ -93,3 +93,66 @@ describe("fetchBotGroups", () => {
     expect(result.map((g) => g.name)).toEqual(["Group"]);
   });
 });
+
+describe("log parameter type compatibility", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should accept ChannelLogSink-compatible log parameter", async () => {
+    // Simulates ChannelLogSink type from OpenClaw SDK:
+    // { info: (msg: string) => void; error: (msg: string) => void; ... }
+    const channelLogSink = {
+      info: (msg: string) => console.log(msg),
+      warn: (msg: string) => console.warn(msg),
+      error: (msg: string) => console.error(msg),
+    };
+
+    const mockGroups = [{ group_no: "g1", name: "Group" }];
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(mockGroups),
+    }) as unknown as typeof fetch;
+
+    const { fetchBotGroups } = await import("./api-fetch.js");
+
+    // This should compile without TypeScript errors
+    const result = await fetchBotGroups({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      log: channelLogSink,
+    });
+
+    expect(result).toEqual(mockGroups);
+  });
+
+  it("should call log.error on non-ok response", async () => {
+    const errorSpy = vi.fn();
+    const log = {
+      info: vi.fn(),
+      error: errorSpy,
+    };
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    }) as unknown as typeof fetch;
+
+    const { fetchBotGroups } = await import("./api-fetch.js");
+
+    await fetchBotGroups({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      log,
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("401"));
+  });
+});

--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -134,7 +134,7 @@ export async function registerBot(params: {
 export async function fetchBotGroups(params: {
   apiUrl: string;
   botToken: string;
-  log?: { info?: (...args: unknown[]) => void; error?: (...args: unknown[]) => void };
+  log?: { info?: (msg: string) => void; error?: (msg: string) => void };
 }): Promise<Array<{ group_no: string; name: string }>> {
   const url = `${params.apiUrl}/v1/bot/groups`;
   const resp = await fetch(url, {
@@ -165,7 +165,7 @@ export async function getGroupMembers(params: {
   apiUrl: string;
   botToken: string;
   groupNo: string;  // 群 ID (channel_id)
-  log?: { info?: (...args: unknown[]) => void; error?: (...args: unknown[]) => void };
+  log?: { info?: (msg: string) => void; error?: (msg: string) => void };
 }): Promise<GroupMember[]> {
   const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${params.groupNo}/members`;
   try {
@@ -205,7 +205,7 @@ export async function getChannelMessages(params: {
   channelType: ChannelType;
   limit?: number;
   signal?: AbortSignal;
-  log?: { info?: (...args: any[]) => void; error?: (...args: any[]) => void };
+  log?: { info?: (msg: string) => void; error?: (msg: string) => void };
 }): Promise<Array<{ from_uid: string; content: string; timestamp: number; type?: number; url?: string; name?: string }>> {
   try {
     const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/channel/messages`;


### PR DESCRIPTION
## What
Fix TypeScript compilation failure caused by incompatible log parameter types in API functions.

Closes #57

## Why
The log parameter type used `(...args: unknown[]) => void` which is incompatible with OpenClaw SDK's `ChannelLogSink` type `(msg: string) => void`. This caused TypeScript compilation to fail when `inbound.ts` passed `ChannelLogSink` to `getGroupMembers`.

Error:
```
src/inbound.ts(170,7): error TS2322: Type 'ChannelLogSink | undefined' is not assignable to type '{ info?: ((...args: unknown[]) => void) | undefined; error?: ((...args: unknown[]) => void) | undefined; } | undefined'.
```

## How
Changed log parameter signatures in `fetchBotGroups`, `getGroupMembers`, and `getChannelMessages` from:
```typescript
log?: { info?: (...args: unknown[]) => void; error?: (...args: unknown[]) => void };
```
to:
```typescript
log?: { info?: (msg: string) => void; error?: (msg: string) => void };
```

This aligns with `ChannelLogSink` type from OpenClaw SDK:
```typescript
type ChannelLogSink = {
    info: (msg: string) => void;
    warn: (msg: string) => void;
    error: (msg: string) => void;
    debug?: (msg: string) => void;
};
```

## Testing
- [x] Local build passes (`npm run build`)
- [x] Type check passes (`npm run type-check`)
- [x] No security risks
- [x] Added 2 new tests for log parameter type compatibility
- [x] All 36 tests pass (`npm test`)

## AI Assistance (if applicable)
Generated with Claude Code. Code is fully understood and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)