### PR TITLE
chore: add dependabot.yml for gomod weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
添加 Dependabot 配置，每周自动检查 Go module 依赖更新。

- package-ecosystem: gomod
- schedule: weekly