### PR TITLE
fix: reduce WebSocket heartbeat interval from 60s to 30s and send immediate PING

### DIFF
--- a/openclaw-channel-dmwork/src/socket.ts
+++ b/openclaw-channel-dmwork/src/socket.ts
@@ -375,6 +375,8 @@ export class WKSocket extends EventEmitter {
   private restartHeart(): void {
     this.stopHeart();
     this.pingRetryCount = 0;
+    // Send immediate PING on connection to prevent server timeout before first interval fires
+    this.sendRaw(encodePingPacket());
     this.heartTimer = setInterval(() => {
       this.pingRetryCount++;
       if (this.pingRetryCount > this.pingMaxRetry) {
@@ -394,7 +396,7 @@ export class WKSocket extends EventEmitter {
         return;
       }
       this.sendRaw(encodePingPacket());
-    }, 60_000); // 60s heartbeat interval (matches SDK default)
+    }, 30_000); // 30s heartbeat interval (matches WuKongIM server expectation)
   }
 
   private stopHeart(): void {


### PR DESCRIPTION
## What

Fix the WebSocket disconnection issue that causes connections to drop every ~60 seconds.

## Why

The original implementation had two problems:
1. `setInterval` fires AFTER the first interval (60s), so the first PING was only sent 60 seconds after connection
2. WuKongIM server expects heartbeat within ~55 seconds, causing connections to timeout before the first PING arrives

This caused:
- Frequent reconnections (~every 60s as shown in the issue logs)
- Potential message loss during reconnection windows
- The multi-account reply issue (messages processed during reconnection may fail silently)

## How

Changed `socket.ts` `restartHeart()` method:
1. **Send immediate PING** when heartbeat starts (line 378) - prevents server timeout before first interval fires
2. **Reduce interval from 60s to 30s** (line 399) - matches WuKongIM server expectation and `DEFAULT_HEARTBEAT_INTERVAL_MS` in accounts.ts

## Testing

- [x] `npm run type-check` passes
- [x] `npm test` passes (41 tests)
- [ ] Manual testing with multi-bot configuration (requires dmwork environment)

## Related

Fixes #79