### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,json,yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
添加 .editorconfig 统一编码格式：UTF-8、LF 换行、Go tab 缩进、TS/JS 2 空格缩进、Markdown 保留尾部空格、末尾留空行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)