### PR TITLE
fix: improve error handling in api-fetch.ts

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -36,7 +36,11 @@ async function postJson<T>(
 
   const text = await response.text();
   if (!text) return undefined;
-  return JSON.parse(text) as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error(`DMWork API ${path} returned invalid JSON: ${text.slice(0, 200)}`);
+  }
 }
 
 export async function sendMessage(params: {
@@ -250,7 +254,8 @@ export async function getChannelMessages(params: {
         try {
           const decoded = Buffer.from(m.payload, "base64").toString("utf-8");
           payload = JSON.parse(decoded);
-        } catch {
+        } catch (decodeErr) {
+          params.log?.info?.(`dmwork: payload decode failed for msg ${m.message_id ?? "unknown"}: ${decodeErr}`);
           // If decoding fails, try treating payload as already-parsed object
           payload = typeof m.payload === "object" ? m.payload : {};
         }


### PR DESCRIPTION
## What
Two error handling improvements in `api-fetch.ts`.

## Why
- **Fixes #68** — `postJson` crashes with unhelpful `SyntaxError` when API returns non-JSON (e.g. HTML error page)
- **Fixes #70** — `getChannelMessages` silently swallows base64/JSON decode failures (empty catch block)

## How
- `postJson`: Wrap `JSON.parse` in try-catch, throw descriptive error with first 200 chars of response
- `getChannelMessages`: Log decode failures via `params.log?.info?` instead of empty catch

## Testing
- [x] No new TypeScript compilation errors
- [x] Minimal change, 1 file, +7/-2 lines
- [x] AI-assisted (OpenClaw agent, lightly tested)