### PR TITLE
fix: upgrade openclaw to 2026.3.2 to resolve dependency vulnerabilities

### DIFF
--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/ws": "^8.5.10",
-    "openclaw": "2026.3.1",
+    "openclaw": "2026.3.2",
     "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   },


### PR DESCRIPTION
## What
Upgrade `openclaw` devDependency from `2026.3.1` to `2026.3.2`.

## Why
Fixes #62 — `npm audit` reports 8 high-severity vulnerabilities, all from transitive dependencies via `openclaw@2026.3.1`. The `2026.3.2` release patches all of them:

- `@hono/node-server` authorization bypass (GHSA-wc8c-qw6v-h7f6)
- `tar` path traversal / symlink poisoning (5 CVEs)
- `openclaw` itself (multiple patched CVEs)

## Testing
- [x] `npm audit` confirms 0 high vulnerabilities after upgrade
- [x] One-line change, devDependency only
- [x] AI-assisted (OpenClaw, fully reviewed)