### PR TITLE
fix: 回退到 WKSDK.shared() 修复 WebSocket Invalid URL

### DIFF
--- a/openclaw-channel-dmwork/src/socket.ts
+++ b/openclaw-channel-dmwork/src/socket.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "events";
 import WKSDK, { ConnectStatus, type Message } from "wukongimjssdk";
+const getSDK = (): InstanceType<typeof WKSDK> => (WKSDK as any).shared();
 import type { BotMessage, MessagePayload } from "./types.js";
 
 interface WKSocketOptions {
@@ -17,19 +18,18 @@ interface WKSocketOptions {
  * Thin wrapper around wukongimjssdk — the SDK handles binary encoding,
  * DH key exchange, encryption, heartbeat, reconnect, and RECVACK.
  *
- * Each WKSocket creates its own WKSDK instance, allowing multiple
- * concurrent connections for multi-account setups.
+ * Uses WKSDK.shared() singleton — the SDK's ConnectManager is global,
+ * so only one WebSocket connection is supported at a time.
  */
 export class WKSocket extends EventEmitter {
-  private im: InstanceType<typeof WKSDK>;
+  private im!: InstanceType<typeof WKSDK>;
   private statusListener: ((status: ConnectStatus, reasonCode?: number) => void) | null = null;
   private messageListener: ((message: Message) => void) | null = null;
   private connected = false;
 
   constructor(private opts: WKSocketOptions) {
     super();
-    this.im = new WKSDK();
-    (this.im as any).init();  // WKSDK constructor is empty; config/managers created in init()
+    this.im = getSDK();
   }
 
   /** Connect to WuKongIM WebSocket */


### PR DESCRIPTION
## P0 修复

v0.2.24 将 `WKSDK.shared()` 改成 `new WKSDK()` 导致 WebSocket 连接失败。

### 根因
SDK 的 `ConnectManager.shared()` 是全局单例，始终读 `WKSDK.shared().config.addr`。`new WKSDK()` 实例的 config 不会被 ConnectManager 使用，导致 `addr=undefined` → `Invalid URL`。

### 修复
回退到 `WKSDK.shared()`，更正注释说明 SDK 单例限制。

### 验证
- tsc ✅ vitest 41/41 ✅
- v0.2.22 用 `WKSDK.shared()` 确认正常

Closes #66