### PR TITLE
fix: makeFullUrl改CDN直连，解决LLM访问媒体401

### DIFF
--- a/openclaw-channel-dmwork/package-lock.json
+++ b/openclaw-channel-dmwork/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-channel-dmwork",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-channel-dmwork",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "bundleDependencies": [
         "crypto-js",
         "curve25519-js",

--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-channel-dmwork",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "DMWork channel plugin for OpenClaw via WuKongIM WebSocket",
   "main": "index.ts",
   "type": "module",

--- a/openclaw-channel-dmwork/src/accounts.ts
+++ b/openclaw-channel-dmwork/src/accounts.ts
@@ -15,6 +15,7 @@ export type ResolvedDmworkAccount = {
     botToken?: string;
     apiUrl: string;
     wsUrl?: string;
+    cdnUrl?: string;  // CDN base URL for media files (public-read, no auth)
     pollIntervalMs: number;
     heartbeatIntervalMs: number;
     requireMention?: boolean;
@@ -51,6 +52,7 @@ export function resolveDmworkAccount(params: {
   const botToken = accountConfig.botToken ?? channel.botToken;
   const apiUrl = accountConfig.apiUrl ?? channel.apiUrl ?? DEFAULT_API_URL;
   const wsUrl = accountConfig.wsUrl ?? channel.wsUrl;
+  const cdnUrl = accountConfig.cdnUrl ?? channel.cdnUrl;
   const pollIntervalMs =
     accountConfig.pollIntervalMs ??
     channel.pollIntervalMs ??
@@ -72,6 +74,7 @@ export function resolveDmworkAccount(params: {
       botToken,
       apiUrl,
       wsUrl,
+      cdnUrl,
       pollIntervalMs,
       heartbeatIntervalMs,
       requireMention: accountConfig.requireMention ?? channel.requireMention,

--- a/openclaw-channel-dmwork/src/config-schema.ts
+++ b/openclaw-channel-dmwork/src/config-schema.ts
@@ -6,6 +6,7 @@ export interface DmworkAccountConfig {
   botToken?: string;
   apiUrl?: string;
   wsUrl?: string;
+  cdnUrl?: string;  // CDN base URL for media files (e.g. https://cdn.example.com/bucket)
   pollIntervalMs?: number;
   heartbeatIntervalMs?: number;
   requireMention?: boolean;
@@ -20,6 +21,7 @@ export interface DmworkConfig {
   botToken?: string;
   apiUrl?: string;
   wsUrl?: string;
+  cdnUrl?: string;  // CDN base URL for media files (e.g. https://cdn.example.com/bucket)
   pollIntervalMs?: number;
   heartbeatIntervalMs?: number;
   requireMention?: boolean;
@@ -43,6 +45,7 @@ export const DmworkConfigJsonSchema = {
       botToken: { type: "string" },
       apiUrl: { type: "string" },
       wsUrl: { type: "string" },
+      cdnUrl: { type: "string" },
       pollIntervalMs: { type: "number", minimum: 500 },
       heartbeatIntervalMs: { type: "number", minimum: 5000 },
       requireMention: { type: "boolean" },
@@ -59,6 +62,7 @@ export const DmworkConfigJsonSchema = {
             botToken: { type: "string" },
             apiUrl: { type: "string" },
             wsUrl: { type: "string" },
+            cdnUrl: { type: "string" },
             pollIntervalMs: { type: "number", minimum: 500 },
             heartbeatIntervalMs: { type: "number", minimum: 5000 },
             requireMention: { type: "boolean" },

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -151,17 +151,28 @@ interface ResolvedContent {
   mediaType?: string;
 }
 
-function resolveContent(payload: BotMessage["payload"], apiUrl?: string, log?: ChannelLogSink): ResolvedContent {
+function resolveContent(payload: BotMessage["payload"], apiUrl?: string, log?: ChannelLogSink, cdnUrl?: string): ResolvedContent {
   if (!payload) return { text: "" };
 
   const makeFullUrl = (relUrl?: string) => {
     if (!relUrl) return undefined;
     if (relUrl.startsWith("http")) return relUrl;
-    // Use bot file proxy endpoint which handles auth via Bearer token
-    // and returns 302 redirect to presigned URL (works with both MinIO and COS).
-    // /v1/botfile/*path auto-strips "file/" prefix from the storage path.
+    // Strip common path prefixes to get the raw storage path
+    let storagePath = relUrl;
+    // Remove "file/preview/" or "file/" prefix
+    if (storagePath.startsWith("file/preview/")) {
+      storagePath = storagePath.substring("file/preview/".length);
+    } else if (storagePath.startsWith("file/")) {
+      storagePath = storagePath.substring("file/".length);
+    }
+    if (cdnUrl) {
+      // CDN direct: public-read, no auth needed, LLM can access directly
+      const base = cdnUrl.replace(/\/+$/, "");
+      return `${base}/${storagePath}`;
+    }
+    // Fallback: Nginx public /file/ path (no auth)
     const baseUrl = apiUrl?.replace(/\/+$/, "") ?? "";
-    return `${baseUrl}/v1/botfile/${relUrl}`;
+    return `${baseUrl}/file/${storagePath}`;
   };
 
   switch (payload.type) {
@@ -436,7 +447,7 @@ export async function handleInboundMessage(params: {
     ? message.channel_id!
     : spaceId ? `${spaceId}:${message.from_uid}` : message.from_uid;
 
-  const resolved = resolveContent(message.payload, account.config.apiUrl, log);
+  const resolved = resolveContent(message.payload, account.config.apiUrl, log, account.config.cdnUrl);
   let rawBody = resolved.text;
   let inboundMediaUrl = resolved.mediaUrl;
   // Inline text file content if possible
@@ -585,7 +596,7 @@ export async function handleInboundMessage(params: {
           // For media message types, resolve the URL directly (storage is public-read)
           const mediaTypes = [MessageType.Image, MessageType.File, MessageType.Voice, MessageType.Video];
           if (mediaTypes.includes(m.type) && !m.content) {
-            const apiResolved = resolveContent({ type: m.type, url: m.url, name: m.name } as any, account.config.apiUrl, log);
+            const apiResolved = resolveContent({ type: m.type, url: m.url, name: m.name } as any, account.config.apiUrl, log, account.config.cdnUrl);
             if (apiResolved.mediaUrl) {
               entry.mediaUrl = apiResolved.mediaUrl;
               entry.body = apiResolved.text;


### PR DESCRIPTION
## 问题
`makeFullUrl` 生成 `/v1/botfile/` 路径需 bot token 认证，LLM 直接访问 401。

## 方案
1. 新增 `cdnUrl` 配置（如 `https://cdn.deepminer.com.cn/im-test-xming`）
2. 有 `cdnUrl` → 直连 CDN（公有读）
3. 无 `cdnUrl` → fallback 到 `/file/` Nginx 公开路径
4. 自动剥离 `file/preview/` 和 `file/` 前缀

## 配置示例
```json
{"cdnUrl": "https://cdn.deepminer.com.cn/im-test-xming"}
```

## 版本
v0.3.7