### PR TITLE
fix: remove TypeScript `any` types and use concrete type definitions

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -7,6 +7,21 @@ import { ChannelType, MessageType } from "./types.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+/** Raw message from /v1/bot/messages/sync API */
+interface ApiSyncMessage {
+  from_uid?: string;
+  payload?: string; // base64-encoded JSON
+  timestamp?: number;
+}
+
+/** Decoded payload from base64 message payload */
+interface ParsedPayload {
+  type?: number;
+  content?: string;
+  url?: string;
+  name?: string;
+}
+
 const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
 };
@@ -242,17 +257,17 @@ export async function getChannelMessages(params: {
     }
 
     const data = await response.json();
-    const messages = data.messages ?? [];
-    return messages.map((m: any) => {
+    const messages: ApiSyncMessage[] = data.messages ?? [];
+    return messages.map((m: ApiSyncMessage) => {
       // payload is base64-encoded JSON string
-      let payload: any = {};
+      let payload: ParsedPayload = {};
       if (m.payload) {
         try {
           const decoded = Buffer.from(m.payload, "base64").toString("utf-8");
-          payload = JSON.parse(decoded);
+          payload = JSON.parse(decoded) as ParsedPayload;
         } catch {
           // If decoding fails, try treating payload as already-parsed object
-          payload = typeof m.payload === "object" ? m.payload : {};
+          payload = typeof m.payload === "object" ? (m.payload as ParsedPayload) : {};
         }
       }
       return {

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -21,11 +21,11 @@ type HistoryEntry = { sender: string; body: string; timestamp: number };
 const DEFAULT_GROUP_HISTORY_LIMIT = 20;
 
 // Module-level history storage — survives auto-restarts
-const _historyMaps = new Map<string, Map<string, any[]>>();
-function getOrCreateHistoryMap(accountId: string): Map<string, any[]> {
+const _historyMaps = new Map<string, Map<string, HistoryEntry[]>>();
+function getOrCreateHistoryMap(accountId: string): Map<string, HistoryEntry[]> {
   let m = _historyMaps.get(accountId);
   if (!m) {
-    m = new Map<string, any[]>();
+    m = new Map<string, HistoryEntry[]>();
     _historyMaps.set(accountId, m);
   }
   return m;

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -9,7 +9,9 @@ import { extractMentionMatches } from "./mention-utils.js";
 
 // Defensive imports — these may not exist in older OpenClaw versions
 // History context managed manually for cross-SDK compatibility
-let clearHistoryEntriesIfEnabled: any;
+// The SDK function signature varies across versions, loaded but currently unused
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+let clearHistoryEntriesIfEnabled: Function | undefined;
 let DEFAULT_GROUP_HISTORY_LIMIT = 20;
 let _sdkLoaded = false;
 
@@ -38,6 +40,16 @@ export interface HistoryEntryCompat {
   sender: string;
   body: string;
   timestamp: number;
+}
+
+/** Type for messages returned by getChannelMessages API */
+interface ApiChannelMessage {
+  from_uid: string;
+  content: string;
+  timestamp: number;
+  type?: number;
+  url?: string;
+  name?: string;
 }
 
 export type DmworkStatusSink = (patch: {
@@ -202,7 +214,7 @@ export async function handleInboundMessage(params: {
   account: ResolvedDmworkAccount;
   message: BotMessage;
   botUid: string;
-  groupHistories: Map<string, any[]>;
+  groupHistories: Map<string, HistoryEntryCompat[]>;
   memberMap: Map<string, string>;  // displayName -> uid mapping
   uidToNameMap: Map<string, string>;  // uid -> displayName mapping (reverse)
   groupCacheTimestamps: Map<string, number>;  // groupId -> lastFetchedAt
@@ -346,9 +358,9 @@ export async function handleInboundMessage(params: {
           log,
         });
         entries = apiMessages
-          .filter((m: any) => m.from_uid !== botUid && (m.content || m.type !== 1))
+          .filter((m: ApiChannelMessage) => m.from_uid !== botUid && (m.content || m.type !== 1))
           .slice(-historyLimit)
-          .map((m: any) => ({
+          .map((m: ApiChannelMessage) => ({
             sender: m.from_uid,
             body: m.content || resolveApiMessagePlaceholder(m.type, m.name),
             timestamp: m.timestamp,  // Already in ms from getChannelMessages
@@ -361,7 +373,7 @@ export async function handleInboundMessage(params: {
 
     // Build history context manually (JSON format)
     if (entries.length > 0) {
-      const messagesJson = JSON.stringify(entries.map((e: any) => ({
+      const messagesJson = JSON.stringify(entries.map((e: HistoryEntryCompat) => ({
         sender: e.sender,
         body: e.body,
       })), null, 2);


### PR DESCRIPTION
## What
Replace `any` types with specific type definitions in api-fetch.ts, channel.ts, and inbound.ts to improve type safety.

## Why
Issue #32 identified several places where `any` types were used instead of concrete types, which reduces TypeScript's ability to catch type errors. This PR addresses the high and medium priority items from the code review.

Closes #32

## How
- **api-fetch.ts**: Added `ApiSyncMessage` and `ParsedPayload` interfaces for the `/v1/bot/messages/sync` API response parsing
- **channel.ts**: Changed `Map<string, any[]>` to `Map<string, HistoryEntry[]>` for history storage
- **inbound.ts**: Added `ApiChannelMessage` interface for API messages, changed `Map<string, any[]>` to `Map<string, HistoryEntryCompat[]>`, used specific types in filter/map callbacks

Note: The `clearHistoryEntriesIfEnabled` variable uses `Function | undefined` type because:
1. It's dynamically imported from different SDK versions with varying signatures
2. It's currently loaded but not actively called (defensive import for compatibility)

## Testing
- [x] Local build passes (`npm run build`)
- [x] Type check passes (`npm run type-check` / `npx tsc --noEmit`)
- [x] All 41 tests pass (`npm test`)
- [x] No security risks

## AI Assistance
- AI assisted with identifying type definitions and implementing the fix
- All changes reviewed and verified manually
- Code is understood

🤖 Generated with [Claude Code](https://claude.com/claude-code)