### PR TITLE
fix: add logging when base64 payload decode fails

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -250,8 +250,8 @@ export async function getChannelMessages(params: {
         try {
           const decoded = Buffer.from(m.payload, "base64").toString("utf-8");
           payload = JSON.parse(decoded);
-        } catch {
-          // If decoding fails, try treating payload as already-parsed object
+        } catch (decodeErr) {
+          params.log?.info?.(`dmwork: payload decode failed for message from ${m.from_uid ?? "unknown"}: ${decodeErr}`);
           payload = typeof m.payload === "object" ? m.payload : {};
         }
       }


### PR DESCRIPTION
## Problem

`getChannelMessages` 中 base64 payload 解码失败时 catch 块为空，没有任何日志输出，增加调试难度。

## Solution

在 catch 块中添加 `params.log?.info?.()` 调用，记录失败原因和来源 uid。

Closes #70