### PR TITLE
fix: 调用 WKSDK.init() 修复 WebSocket 连接失败

### DIFF
--- a/openclaw-channel-dmwork/src/socket.ts
+++ b/openclaw-channel-dmwork/src/socket.ts
@@ -29,6 +29,7 @@ export class WKSocket extends EventEmitter {
   constructor(private opts: WKSocketOptions) {
     super();
     this.im = new WKSDK();
+    (this.im as any).init();  // WKSDK constructor is empty; config/managers created in init()
   }
 
   /** Connect to WuKongIM WebSocket */


### PR DESCRIPTION
## P0 修复

`new WKSDK()` 后未调 `init()`，导致 `im.config` 为 undefined，WebSocket 无法连接。

### 改动
`socket.ts` 第32行加一行：`this.im.init();`

### 验证
- tsc ✅ vitest 41/41 ✅

Closes #66