### PR TITLE
fix: getChannelMessages 对接 /v1/bot/messages/sync 接口

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -217,7 +217,8 @@ export async function getChannelMessages(params: {
   log?: { info?: (msg: string) => void; error?: (msg: string) => void };
 }): Promise<Array<{ from_uid: string; content: string; timestamp: number; type?: number; url?: string; name?: string }>> {
   try {
-    const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/channel/messages`;
+    const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/messages/sync`;
+    const limit = params.limit ?? 20;
     const response = await fetch(url, {
       method: "POST",
       headers: {
@@ -227,7 +228,10 @@ export async function getChannelMessages(params: {
       body: JSON.stringify({
         channel_id: params.channelId,
         channel_type: params.channelType,
-        limit: params.limit ?? 20,
+        limit,
+        start_message_seq: 0,
+        end_message_seq: 0,
+        pull_mode: 1,  // 1 = pull up (newer messages)
       }),
       signal: params.signal,
     });
@@ -238,15 +242,29 @@ export async function getChannelMessages(params: {
     }
 
     const data = await response.json();
-    return (data.messages ?? data ?? []).map((m: any) => ({
-      from_uid: m.from_uid ?? m.sender_id ?? "unknown",
-      type: m.payload?.type ?? undefined,
-      url: m.payload?.url ?? undefined,
-      name: m.payload?.name ?? undefined,
-      content: m.payload?.content ?? m.content ?? "",
-      // Convert seconds to milliseconds (API returns seconds, internal standard is ms)
-      timestamp: (m.timestamp ?? Math.floor(Date.now() / 1000)) * 1000,
-    }));
+    const messages = data.messages ?? [];
+    return messages.map((m: any) => {
+      // payload is base64-encoded JSON string
+      let payload: any = {};
+      if (m.payload) {
+        try {
+          const decoded = Buffer.from(m.payload, "base64").toString("utf-8");
+          payload = JSON.parse(decoded);
+        } catch {
+          // If decoding fails, try treating payload as already-parsed object
+          payload = typeof m.payload === "object" ? m.payload : {};
+        }
+      }
+      return {
+        from_uid: m.from_uid ?? "unknown",
+        type: payload.type ?? undefined,
+        url: payload.url ?? undefined,
+        name: payload.name ?? undefined,
+        content: payload.content ?? "",
+        // Convert seconds to milliseconds (API returns seconds, internal standard is ms)
+        timestamp: (m.timestamp ?? Math.floor(Date.now() / 1000)) * 1000,
+      };
+    });
   } catch (err) {
     params.log?.error?.(`dmwork: getChannelMessages error: ${err}`);
     return [];

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -331,9 +331,10 @@ export async function handleInboundMessage(params: {
     const historyCountBefore = entries.length;
     log?.info?.(`dmwork: [MENTION] 收到@消息 | 缓存=${historyCountBefore}条 | historyLimit=${historyLimit}`);
 
-    // If memory cache is empty, try fetching from API
-    if (entries.length === 0 && account.config.botToken) {
-      log?.info?.(`dmwork: [MENTION] 内存缓存为空，尝试从API获取历史...`);
+    // If memory cache is empty or insufficient, try fetching from API
+    const cacheInsufficient = entries.length < Math.ceil(historyLimit / 2);
+    if (cacheInsufficient && account.config.botToken) {
+      log?.info?.(`dmwork: [MENTION] 缓存不足(${entries.length}/${historyLimit})，从API补充历史...`);
       try {
         const fetchLimit = Math.min(historyLimit, 100);  // Cap at 100
         const apiMessages = await getChannelMessages({


### PR DESCRIPTION
## 修复

`getChannelMessages()` API 路径和响应解析与服务端 `/v1/bot/messages/sync` 接口不匹配。

### 改动

| 项目 | 修复前 | 修复后 |
|------|--------|--------|
| URL | `/v1/bot/channel/messages` (404) | `/v1/bot/messages/sync` ✅ |
| 请求体 | 缺少 `pull_mode` | 加上 `pull_mode: 1`, `start_message_seq: 0` |
| payload 解析 | 直接取 `.content` | base64 解码 → JSON.parse → 取 `.content` |
| 触发条件 | 仅缓存为空时拉取 | 缓存不足 (<50%) 时也补充 |

### 验证

- `tsc --noEmit` ✅
- `vitest run` 41/41 通过 ✅

Closes #64