### PR TITLE
fix: wrap postJson JSON.parse with contextual error message

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -36,7 +36,13 @@ async function postJson<T>(
 
   const text = await response.text();
   if (!text) return undefined;
-  return JSON.parse(text) as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error(
+      `DMWork API ${path} returned invalid JSON: ${text.slice(0, 200)}`,
+    );
+  }
 }
 
 export async function sendMessage(params: {


### PR DESCRIPTION
## Problem

`postJson` 直接调用 `JSON.parse(text)`，当 API 返回非 JSON 内容（如 502 HTML 页面）时，抛出的 `SyntaxError` 没有上下文信息，难以排查。

## Solution

用 try-catch 包裹 `JSON.parse`，捕获后抛出包含 API path 和响应内容前 200 字符的 Error。

Closes #68