### PR TITLE
fix: 历史JSON注入mediaUrl替代hasMedia标记

### DIFF
--- a/openclaw-channel-dmwork/package-lock.json
+++ b/openclaw-channel-dmwork/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-channel-dmwork",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-channel-dmwork",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "bundleDependencies": [
         "crypto-js",
         "curve25519-js",

--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-channel-dmwork",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "DMWork channel plugin for OpenClaw via WuKongIM WebSocket",
   "main": "index.ts",
   "type": "module",

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -620,7 +620,7 @@ export async function handleInboundMessage(params: {
       const messagesJson = JSON.stringify(entries.map((e: any) => ({
         sender: e.sender,
         body: e.body,
-        ...(e.mediaUrl ? { hasMedia: true } : {}),
+        ...(e.mediaUrl ? { mediaUrl: e.mediaUrl } : {}),
       })), null, 2);
       const template = account.config.historyPromptTemplate || DEFAULT_HISTORY_PROMPT_TEMPLATE;
       historyPrefix = template


### PR DESCRIPTION
## 状态分析

PR #88 + #89 已完成大部分工作：
- ✅ 删除 fetchAsDataUrl 调用（改动1）— PR #88 v3 已完成
- ✅ 非@消息缓存存 mediaUrl — PR #88 v3 已完成
- ✅ API历史补充用 resolveContent+cdnUrl 拿 mediaUrl — PR #88+89 已完成
- ✅ historyMediaUrls 收集 — 已完成

## 本 PR 修复

**历史JSON注入时传 `mediaUrl` 而非 `hasMedia: true`**

`hasMedia: true` 只是标记，Agent 无法用它访问图片。改为直接传 `mediaUrl` 字段。

v0.3.8