### PR TITLE
fix: allow bot-to-bot @mention in group chats

### DIFF
--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -341,7 +341,9 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
           // Skip self messages
           if (msg.from_uid === credentials.robot_id) return;
           // Skip messages from any other bot in this plugin instance (prevent bot-to-bot loops)
-          if (_knownBotUids.has(msg.from_uid)) return;
+          // But allow group messages through — bot-to-bot @mention in groups is legitimate;
+          // mention gating in inbound.ts ensures only @-targeted messages trigger AI.
+          if (_knownBotUids.has(msg.from_uid) && msg.channel_type === ChannelType.DM) return;
           // Skip unsupported message types (Location, Card)
           const supportedTypes = [MessageType.Text, MessageType.Image, MessageType.GIF, MessageType.Voice, MessageType.Video, MessageType.File];
           if (!msg.payload || !supportedTypes.includes(msg.payload.type)) return;


### PR DESCRIPTION
## Problem

In a single OpenClaw instance with multiple DMWork bot accounts, `_knownBotUids` in `channel.ts` blocks **all** messages from sibling bots — including legitimate group chat @mentions.

When bot_a replies with `@bot_b` in a group, bot_b's `onMessage` callback drops the message at line 344:
```typescript
if (_knownBotUids.has(msg.from_uid)) return;
```

## Fix

Only block bot-to-bot messages in DM (loop prevention). Group messages pass through to `inbound.ts` where mention gating already handles non-targeted messages correctly.

```typescript
if (_knownBotUids.has(msg.from_uid) && msg.channel_type === ChannelType.DM) return;
```

## Testing

- DM between bots: still blocked ✅ (loop prevention)
- Group @mention between bots: now delivered ✅
- Group non-@mention messages from bots: delivered but filtered by mention gating in inbound.ts ✅