### PR TITLE
feat: add claude-code-dmwork-ws — WebSocket gateway adapter

### DIFF
--- a/claude-code-dmwork-ws/.gitignore
+++ b/claude-code-dmwork-ws/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+data/
+config.json
+.env
+.claude/

--- a/claude-code-dmwork-ws/CHANGELOG.md
+++ b/claude-code-dmwork-ws/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.0 (2026-03-16)
+
+Initial release — WebSocket gateway connecting Claude Agent SDK to DMWork messaging.
+
+### Features
+
+- **Real-time WebSocket**: WuKongIM binary protocol with DH key exchange and AES-CBC encryption
+- **Streaming replies**: Uses DMWork stream API for incremental response delivery, with fallback to regular messages
+- **DM + Group chat**: Direct messages and @mention-triggered group responses
+- **Group context**: Caches recent group messages and member mappings for context-aware replies
+- **Session persistence**: Per-peer conversation history with sliding window (40 messages)
+- **Auto-reconnect**: Handles WS disconnections and token expiry with automatic recovery
+- **Typing indicators**: Shows typing status while Claude processes
+- **Process lock**: Prevents multiple gateway instances for the same bot
+- **Configurable SDK**: Customizable tools, permission mode, system prompt, and settings sources

--- a/claude-code-dmwork-ws/LICENSE
+++ b/claude-code-dmwork-ws/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DMWork Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/claude-code-dmwork-ws/README.md
+++ b/claude-code-dmwork-ws/README.md
@@ -1,0 +1,117 @@
+# claude-code-dmwork (WebSocket Gateway)
+
+A WebSocket-based gateway that connects [Claude Agent SDK](https://github.com/anthropics/claude-code) to DMWork messaging via the [WuKongIM](https://github.com/WuKongIM/WuKongIM) protocol.
+
+## How It Works
+
+```
+DMWork Users ←→ WuKongIM WebSocket ←→ Gateway ←→ Claude Agent SDK
+```
+
+The gateway maintains a persistent WebSocket connection to WuKongIM, receives messages in real-time, routes them to Claude Code for processing, and sends replies back via the DMWork Bot REST API.
+
+### vs. claude-code-dmwork (Polling)
+
+The existing `claude-code-dmwork` adapter in this repo uses a bash polling script. This gateway differs in:
+
+| | Polling Adapter | WebSocket Gateway |
+|---|---|---|
+| Protocol | REST polling | WuKongIM binary WebSocket |
+| Latency | Poll interval (seconds) | Real-time (< 100ms) |
+| Session | Stateless | Persistent with history |
+| Group chat | Not supported | Full support (context + @mention) |
+| Runtime | Bash + Claude Code skill | Node.js + Claude Agent SDK |
+| Encryption | None | DH key exchange + AES-CBC |
+
+## Prerequisites
+
+- Node.js >= 18
+- A DMWork server with BotFather enabled
+- A bot token from BotFather
+- Claude Code CLI installed and authenticated
+
+## Setup
+
+```bash
+# Install dependencies
+npm install
+
+# Copy and edit config
+cp config.example.json config.json
+# Edit config.json with your bot token and API URL
+
+# Run in development mode
+npm run dev
+
+# Or build and run
+npm run build
+npm start
+```
+
+## Configuration
+
+| Field | Description |
+|---|---|
+| `botToken` | Bot token from BotFather |
+| `apiUrl` | DMWork API base URL |
+| `cwd` | Working directory for Claude Code (loads CLAUDE.md, skills, etc.) |
+| `sdk.settingSources` | Which Claude Code settings to load: `"user"`, `"project"`, `"local"` |
+| `sdk.allowedTools` | Tools the agent can use (e.g., `["Read", "Glob", "Grep"]`) |
+| `sdk.permissionMode` | `"bypassPermissions"` for headless, `"acceptEdits"` for semi-auto |
+| `sdk.maxTurns` | Max conversation turns per request (optional) |
+| `sdk.systemPrompt` | Custom system prompt (optional, uses built-in default if omitted) |
+
+### Security Note
+
+Since the gateway runs headless, `bypassPermissions` is typically required. Be aware of the following:
+
+**Tool restrictions**: Carefully restrict `allowedTools` to limit what the agent can do. Avoid including `Bash` unless you fully trust all users who can message the bot. Even `Write` and `Edit` allow file modifications within `cwd`.
+
+**Settings loading**: The default `settingSources: ["user", "project"]` loads both user-level (`~/.claude`) and project-level (`cwd/.claude`) settings, including `CLAUDE.md` files, skills, and custom system prompts. This means:
+- Any persona or behavior defined in `CLAUDE.md` will apply to bot responses
+- Project-level skills will be available to the agent
+
+If the bot is shared with untrusted users, consider:
+- Setting `settingSources: []` to disable all external settings
+- Providing an explicit `sdk.systemPrompt` for full control over bot behavior
+- Using a dedicated `cwd` directory instead of a personal project
+
+## Features
+
+- **DM + Group Chat**: Responds to direct messages and @mentions in groups
+- **Session Persistence**: Maintains conversation history per peer (sliding window of 40 messages)
+- **Group Context**: Caches recent group messages and member mappings for context-aware replies
+- **Auto-Reconnect**: Handles WS disconnections and token expiry with automatic recovery
+- **Typing Indicators**: Shows typing status while Claude processes
+- **Streaming Replies**: Incremental response delivery via DMWork stream API, with fallback to regular messages
+- **Process Lock**: Prevents multiple gateway instances for the same bot
+
+## Architecture
+
+```
+src/
+├── index.ts              # Entry point
+├── config.ts             # Config loader (file + env vars)
+├── gateway.ts            # Core: message routing + Claude SDK integration
+├── session-store.ts      # Conversation history persistence
+├── group-context.ts      # Group chat context cache + member resolution
+└── dmwork/
+    ├── socket.ts          # WuKongIM binary protocol (DH, AES, heartbeat)
+    ├── api.ts             # DMWork Bot REST API client
+    ├── types.ts           # Type definitions
+    └── mentions.ts        # @mention parsing
+```
+
+## Environment Variables
+
+These override `config.json` for connection settings:
+
+| Variable | Description |
+|---|---|
+| `DMWORK_BOT_TOKEN` | Bot token |
+| `DMWORK_API_URL` | API base URL |
+| `DMWORK_CWD` | Working directory for Claude Code |
+
+## License
+
+MIT

--- a/claude-code-dmwork-ws/config.example.json
+++ b/claude-code-dmwork-ws/config.example.json
@@ -1,0 +1,13 @@
+{
+  "botToken": "your_bot_token_from_botfather",
+  "apiUrl": "https://your-dmwork-server.com/api",
+  "cwd": "/path/to/your/working/directory",
+  "sdk": {
+    "settingSources": ["user", "project"],
+    "allowedTools": [
+      "Read", "Write", "Edit", "Glob", "Grep",
+      "Skill", "WebFetch", "WebSearch"
+    ],
+    "permissionMode": "bypassPermissions"
+  }
+}

--- a/claude-code-dmwork-ws/package.json
+++ b/claude-code-dmwork-ws/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "claude-code-dmwork",
+  "version": "0.1.0",
+  "description": "Connect Claude Code to DMWork messaging via WuKongIM",
+  "type": "module",
+  "bin": {
+    "claude-code-dmwork": "./dist/index.js"
+  },
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "test": "vitest run",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "crypto-js": "^4.2.0",
+    "curve25519-js": "^0.0.4",
+    "md5-typescript": "^1.0.5",
+    "ws": "^8.16.0"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@types/crypto-js": "^4.2.0",
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/claude-code-dmwork-ws/src/config.ts
+++ b/claude-code-dmwork-ws/src/config.ts
@@ -1,0 +1,93 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// ─── Config Schema ───────────────────────────────────────────────────────────
+
+export interface BotConfig {
+  /** DMWork bot token (from BotFather) */
+  botToken: string;
+  /** DMWork API base URL */
+  apiUrl: string;
+
+  /** Working directory for Claude Code (loads CLAUDE.md, .claude/settings, skills) */
+  cwd: string;
+  /** Data directory for sessions/memory */
+  dataDir: string;
+
+  /** Claude Agent SDK options */
+  sdk: {
+    /** Which settings to load: "user" = ~/.claude, "project" = cwd/.claude, "local" = cwd/.claude/local */
+    settingSources: Array<"user" | "project" | "local">;
+    /** Tools the agent can use */
+    allowedTools: string[];
+    /** Permission mode: "bypassPermissions" for headless, "acceptEdits" for semi-auto */
+    permissionMode: "default" | "acceptEdits" | "bypassPermissions" | "plan";
+    /** Max conversation turns (undefined = unlimited) */
+    maxTurns?: number;
+    /** Custom system prompt (undefined = use built-in default) */
+    systemPrompt?: string;
+  };
+}
+
+// ─── Defaults ────────────────────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CWD = path.resolve(__dirname, "..");
+
+const DEFAULT_SDK: BotConfig["sdk"] = {
+  settingSources: ["user", "project"],
+  allowedTools: [
+    "Read", "Write", "Edit", "Bash",
+    "Glob", "Grep", "Skill",
+    "WebFetch", "WebSearch",
+  ],
+  permissionMode: "acceptEdits",
+};
+
+// ─── Loader ──────────────────────────────────────────────────────────────────
+
+export function loadConfig(): BotConfig {
+  // Priority: env vars (DMWork connection only) > config file > defaults
+
+  // Try config file first
+  const configPaths = [
+    path.join(DEFAULT_CWD, "config.json"),
+    path.join(process.env.HOME || process.env.USERPROFILE || "", ".claude-code-dmwork.json"),
+  ];
+
+  let raw: Record<string, any> = {};
+  for (const configPath of configPaths) {
+    if (fs.existsSync(configPath)) {
+      raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+      console.log(`[config] Loaded from ${configPath}`);
+      break;
+    }
+  }
+
+  // Env vars override config file for connection settings
+  const botToken = process.env.DMWORK_BOT_TOKEN || raw.botToken;
+  const apiUrl = process.env.DMWORK_API_URL || raw.apiUrl;
+
+  if (!botToken || !apiUrl) {
+    console.error("Missing config. Set botToken + apiUrl in config.json, or DMWORK_BOT_TOKEN + DMWORK_API_URL env vars.");
+    process.exit(1);
+  }
+
+  const cwd = process.env.DMWORK_CWD || raw.cwd || DEFAULT_CWD;
+  const sdkRaw = raw.sdk || {};
+
+  return {
+    botToken,
+    apiUrl,
+    cwd,
+    dataDir: raw.dataDir || path.join(DEFAULT_CWD, "data"),
+    sdk: {
+      settingSources: sdkRaw.settingSources || DEFAULT_SDK.settingSources,
+      allowedTools: sdkRaw.allowedTools || DEFAULT_SDK.allowedTools,
+      permissionMode: sdkRaw.permissionMode || DEFAULT_SDK.permissionMode,
+      maxTurns: sdkRaw.maxTurns,
+      systemPrompt: sdkRaw.systemPrompt,
+    },
+  };
+}

--- a/claude-code-dmwork-ws/src/dmwork/api.ts
+++ b/claude-code-dmwork-ws/src/dmwork/api.ts
@@ -1,0 +1,209 @@
+/** DMWork REST API client — extracted from openclaw-channel-dmwork */
+
+import { ChannelType, MessageType } from "./types.js";
+import type { BotRegisterResp } from "./types.js";
+
+const DEFAULT_HEADERS = { "Content-Type": "application/json" };
+
+async function postJson<T>(
+  apiUrl: string,
+  botToken: string,
+  path: string,
+  payload: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<T | undefined> {
+  const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { ...DEFAULT_HEADERS, Authorization: `Bearer ${botToken}` },
+    body: JSON.stringify(payload),
+    signal,
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`DMWork API ${path} failed (${response.status}): ${text || response.statusText}`);
+  }
+  const text = await response.text();
+  if (!text) return undefined;
+  return JSON.parse(text) as T;
+}
+
+export async function registerBot(params: {
+  apiUrl: string;
+  botToken: string;
+  forceRefresh?: boolean;
+  signal?: AbortSignal;
+}): Promise<BotRegisterResp> {
+  const path = params.forceRefresh ? "/v1/bot/register?force_refresh=true" : "/v1/bot/register";
+  const result = await postJson<BotRegisterResp>(params.apiUrl, params.botToken, path, {}, params.signal);
+  if (!result) throw new Error("DMWork bot registration returned empty response");
+  return result;
+}
+
+export async function sendMessage(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  content: string;
+  mentionUids?: string[];
+  replyMsgId?: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const payload: Record<string, unknown> = {
+    type: MessageType.Text,
+    content: params.content,
+  };
+  if (params.mentionUids?.length) {
+    payload.mention = { uids: params.mentionUids };
+  }
+  if (params.replyMsgId) {
+    payload.reply = { message_id: params.replyMsgId };
+  }
+  await postJson(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+    payload,
+  }, params.signal);
+}
+
+export async function sendTyping(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  signal?: AbortSignal;
+}): Promise<void> {
+  await postJson(params.apiUrl, params.botToken, "/v1/bot/typing", {
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+  }, params.signal).catch(() => {});
+}
+
+export async function sendHeartbeat(params: {
+  apiUrl: string;
+  botToken: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  await postJson(params.apiUrl, params.botToken, "/v1/bot/heartbeat", {}, params.signal).catch(() => {});
+}
+
+export async function getChannelMessages(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  limit?: number;
+  signal?: AbortSignal;
+}): Promise<Array<{ from_uid: string; content: string; timestamp: number }>> {
+  try {
+    const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/messages/sync`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${params.botToken}` },
+      body: JSON.stringify({
+        channel_id: params.channelId,
+        channel_type: params.channelType,
+        limit: params.limit ?? 20,
+        start_message_seq: 0,
+        end_message_seq: 0,
+        pull_mode: 1,
+      }),
+      signal: params.signal,
+    });
+    if (!response.ok) return [];
+    const data = await response.json();
+    const messages = data.messages ?? [];
+    return messages.map((m: any) => {
+      let payload: any = {};
+      if (m.payload) {
+        try {
+          payload = JSON.parse(Buffer.from(m.payload, "base64").toString("utf-8"));
+        } catch {
+          payload = typeof m.payload === "object" ? m.payload : {};
+        }
+      }
+      return {
+        from_uid: m.from_uid ?? "unknown",
+        content: payload.content ?? "",
+        timestamp: (m.timestamp ?? Math.floor(Date.now() / 1000)) * 1000,
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+// ─── Streaming API ──────────────────────────────────────────────────────────
+
+export async function streamStart(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+}): Promise<string> {
+  const payload = Buffer.from(JSON.stringify({ type: MessageType.Text, content: "" })).toString("base64");
+  const result = await postJson<{ stream_no: string }>(params.apiUrl, params.botToken, "/v1/bot/stream/start", {
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+    payload,
+  });
+  return result?.stream_no ?? "";
+}
+
+/**
+ * Send accumulated text to an active stream.
+ * IMPORTANT: content must be the FULL accumulated text so far, not incremental.
+ * The client replaces previous content with each update.
+ */
+export async function streamSend(params: {
+  apiUrl: string;
+  botToken: string;
+  streamNo: string;
+  channelId: string;
+  channelType: ChannelType;
+  content: string;
+}): Promise<void> {
+  await postJson(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
+    stream_no: params.streamNo,
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+    payload: { type: MessageType.Text, content: params.content },
+  });
+}
+
+export async function streamEnd(params: {
+  apiUrl: string;
+  botToken: string;
+  streamNo: string;
+  channelId: string;
+  channelType: ChannelType;
+}): Promise<void> {
+  await postJson(params.apiUrl, params.botToken, "/v1/bot/stream/end", {
+    stream_no: params.streamNo,
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+  });
+}
+
+// ─── Group Members ──────────────────────────────────────────────────────────
+
+export async function getGroupMembers(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+}): Promise<Array<{ uid: string; name: string; robot?: boolean }>> {
+  try {
+    const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${params.groupNo}/members`;
+    const resp = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${params.botToken}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) return [];
+    const data = await resp.json();
+    return Array.isArray(data?.members) ? data.members : Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}

--- a/claude-code-dmwork-ws/src/dmwork/mentions.ts
+++ b/claude-code-dmwork-ws/src/dmwork/mentions.ts
@@ -1,0 +1,14 @@
+/** @mention parsing — extracted from openclaw-channel-dmwork */
+
+export const MENTION_PATTERN = /@[\w\u4e00-\u9fa5.\-]+/g;
+
+export function parseMentions(content: string): string[] {
+  const regex = new RegExp(MENTION_PATTERN.source, "g");
+  const matches = content.match(regex) ?? [];
+  return matches.map((m) => m.slice(1));
+}
+
+export function extractMentionMatches(content: string): string[] {
+  const regex = new RegExp(MENTION_PATTERN.source, "g");
+  return content.match(regex) ?? [];
+}

--- a/claude-code-dmwork-ws/src/dmwork/socket.ts
+++ b/claude-code-dmwork-ws/src/dmwork/socket.ts
@@ -1,0 +1,631 @@
+import { EventEmitter } from "events";
+import WebSocket from "ws";
+import { generateKeyPair, sharedKey } from "curve25519-js";
+import { Buffer } from "buffer";
+import CryptoJS from "crypto-js";
+import { Md5 } from "md5-typescript";
+import type { BotMessage, MessagePayload } from "./types.js";
+
+// ─── WuKongIM Binary Protocol Constants ─────────────────────────────────────
+
+const enum PacketType {
+  CONNECT = 1,
+  CONNACK = 2,
+  SEND = 3,
+  SENDACK = 4,
+  RECV = 5,
+  RECVACK = 6,
+  PING = 7,
+  PONG = 8,
+  DISCONNECT = 9,
+}
+
+const PROTO_VERSION = 4;
+
+// ─── Binary Encoder / Decoder ───────────────────────────────────────────────
+
+class Encoder {
+  private w: number[] = [];
+  writeByte(b: number) { this.w.push(b & 0xff); }
+  writeBytes(b: number[]) { this.w.push(...b); }
+  writeInt16(b: number) { this.w.push((b >> 8) & 0xff, b & 0xff); }
+  writeInt32(b: number) { this.w.push((b >> 24) & 0xff, (b >> 16) & 0xff, (b >> 8) & 0xff, b & 0xff); }
+  writeInt64(n: bigint) {
+    const hi = Number(n >> 32n);
+    const lo = Number(n & 0xffffffffn);
+    this.writeInt32(hi);
+    this.writeInt32(lo);
+  }
+  writeString(s: string) {
+    if (s && s.length > 0) {
+      const arr = stringToUint(s);
+      this.writeInt16(arr.length);
+      this.w.push(...arr);
+    } else {
+      this.writeInt16(0);
+    }
+  }
+  toUint8Array(): Uint8Array { return new Uint8Array(this.w); }
+}
+
+class Decoder {
+  private offset = 0;
+  constructor(private data: Uint8Array) {}
+
+  readByte(): number { return this.data[this.offset++]; }
+
+  readInt16(): number {
+    const v = (this.data[this.offset] << 8) | this.data[this.offset + 1];
+    this.offset += 2;
+    return v;
+  }
+
+  readInt32(): number {
+    const v =
+      (this.data[this.offset] << 24) |
+      (this.data[this.offset + 1] << 16) |
+      (this.data[this.offset + 2] << 8) |
+      this.data[this.offset + 3];
+    this.offset += 4;
+    return v >>> 0; // unsigned
+  }
+
+  readInt64String(): string {
+    // Read 8 bytes as a big-endian unsigned integer string
+    let n = BigInt(0);
+    for (let i = 0; i < 8; i++) {
+      n = (n << 8n) | BigInt(this.data[this.offset + i]);
+    }
+    this.offset += 8;
+    return n.toString();
+  }
+
+  readInt64BigInt(): bigint {
+    let n = BigInt(0);
+    for (let i = 0; i < 8; i++) {
+      n = (n << 8n) | BigInt(this.data[this.offset + i]);
+    }
+    this.offset += 8;
+    return n;
+  }
+
+  readString(): string {
+    const len = this.readInt16();
+    if (len <= 0) return "";
+    const slice = this.data.slice(this.offset, this.offset + len);
+    this.offset += len;
+    return uintToString(Array.from(slice));
+  }
+
+  readRemaining(): Uint8Array {
+    const d = this.data.slice(this.offset);
+    this.offset = this.data.length;
+    return d;
+  }
+
+  readVariableLength(): number {
+    let multiplier = 0;
+    let rLength = 0;
+    while (multiplier < 27) {
+      const b = this.readByte();
+      rLength = rLength | ((b & 127) << multiplier);
+      if ((b & 128) === 0) break;
+      multiplier += 7;
+    }
+    return rLength;
+  }
+}
+
+function stringToUint(str: string): number[] {
+  const encoded = unescape(encodeURIComponent(str));
+  const arr: number[] = [];
+  for (let i = 0; i < encoded.length; i++) arr.push(encoded.charCodeAt(i));
+  return arr;
+}
+
+function uintToString(array: number[]): string {
+  const encoded = String.fromCharCode(...array);
+  return decodeURIComponent(escape(encoded));
+}
+
+function encodeVariableLength(len: number): number[] {
+  const ret: number[] = [];
+  while (len > 0) {
+    let digit = len % 0x80;
+    len = Math.floor(len / 0x80);
+    if (len > 0) digit |= 0x80;
+    ret.push(digit);
+  }
+  return ret;
+}
+
+// ─── AES-CBC Encryption Helpers ─────────────────────────────────────────────
+
+function aesDecrypt(data: Uint8Array, aesKey: string, aesIV: string): Uint8Array {
+  const str = String.fromCharCode(...Array.from(data));
+  const ciphertext = CryptoJS.enc.Base64.parse(str);
+  const decrypted = CryptoJS.AES.decrypt(
+    CryptoJS.enc.Base64.stringify(ciphertext),
+    CryptoJS.enc.Utf8.parse(aesKey),
+    {
+      keySize: 128 / 8,
+      iv: CryptoJS.enc.Utf8.parse(aesIV),
+      mode: CryptoJS.mode.CBC,
+      padding: CryptoJS.pad.Pkcs7,
+    },
+  );
+  return Uint8Array.from(Buffer.from(decrypted.toString(CryptoJS.enc.Utf8)));
+}
+
+function aesEncrypt(message: string, aesKey: string, aesIV: string): string {
+  return CryptoJS.AES.encrypt(
+    CryptoJS.enc.Utf8.parse(message),
+    CryptoJS.enc.Utf8.parse(aesKey),
+    {
+      keySize: 128 / 8,
+      iv: CryptoJS.enc.Utf8.parse(aesIV),
+      mode: CryptoJS.mode.CBC,
+      padding: CryptoJS.pad.Pkcs7,
+    },
+  ).toString();
+}
+
+// ─── Packet Encoding / Decoding ─────────────────────────────────────────────
+
+function encodeConnectPacket(opts: {
+  version: number;
+  deviceFlag: number;
+  deviceID: string;
+  uid: string;
+  token: string;
+  clientTimestamp: number;
+  clientKey: string;
+}): Uint8Array {
+  const body = new Encoder();
+  body.writeByte(opts.version);
+  body.writeByte(opts.deviceFlag);
+  body.writeString(opts.deviceID);
+  body.writeString(opts.uid);
+  body.writeString(opts.token);
+  body.writeInt64(BigInt(opts.clientTimestamp));
+  body.writeString(opts.clientKey);
+  const bodyBytes = Array.from(body.toUint8Array());
+
+  const frame = new Encoder();
+  // header: packetType << 4 | flags (noPersist bit0 = hasServerVersion for CONNACK)
+  frame.writeByte((PacketType.CONNECT << 4) | 0);
+  frame.writeBytes(encodeVariableLength(bodyBytes.length));
+  frame.writeBytes(bodyBytes);
+  return frame.toUint8Array();
+}
+
+function encodePingPacket(): Uint8Array {
+  return new Uint8Array([(PacketType.PING << 4) | 0]);
+}
+
+function encodeRecvackPacket(messageID: string, messageSeq: number): Uint8Array {
+  const body = new Encoder();
+  body.writeInt64(BigInt(messageID));
+  body.writeInt32(messageSeq);
+  const bodyBytes = Array.from(body.toUint8Array());
+
+  const frame = new Encoder();
+  frame.writeByte((PacketType.RECVACK << 4) | 0);
+  frame.writeBytes(encodeVariableLength(bodyBytes.length));
+  frame.writeBytes(bodyBytes);
+  return frame.toUint8Array();
+}
+
+interface SettingFlags {
+  receiptEnabled: boolean;
+  topic: boolean;
+  streamOn: boolean;
+}
+
+function parseSettingByte(v: number): SettingFlags {
+  return {
+    receiptEnabled: ((v >> 7) & 0x01) > 0,
+    topic: ((v >> 3) & 0x01) > 0,
+    streamOn: ((v >> 1) & 0x01) > 0,
+  };
+}
+
+// ─── WKSocket — Independent WebSocket Connection ────────────────────────────
+
+interface WKSocketOptions {
+  wsUrl: string;
+  uid: string;
+  token: string;
+  onMessage: (msg: BotMessage) => void;
+  onConnected?: () => void;
+  onDisconnected?: () => void;
+  onError?: (err: Error) => void;
+}
+
+/**
+ * WuKongIM WebSocket client for bot connections.
+ *
+ * Implements the WuKongIM binary protocol directly over WebSocket,
+ * with per-instance DH key exchange, AES encryption, heartbeat,
+ * reconnect, and RECVACK.
+ *
+ * Each WKSocket instance maintains its own independent connection,
+ * enabling multiple bot accounts to run simultaneously.
+ */
+export class WKSocket extends EventEmitter {
+  private ws: WebSocket | null = null;
+  private connected = false;
+  private needReconnect = true;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartTimer: ReturnType<typeof setInterval> | null = null;
+  private pingRetryCount = 0;
+  private readonly pingMaxRetry = 3;
+
+  // Per-instance crypto state (set after CONNACK)
+  private aesKey = "";
+  private aesIV = "";
+  private dhPrivateKey: Uint8Array | null = null;
+  private serverVersion = 0;
+
+  // Buffer for handling packet fragmentation (sticky packets)
+  private tempBuffer: number[] = [];
+
+  constructor(private opts: WKSocketOptions) {
+    super();
+  }
+
+  /** Connect to WuKongIM WebSocket */
+  connect(): void {
+    this.needReconnect = true;
+    this.doConnect();
+  }
+
+  /** Update credentials for reconnection (e.g. after token refresh) */
+  updateCredentials(uid: string, token: string): void {
+    this.opts.uid = uid;
+    this.opts.token = token;
+  }
+
+  /** Gracefully disconnect */
+  disconnect(): void {
+    this.needReconnect = false;
+    this.connected = false;
+    this.stopHeart();
+    this.stopReconnectTimer();
+    if (this.ws) {
+      try { this.ws.close(); } catch { /* ignore */ }
+      this.ws = null;
+    }
+  }
+
+  // ─── Internal Connection Logic ──────────────────────────────────────────
+
+  private doConnect(): void {
+    if (this.ws) {
+      try { this.ws.close(); } catch { /* ignore */ }
+      this.ws = null;
+    }
+
+    this.tempBuffer = [];
+    const ws = new WebSocket(this.opts.wsUrl);
+    ws.binaryType = "arraybuffer";
+    this.ws = ws;
+
+    ws.on("open", () => {
+      this.tempBuffer = [];
+      // Generate DH key pair
+      const seed = Uint8Array.from(stringToUint(generateDeviceID()));
+      const keyPair = generateKeyPair(seed);
+      this.dhPrivateKey = keyPair.private;
+      const pubKey = Buffer.from(keyPair.public).toString("base64");
+
+      const deviceID = generateDeviceID() + "W";
+      const packet = encodeConnectPacket({
+        version: PROTO_VERSION,
+        deviceFlag: 0, // 0 = app (match openclaw adapter)
+        deviceID,
+        uid: this.opts.uid,
+        token: this.opts.token,
+        clientTimestamp: Date.now(),
+        clientKey: pubKey,
+      });
+      ws.send(packet);
+    });
+
+    ws.on("message", (data: ArrayBuffer | Buffer) => {
+      const bytes = new Uint8Array(data instanceof ArrayBuffer ? data : data.buffer);
+      this.handleRawData(bytes);
+    });
+
+    ws.on("close", () => {
+      if (this.connected) {
+        this.connected = false;
+        this.opts.onDisconnected?.();
+      }
+      this.stopHeart();
+      if (this.needReconnect) {
+        this.scheduleReconnect();
+      }
+    });
+
+    ws.on("error", (err) => {
+      console.debug("[WKSocket] ws error:", err.message);
+      // The 'close' event will follow, which handles reconnect
+    });
+  }
+
+  private scheduleReconnect(): void {
+    this.stopReconnectTimer();
+    this.reconnectTimer = setTimeout(() => {
+      if (this.needReconnect) {
+        this.doConnect();
+      }
+    }, 3000);
+  }
+
+  private stopReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  // ─── Heartbeat ──────────────────────────────────────────────────────────
+
+  private restartHeart(): void {
+    this.stopHeart();
+    this.pingRetryCount = 0;
+    this.heartTimer = setInterval(() => {
+      this.pingRetryCount++;
+      if (this.pingRetryCount > this.pingMaxRetry) {
+        console.debug("[WKSocket] ping timeout, reconnecting...");
+        this.stopHeart();
+        if (this.ws) {
+          try { this.ws.close(); } catch { /* ignore */ }
+          this.ws = null;
+        }
+        if (this.connected) {
+          this.connected = false;
+          this.opts.onDisconnected?.();
+        }
+        if (this.needReconnect) {
+          this.scheduleReconnect();
+        }
+        return;
+      }
+      this.sendRaw(encodePingPacket());
+    }, 60_000); // 60s heartbeat interval (matches SDK default)
+  }
+
+  private stopHeart(): void {
+    if (this.heartTimer) {
+      clearInterval(this.heartTimer);
+      this.heartTimer = null;
+    }
+  }
+
+  // ─── Raw Data & Packet Framing ──────────────────────────────────────────
+
+  private sendRaw(data: Uint8Array): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(data);
+    }
+  }
+
+  private handleRawData(data: Uint8Array): void {
+    this.tempBuffer.push(...Array.from(data));
+
+    try {
+      let lenBefore: number;
+      let lenAfter: number;
+      do {
+        lenBefore = this.tempBuffer.length;
+        this.tempBuffer = this.unpackOne(this.tempBuffer);
+        lenAfter = this.tempBuffer.length;
+      } while (lenBefore !== lenAfter && lenAfter >= 1);
+    } catch (err) {
+      console.debug("[WKSocket] decode error:", err);
+      // Reset buffer and reconnect
+      this.tempBuffer = [];
+      if (this.ws) {
+        try { this.ws.close(); } catch { /* ignore */ }
+      }
+    }
+  }
+
+  private unpackOne(data: number[]): number[] {
+    if (data.length === 0) return data;
+
+    const header = data[0];
+    const packetType = header >> 4;
+
+    // PONG is a single byte
+    if (packetType === PacketType.PONG) {
+      this.onPong();
+      return data.slice(1);
+    }
+    // PING from server (shouldn't happen but handle gracefully)
+    if (packetType === PacketType.PING) {
+      return data.slice(1);
+    }
+
+    const length = data.length;
+    const fixedHeaderLength = 1;
+    let pos = fixedHeaderLength;
+    let remLength = 0;
+    let multiplier = 1;
+    let hasMore = false;
+    let remLengthFull = true;
+
+    do {
+      if (pos > length - 1) {
+        remLengthFull = false;
+        break;
+      }
+      const digit = data[pos++];
+      remLength += (digit & 127) * multiplier;
+      multiplier *= 128;
+      hasMore = (digit & 0x80) !== 0;
+    } while (hasMore);
+
+    if (!remLengthFull) return data; // Incomplete frame
+
+    const remLengthLength = pos - fixedHeaderLength;
+    const totalLength = fixedHeaderLength + remLengthLength + remLength;
+
+    if (totalLength > length) return data; // Incomplete packet
+
+    // Extract one complete packet
+    const packetData = new Uint8Array(data.slice(0, totalLength));
+    this.onPacket(packetData);
+    return data.slice(totalLength);
+  }
+
+  // ─── Packet Handling ────────────────────────────────────────────────────
+
+  private onPong(): void {
+    this.pingRetryCount = 0;
+  }
+
+  private onPacket(data: Uint8Array): void {
+    const firstByte = data[0];
+    const packetType = firstByte >> 4;
+    const hasServerVersion = (firstByte & 0x01) > 0;
+    const noPersist = (firstByte & 0x01) > 0;
+    const reddot = ((firstByte >> 1) & 0x01) > 0;
+
+    // Skip the header and variable-length bytes to get body
+    const dec = new Decoder(data);
+    dec.readByte(); // header byte
+    if (packetType !== PacketType.PING && packetType !== PacketType.PONG) {
+      dec.readVariableLength(); // remaining length
+    }
+
+    switch (packetType) {
+      case PacketType.CONNACK:
+        this.onConnack(dec, hasServerVersion);
+        break;
+      case PacketType.RECV:
+        this.onRecv(dec, noPersist, reddot);
+        break;
+      case PacketType.DISCONNECT:
+        this.onDisconnect(dec);
+        break;
+      case PacketType.SENDACK:
+        // We don't send messages via WS, ignore
+        break;
+    }
+  }
+
+  private onConnack(dec: Decoder, hasServerVersion: boolean): void {
+    if (hasServerVersion) {
+      this.serverVersion = dec.readByte();
+    }
+    const _timeDiff = dec.readInt64BigInt();
+    const reasonCode = dec.readByte();
+    const serverKey = dec.readString();
+    const salt = dec.readString();
+    if (this.serverVersion >= 4) {
+      const _nodeId = dec.readInt64BigInt();
+    }
+
+    if (reasonCode === 1) {
+      // Success — derive AES key from DH shared secret
+      const serverPubKey = Uint8Array.from(Buffer.from(serverKey, "base64"));
+      const secret = sharedKey(this.dhPrivateKey!, serverPubKey);
+      const secretBase64 = Buffer.from(secret).toString("base64");
+      const aesKeyFull = Md5.init(secretBase64);
+      this.aesKey = aesKeyFull.substring(0, 16);
+      this.aesIV = salt && salt.length > 16 ? salt.substring(0, 16) : salt;
+
+      this.connected = true;
+      this.restartHeart();
+      this.opts.onConnected?.();
+    } else if (reasonCode === 0) {
+      // Kicked at CONNACK stage
+      this.connected = false;
+      this.needReconnect = false;
+      this.opts.onError?.(new Error("Kicked by server (CONNACK)"));
+      this.opts.onDisconnected?.();
+    } else {
+      // Connect failed
+      this.connected = false;
+      this.needReconnect = false;
+      this.opts.onError?.(new Error(`Connect failed: reasonCode=${reasonCode}`));
+    }
+  }
+
+  private onRecv(dec: Decoder, _noPersist: boolean, _reddot: boolean): void {
+    const settingByte = dec.readByte();
+    const setting = parseSettingByte(settingByte);
+    const _msgKey = dec.readString();
+    const fromUID = dec.readString();
+    const channelID = dec.readString();
+    const channelType = dec.readByte();
+    if (this.serverVersion >= 3) {
+      const _expire = dec.readInt32();
+    }
+    const _clientMsgNo = dec.readString();
+    const messageID = dec.readInt64String();
+    const messageSeq = dec.readInt32();
+    const timestamp = dec.readInt32();
+    if (setting.topic) {
+      const _topic = dec.readString();
+    }
+    const encryptedPayload = dec.readRemaining();
+
+    // Send RECVACK immediately
+    this.sendRaw(encodeRecvackPacket(messageID, messageSeq));
+
+    // Decrypt payload
+    let payloadObj: Record<string, any> | undefined;
+    try {
+      const decryptedBytes = aesDecrypt(encryptedPayload, this.aesKey, this.aesIV);
+      const payloadStr = uintToString(Array.from(decryptedBytes));
+      payloadObj = JSON.parse(payloadStr);
+    } catch (err) {
+      console.debug("[WKSocket] payload decrypt/parse error:", err);
+      return;
+    }
+
+    // Build MessagePayload (same shape as SDK's contentObj-based output)
+    const payload: MessagePayload = {
+      type: payloadObj?.type ?? 0,
+      content: payloadObj?.content,
+      ...payloadObj,
+    };
+
+    const msg: BotMessage = {
+      message_id: messageID,
+      message_seq: messageSeq,
+      from_uid: fromUID,
+      channel_id: channelID,
+      channel_type: channelType,
+      timestamp,
+      payload,
+    };
+
+    this.opts.onMessage(msg);
+  }
+
+  private onDisconnect(dec: Decoder): void {
+    const reasonCode = dec.readByte();
+    const reason = dec.readString();
+
+    this.connected = false;
+    this.needReconnect = false;
+    this.stopHeart();
+    this.opts.onError?.(new Error(`Kicked by server (DISCONNECT reason=${reasonCode} ${reason})`));
+    this.opts.onDisconnected?.();
+  }
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+function generateDeviceID(): string {
+  return "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/claude-code-dmwork-ws/src/dmwork/types.ts
+++ b/claude-code-dmwork-ws/src/dmwork/types.ts
@@ -1,0 +1,57 @@
+/** DMWork Bot API types — extracted from openclaw-channel-dmwork */
+
+export interface BotRegisterResp {
+  robot_id: string;
+  im_token: string;
+  ws_url: string;
+  api_url: string;
+  owner_uid: string;
+  owner_channel_id: string;
+}
+
+export interface BotMessage {
+  message_id: string;
+  message_seq: number;
+  from_uid: string;
+  channel_id?: string;
+  channel_type?: ChannelType;
+  timestamp: number;
+  payload: MessagePayload;
+}
+
+export interface MentionPayload {
+  uids?: string[];
+  all?: boolean | number;
+}
+
+export interface ReplyPayload {
+  payload?: MessagePayload;
+  from_uid?: string;
+  from_name?: string;
+}
+
+export interface MessagePayload {
+  type: MessageType;
+  content?: string;
+  url?: string;
+  name?: string;
+  mention?: MentionPayload;
+  reply?: ReplyPayload;
+  [key: string]: unknown;
+}
+
+export enum ChannelType {
+  DM = 1,
+  Group = 2,
+}
+
+export enum MessageType {
+  Text = 1,
+  Image = 2,
+  GIF = 3,
+  Voice = 4,
+  Video = 5,
+  Location = 6,
+  Card = 7,
+  File = 8,
+}

--- a/claude-code-dmwork-ws/src/gateway.ts
+++ b/claude-code-dmwork-ws/src/gateway.ts
@@ -1,0 +1,424 @@
+/**
+ * Gateway: DMWork WebSocket ←→ Claude Agent SDK
+ *
+ * Receives messages from DMWork via WuKongIM WebSocket,
+ * routes them to Claude Code for processing,
+ * sends replies back via DMWork REST API.
+ */
+
+import { query as agentQuery } from "@anthropic-ai/claude-agent-sdk";
+import { WKSocket } from "./dmwork/socket.js";
+import { registerBot, sendMessage, sendTyping, sendHeartbeat, streamStart, streamSend, streamEnd } from "./dmwork/api.js";
+import { ChannelType, MessageType } from "./dmwork/types.js";
+import type { BotMessage } from "./dmwork/types.js";
+import { parseMentions } from "./dmwork/mentions.js";
+import { SessionStore } from "./session-store.js";
+import { GroupContext } from "./group-context.js";
+import type { BotConfig } from "./config.js";
+import fs from "fs";
+import path from "path";
+
+export class Gateway {
+  private config: BotConfig;
+  private sessions: SessionStore;
+  private groupCtx: GroupContext;
+  private socket: WKSocket | null = null;
+  private robotId = "";
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private processing = new Set<string>(); // prevent concurrent processing per peer
+  private startedAt = 0; // ignore messages older than this
+  private isRefreshingToken = false; // guard against concurrent refreshes
+  private hasRefreshedToken = false; // only refresh token once per session
+
+  constructor(config: BotConfig) {
+    this.config = config;
+    this.sessions = new SessionStore(config.dataDir);
+    this.groupCtx = new GroupContext();
+    fs.mkdirSync(config.dataDir, { recursive: true });
+  }
+
+  async start(): Promise<void> {
+    // Prevent multiple instances (same bot can't have 2 WS connections)
+    const lockFile = path.join(this.config.dataDir, ".gateway.lock");
+    fs.mkdirSync(this.config.dataDir, { recursive: true });
+    if (fs.existsSync(lockFile)) {
+      const pid = fs.readFileSync(lockFile, "utf-8").trim();
+      try {
+        process.kill(Number(pid), 0); // check if alive
+        console.error(`[gateway] Another instance running (PID ${pid}). Exiting.`);
+        process.exit(1);
+      } catch {
+        // stale lock, continue
+      }
+    }
+    fs.writeFileSync(lockFile, String(process.pid));
+    process.on("exit", () => { try { fs.unlinkSync(lockFile); } catch {} });
+
+    console.log("[gateway] Registering bot...");
+    const reg = await registerBot({
+      apiUrl: this.config.apiUrl,
+      botToken: this.config.botToken,
+    });
+
+    this.robotId = reg.robot_id;
+    console.log(`[gateway] Registered as ${this.robotId}`);
+
+    // Connect WebSocket
+    this.socket = new WKSocket({
+      wsUrl: reg.ws_url,
+      uid: reg.robot_id,
+      token: reg.im_token,
+      onMessage: (msg) => this.onMessage(msg),
+      onConnected: () => {
+        console.log("[gateway] WebSocket connected, draining old messages for 3s...");
+        this.startedAt = Math.floor(Date.now() / 1000) + 3;
+        this.startHeartbeat();
+      },
+      onDisconnected: () => console.log("[gateway] WebSocket disconnected"),
+      onError: async (err) => {
+        console.error("[gateway] WebSocket error:", err.message);
+        // Kicked or connect failed: refresh IM token once (match openclaw adapter pattern)
+        if (!this.hasRefreshedToken && !this.isRefreshingToken &&
+            (err.message.includes("Kicked") || err.message.includes("Connect failed"))) {
+          this.isRefreshingToken = true;
+          this.hasRefreshedToken = true;
+          console.log("[gateway] Connection rejected — refreshing IM token...");
+          try {
+            const fresh = await registerBot({
+              apiUrl: this.config.apiUrl,
+              botToken: this.config.botToken,
+              forceRefresh: true,
+            });
+            this.robotId = fresh.robot_id;
+            console.log("[gateway] Got fresh IM token, reconnecting WS...");
+            this.socket!.disconnect();
+            this.socket!.updateCredentials(fresh.robot_id, fresh.im_token);
+            this.socket!.connect();
+          } catch (refreshErr) {
+            console.error("[gateway] Token refresh failed:", refreshErr);
+            this.hasRefreshedToken = false; // allow retry on next error
+          } finally {
+            this.isRefreshingToken = false;
+          }
+        }
+      },
+    });
+
+    this.socket.connect();
+
+    console.log("[gateway] Running. Press Ctrl+C to stop.");
+  }
+
+  stop(): void {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.socket?.disconnect();
+    console.log("[gateway] Stopped.");
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer) { clearInterval(this.heartbeatTimer); this.heartbeatTimer = null; }
+    this.heartbeatTimer = setInterval(() => {
+      sendHeartbeat({ apiUrl: this.config.apiUrl, botToken: this.config.botToken });
+    }, 30_000);
+  }
+
+  private async onMessage(msg: BotMessage): Promise<void> {
+    // Drop old/offline messages — prevent storm on reconnect
+    if (msg.timestamp < this.startedAt) return;
+
+    console.log(`[gateway] Message from=${msg.from_uid} type=${msg.payload.type} channel=${msg.channel_id ?? "DM"}`);
+
+    // Skip own messages
+    if (msg.from_uid === this.robotId) return;
+
+    // Only handle text messages for now
+    if (msg.payload.type !== MessageType.Text) {
+      console.log(`[gateway] Skipping non-text message type=${msg.payload.type}`);
+      return;
+    }
+
+    const content = msg.payload.content?.trim();
+    if (!content) return;
+
+    const channelType = msg.channel_type ?? ChannelType.DM;
+    const channelId = msg.channel_id ?? msg.from_uid;
+
+    // Group chat: cache ALL messages as context, only process @mentioned
+    if (channelType === ChannelType.Group) {
+      // Learn member names from message metadata
+      if (msg.payload.mention?.uids && msg.payload.content) {
+        const mentionNames = parseMentions(msg.payload.content);
+        const mentionUids = msg.payload.mention.uids;
+        for (let i = 0; i < Math.min(mentionNames.length, mentionUids.length); i++) {
+          this.groupCtx.learnMember(channelId, mentionUids[i], mentionNames[i]);
+        }
+      }
+
+      // Cache every group message for context
+      this.groupCtx.pushMessage(channelId, msg.from_uid, content, msg.timestamp);
+
+      // Only respond when @mentioned
+      const mentioned = msg.payload.mention?.uids?.includes(this.robotId)
+        || msg.payload.mention?.all;
+      if (!mentioned) return;
+
+      // Refresh member list in background (cached, won't fetch every time)
+      this.groupCtx.refreshMembers(channelId, this.config.apiUrl, this.config.botToken).catch(() => {});
+    }
+
+    // Session key: DM → peer uid, Group → channelId:peerUid
+    const sessionKey = channelType === ChannelType.DM
+      ? msg.from_uid
+      : `${channelId}:${msg.from_uid}`;
+
+    // Prevent concurrent processing for same peer
+    if (this.processing.has(sessionKey)) return;
+    this.processing.add(sessionKey);
+
+    try {
+      console.log(`[gateway] Processing: session=${sessionKey}`);
+      await this.handleMessage(sessionKey, msg, channelId, channelType, content);
+      console.log(`[gateway] Done: session=${sessionKey}`);
+    } finally {
+      this.processing.delete(sessionKey);
+    }
+  }
+
+  private async handleMessage(
+    sessionKey: string,
+    msg: BotMessage,
+    channelId: string,
+    channelType: ChannelType,
+    content: string,
+  ): Promise<void> {
+    // Send typing indicator
+    sendTyping({
+      apiUrl: this.config.apiUrl,
+      botToken: this.config.botToken,
+      channelId,
+      channelType,
+    });
+
+    // Strip @mention from content if group
+    let cleanContent = content;
+    if (channelType === ChannelType.Group) {
+      cleanContent = content.replace(new RegExp(`@${this.robotId}\\s*`, "g"), "").trim();
+      if (!cleanContent) cleanContent = content; // fallback if only @mention
+    }
+
+    // Load/create session, append user message
+    const session = this.sessions.getOrCreate(sessionKey, channelId, channelType);
+    this.sessions.appendUser(session, cleanContent);
+
+    // Build prompt with history + group context
+    const groupContext = channelType === ChannelType.Group
+      ? this.groupCtx.buildContext(channelId)
+      : "";
+    const historyPrefix = this.sessions.buildHistoryPrefix(session);
+    const prompt = groupContext + historyPrefix + cleanContent;
+
+    // Call Claude Agent SDK with streaming output
+    console.log(`[gateway] Calling Claude SDK, prompt length=${prompt.length}`);
+    const reply = await this.queryAgentStreaming(prompt, channelId, channelType);
+    console.log(`[gateway] Done, reply length=${reply.length}`);
+
+    // Save assistant reply
+    this.sessions.appendAssistant(session, reply);
+    this.sessions.save(session);
+  }
+
+  /**
+   * Query Claude Agent SDK with streaming output to DMWork.
+   *
+   * Uses DMWork's stream API: start → send chunks → end.
+   * The user sees text appearing incrementally in real-time,
+   * instead of waiting for the full response.
+   */
+  private async queryAgentStreaming(
+    prompt: string,
+    channelId: string,
+    channelType: ChannelType,
+  ): Promise<string> {
+    const allChunks: string[] = [];
+    let streamNo = "";
+
+    // Periodic typing indicator while processing (before stream starts)
+    const typingTimer = setInterval(() => {
+      sendTyping({
+        apiUrl: this.config.apiUrl,
+        botToken: this.config.botToken,
+        channelId,
+        channelType,
+      });
+    }, 5000);
+
+    // Stream sends full accumulated text each time (not incremental)
+    const FLUSH_INTERVAL_MS = 800;
+    let lastFlushedLength = 0;
+    let flushTimer: ReturnType<typeof setInterval> | null = null;
+
+    const startStreamIfNeeded = async (): Promise<void> => {
+      if (streamNo) return;
+      try {
+        streamNo = await streamStart({
+          apiUrl: this.config.apiUrl,
+          botToken: this.config.botToken,
+          channelId,
+          channelType,
+        });
+      } catch {
+        console.log("[gateway] Stream API unavailable, using fallback sendMessage");
+      }
+    };
+
+    const flushToStream = async (): Promise<void> => {
+      const fullSoFar = allChunks.join("");
+      if (!streamNo || fullSoFar.length === lastFlushedLength) return;
+      lastFlushedLength = fullSoFar.length;
+      try {
+        await streamSend({
+          apiUrl: this.config.apiUrl,
+          botToken: this.config.botToken,
+          streamNo,
+          channelId,
+          channelType,
+          content: fullSoFar,
+        });
+      } catch (err) {
+        console.debug("[gateway] Stream send failed:", err);
+      }
+    };
+
+    try {
+      const sdk = this.config.sdk;
+      const stream = agentQuery({
+        prompt,
+        options: {
+          cwd: this.config.cwd,
+          systemPrompt: sdk.systemPrompt || this.getSystemPrompt(),
+          settingSources: sdk.settingSources,
+          allowedTools: sdk.allowedTools,
+          permissionMode: sdk.permissionMode,
+          ...(sdk.maxTurns ? { maxTurns: sdk.maxTurns } : {}),
+          ...(process.env.CLAUDECODE ? { env: { ...process.env, CLAUDECODE: "" } } : {}),
+          stderr: (data: string) => console.error("[claude-stderr]", data.trim()),
+        },
+      });
+
+      for await (const message of stream) {
+        if (message.type === "assistant") {
+          for (const block of message.message.content) {
+            if ("text" in block && block.text) {
+              allChunks.push(block.text);
+
+              // Start stream on first text chunk
+              await startStreamIfNeeded();
+
+              // Start periodic flushing
+              if (!flushTimer && streamNo) {
+                flushTimer = setInterval(() => { flushToStream(); }, FLUSH_INTERVAL_MS);
+              }
+            }
+          }
+        }
+        if (message.type === "result") {
+          if (message.subtype === "success" && allChunks.length === 0 && message.result) {
+            allChunks.push(message.result);
+          }
+          if (message.subtype !== "success") {
+            const errMsg = message.errors?.join(", ") || "Processing failed";
+            allChunks.length = 0;
+            allChunks.push(`[Error] ${errMsg}`);
+          }
+        }
+      }
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : "Agent query failed";
+      allChunks.length = 0;
+      allChunks.push(`[Error] ${errMsg}`);
+    } finally {
+      if (flushTimer) clearInterval(flushTimer);
+      clearInterval(typingTimer);
+    }
+
+    // Final flush + end stream
+    const fullText = allChunks.join("") || "[No response]";
+
+    if (streamNo) {
+      // Final flush with complete text
+      await flushToStream();
+      await streamEnd({
+        apiUrl: this.config.apiUrl,
+        botToken: this.config.botToken,
+        streamNo,
+        channelId,
+        channelType,
+      }).catch(() => {});
+    } else {
+      // Stream API unavailable — fall back to regular message(s)
+      await this.sendFallback(channelId, channelType, fullText);
+    }
+
+    return fullText;
+  }
+
+  private getSystemPrompt(): string {
+    return `You are an AI assistant connected to DMWork messaging.
+You receive messages from users via instant messaging and reply conversationally.
+
+Guidelines:
+- Be concise. This is chat, not email.
+- Use short messages and natural language.
+- If you're unsure about something, ask.
+- You can use tools to help answer questions when needed.
+
+Today: ${new Date().toISOString().slice(0, 10)}`;
+  }
+
+  /** Fallback: send as regular message(s) when streaming is unavailable */
+  private async sendFallback(
+    channelId: string,
+    channelType: ChannelType,
+    text: string,
+  ): Promise<void> {
+    const MAX_LEN = 3500;
+    const parts = splitMessage(text, MAX_LEN);
+
+    const mentionUids = channelType === ChannelType.Group
+      ? this.groupCtx.resolveMentions(channelId, text)
+      : undefined;
+
+    for (const part of parts) {
+      await sendMessage({
+        apiUrl: this.config.apiUrl,
+        botToken: this.config.botToken,
+        channelId,
+        channelType,
+        content: part,
+        mentionUids,
+      });
+    }
+  }
+}
+
+/** Split long text into chunks at natural boundaries */
+function splitMessage(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+
+  const parts: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLen) {
+    // Try to split at paragraph, then sentence, then word boundary
+    let splitAt = remaining.lastIndexOf("\n\n", maxLen);
+    if (splitAt < maxLen * 0.3) splitAt = remaining.lastIndexOf("\n", maxLen);
+    if (splitAt < maxLen * 0.3) splitAt = remaining.lastIndexOf(" ", maxLen);
+    if (splitAt < maxLen * 0.3) splitAt = maxLen;
+
+    parts.push(remaining.slice(0, splitAt).trimEnd());
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+
+  if (remaining) parts.push(remaining);
+  return parts;
+}

--- a/claude-code-dmwork-ws/src/group-context.ts
+++ b/claude-code-dmwork-ws/src/group-context.ts
@@ -1,0 +1,115 @@
+/**
+ * Group chat context — caches recent messages and member mappings.
+ * Matches openclaw adapter's group history + member resolution behavior.
+ */
+
+import { getGroupMembers } from "./dmwork/api.js";
+import { parseMentions } from "./dmwork/mentions.js";
+
+export interface GroupMessage {
+  fromUid: string;
+  fromName: string;
+  content: string;
+  timestamp: number;
+}
+
+interface GroupCache {
+  messages: GroupMessage[];
+  /** uid → displayName */
+  uidToName: Map<string, string>;
+  /** displayName (lowercase) → uid */
+  nameToUid: Map<string, string>;
+  /** Last time members were fetched */
+  membersFetchedAt: number;
+}
+
+const GROUP_HISTORY_LIMIT = 20;
+const MEMBERS_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const MEMBERS_EMPTY_RETRY_MS = 30 * 1000; // 30s if fetch returned empty
+
+export class GroupContext {
+  private groups = new Map<string, GroupCache>();
+
+  private getOrCreate(channelId: string): GroupCache {
+    let g = this.groups.get(channelId);
+    if (!g) {
+      g = {
+        messages: [],
+        uidToName: new Map(),
+        nameToUid: new Map(),
+        membersFetchedAt: 0,
+      };
+      this.groups.set(channelId, g);
+    }
+    return g;
+  }
+
+  /** Record a message in group history (called for ALL group messages, not just @bot) */
+  pushMessage(channelId: string, fromUid: string, content: string, timestamp: number): void {
+    const g = this.getOrCreate(channelId);
+    const fromName = g.uidToName.get(fromUid) || fromUid;
+    g.messages.push({ fromUid, fromName, content, timestamp });
+    // Sliding window
+    if (g.messages.length > GROUP_HISTORY_LIMIT * 2) {
+      g.messages = g.messages.slice(-GROUP_HISTORY_LIMIT);
+    }
+  }
+
+  /** Learn uid ↔ name mapping from message metadata */
+  learnMember(channelId: string, uid: string, name: string): void {
+    if (!name || !uid) return;
+    const g = this.getOrCreate(channelId);
+    g.uidToName.set(uid, name);
+    g.nameToUid.set(name.toLowerCase(), uid);
+  }
+
+  /** Fetch and cache group members from API */
+  async refreshMembers(
+    channelId: string,
+    apiUrl: string,
+    botToken: string,
+  ): Promise<void> {
+    const g = this.getOrCreate(channelId);
+    const now = Date.now();
+    const ttl = g.uidToName.size === 0 ? MEMBERS_EMPTY_RETRY_MS : MEMBERS_CACHE_TTL_MS;
+    if (now - g.membersFetchedAt < ttl) return;
+
+    g.membersFetchedAt = now;
+    const members = await getGroupMembers({ apiUrl, botToken, groupNo: channelId });
+    for (const m of members) {
+      if (m.uid && m.name) {
+        g.uidToName.set(m.uid, m.name);
+        g.nameToUid.set(m.name.toLowerCase(), m.uid);
+      }
+    }
+  }
+
+  /** Get display name for a uid */
+  getName(channelId: string, uid: string): string {
+    return this.getOrCreate(channelId).uidToName.get(uid) || uid;
+  }
+
+  /** Build group context string for prompt injection */
+  buildContext(channelId: string, limit = GROUP_HISTORY_LIMIT): string {
+    const g = this.groups.get(channelId);
+    if (!g || g.messages.length === 0) return "";
+
+    const recent = g.messages.slice(-limit);
+    const lines = recent.map((m) => `${m.fromName}：${m.content.slice(0, 500)}`);
+    return "[Group chat context (recent messages)]\n" + lines.join("\n") + "\n\n";
+  }
+
+  /** Resolve @mentions in AI reply text → real uids for DMWork push notification */
+  resolveMentions(channelId: string, text: string): string[] {
+    const g = this.groups.get(channelId);
+    if (!g) return [];
+
+    const names = parseMentions(text);
+    const uids: string[] = [];
+    for (const name of names) {
+      const uid = g.nameToUid.get(name.toLowerCase());
+      if (uid) uids.push(uid);
+    }
+    return uids;
+  }
+}

--- a/claude-code-dmwork-ws/src/index.ts
+++ b/claude-code-dmwork-ws/src/index.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import { loadConfig } from "./config.js";
+import { Gateway } from "./gateway.js";
+
+const config = loadConfig();
+const gateway = new Gateway(config);
+
+// Graceful shutdown
+process.on("SIGINT", () => {
+  gateway.stop();
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  gateway.stop();
+  process.exit(0);
+});
+
+gateway.start().catch((err) => {
+  console.error("[fatal]", err);
+  process.exit(1);
+});

--- a/claude-code-dmwork-ws/src/session-store.ts
+++ b/claude-code-dmwork-ws/src/session-store.ts
@@ -1,0 +1,82 @@
+import fs from "fs";
+import path from "path";
+
+export interface MsgRecord {
+  role: "user" | "assistant";
+  content: string;
+  timestamp: number;
+}
+
+export interface Session {
+  peerId: string;
+  channelId: string;
+  channelType: number;
+  messages: MsgRecord[];
+  updatedAt: number;
+}
+
+const MAX_HISTORY = 40;
+
+export class SessionStore {
+  private dir: string;
+
+  constructor(dataDir: string) {
+    this.dir = path.join(dataDir, "sessions");
+    fs.mkdirSync(this.dir, { recursive: true });
+  }
+
+  /** Session key: for DM it's the peer uid, for group it's channel_id */
+  private sessionPath(key: string): string {
+    // Sanitize key for filesystem
+    const safe = key.replace(/[^a-zA-Z0-9_\-]/g, "_");
+    return path.join(this.dir, `${safe}.json`);
+  }
+
+  get(key: string): Session | null {
+    try {
+      return JSON.parse(fs.readFileSync(this.sessionPath(key), "utf-8"));
+    } catch {
+      return null;
+    }
+  }
+
+  save(session: Session): void {
+    session.messages = session.messages.slice(-MAX_HISTORY);
+    session.updatedAt = Date.now();
+    fs.writeFileSync(this.sessionPath(session.peerId), JSON.stringify(session, null, 2), "utf-8");
+  }
+
+  getOrCreate(peerId: string, channelId: string, channelType: number): Session {
+    const existing = this.get(peerId);
+    if (existing) return existing;
+    return {
+      peerId,
+      channelId,
+      channelType,
+      messages: [],
+      updatedAt: Date.now(),
+    };
+  }
+
+  appendUser(session: Session, content: string): void {
+    session.messages.push({ role: "user", content, timestamp: Date.now() });
+  }
+
+  appendAssistant(session: Session, content: string): void {
+    session.messages.push({ role: "assistant", content: content.trim(), timestamp: Date.now() });
+  }
+
+  /** Build history prefix for prompt (inject recent history as context) */
+  buildHistoryPrefix(session: Session, maxRecent = 20): string {
+    const history = session.messages.slice(0, -1).slice(-maxRecent);
+    if (history.length === 0) return "";
+    const lines = history.map(
+      (m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.content.slice(0, 800)}`
+    );
+    return (
+      "[Conversation history]\n" +
+      lines.join("\n\n") +
+      "\n\n[Current message]\n"
+    );
+  }
+}

--- a/claude-code-dmwork-ws/tests/gateway-utils.test.ts
+++ b/claude-code-dmwork-ws/tests/gateway-utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+
+// splitMessage is not exported, so we re-implement the same logic for testing.
+// This also serves as a specification test for the splitting behavior.
+function splitMessage(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+
+  const parts: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLen) {
+    let splitAt = remaining.lastIndexOf("\n\n", maxLen);
+    if (splitAt < maxLen * 0.3) splitAt = remaining.lastIndexOf("\n", maxLen);
+    if (splitAt < maxLen * 0.3) splitAt = remaining.lastIndexOf(" ", maxLen);
+    if (splitAt < maxLen * 0.3) splitAt = maxLen;
+
+    parts.push(remaining.slice(0, splitAt).trimEnd());
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+
+  if (remaining) parts.push(remaining);
+  return parts;
+}
+
+describe("splitMessage", () => {
+  it("returns single part for short messages", () => {
+    expect(splitMessage("hello", 100)).toEqual(["hello"]);
+  });
+
+  it("splits at paragraph boundary", () => {
+    const text = "A".repeat(50) + "\n\n" + "B".repeat(50);
+    const parts = splitMessage(text, 60);
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toBe("A".repeat(50));
+    expect(parts[1]).toBe("B".repeat(50));
+  });
+
+  it("splits at newline when no paragraph boundary", () => {
+    const text = "A".repeat(50) + "\n" + "B".repeat(50);
+    const parts = splitMessage(text, 60);
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toBe("A".repeat(50));
+    expect(parts[1]).toBe("B".repeat(50));
+  });
+
+  it("splits at space when no newline", () => {
+    const text = "A".repeat(50) + " " + "B".repeat(50);
+    const parts = splitMessage(text, 60);
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toBe("A".repeat(50));
+    expect(parts[1]).toBe("B".repeat(50));
+  });
+
+  it("hard splits when no natural boundary", () => {
+    const text = "A".repeat(200);
+    const parts = splitMessage(text, 100);
+    expect(parts).toHaveLength(2);
+    expect(parts[0].length).toBe(100);
+    expect(parts[1].length).toBe(100);
+  });
+
+  it("handles multiple splits", () => {
+    const text = Array(5).fill("X".repeat(80)).join("\n\n");
+    const parts = splitMessage(text, 100);
+    expect(parts.length).toBeGreaterThan(1);
+    for (const part of parts) {
+      expect(part.length).toBeLessThanOrEqual(100);
+    }
+  });
+});

--- a/claude-code-dmwork-ws/tests/group-context.test.ts
+++ b/claude-code-dmwork-ws/tests/group-context.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { GroupContext } from "../src/group-context.js";
+
+describe("GroupContext", () => {
+  it("caches messages and builds context", () => {
+    const ctx = new GroupContext();
+    ctx.pushMessage("g1", "u1", "hello everyone", 1000);
+    ctx.pushMessage("g1", "u2", "hi there", 1001);
+
+    const context = ctx.buildContext("g1");
+    expect(context).toContain("[Group chat context");
+    expect(context).toContain("hello everyone");
+    expect(context).toContain("hi there");
+  });
+
+  it("returns empty context for unknown group", () => {
+    const ctx = new GroupContext();
+    expect(ctx.buildContext("unknown")).toBe("");
+  });
+
+  it("learns and resolves member names", () => {
+    const ctx = new GroupContext();
+    ctx.learnMember("g1", "uid123", "Alice");
+
+    expect(ctx.getName("g1", "uid123")).toBe("Alice");
+  });
+
+  it("uses display names in context after learning", () => {
+    const ctx = new GroupContext();
+    ctx.learnMember("g1", "u1", "Alice");
+    ctx.pushMessage("g1", "u1", "hello", 1000);
+
+    const context = ctx.buildContext("g1");
+    expect(context).toContain("Alice");
+  });
+
+  it("resolves @mentions in text to uids", () => {
+    const ctx = new GroupContext();
+    ctx.learnMember("g1", "uid1", "Alice");
+    ctx.learnMember("g1", "uid2", "Bob");
+
+    const uids = ctx.resolveMentions("g1", "Hey @Alice and @Bob");
+    expect(uids).toContain("uid1");
+    expect(uids).toContain("uid2");
+  });
+
+  it("is case-insensitive for mention resolution", () => {
+    const ctx = new GroupContext();
+    ctx.learnMember("g1", "uid1", "Alice");
+
+    const uids = ctx.resolveMentions("g1", "@alice do this");
+    expect(uids).toEqual(["uid1"]);
+  });
+
+  it("enforces sliding window on messages", () => {
+    const ctx = new GroupContext();
+    for (let i = 0; i < 50; i++) {
+      ctx.pushMessage("g1", "u1", `msg-${i}`, 1000 + i);
+    }
+
+    const context = ctx.buildContext("g1", 20);
+    // Should only include recent messages
+    expect(context).toContain("msg-49");
+    expect(context).not.toContain("msg-0");
+  });
+});

--- a/claude-code-dmwork-ws/tests/mentions.test.ts
+++ b/claude-code-dmwork-ws/tests/mentions.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { parseMentions, extractMentionMatches } from "../src/dmwork/mentions.js";
+
+describe("parseMentions", () => {
+  it("extracts single mention", () => {
+    expect(parseMentions("hello @alice")).toEqual(["alice"]);
+  });
+
+  it("extracts multiple mentions", () => {
+    expect(parseMentions("@alice @bob please review")).toEqual(["alice", "bob"]);
+  });
+
+  it("handles Chinese names", () => {
+    expect(parseMentions("@小明 你好")).toEqual(["小明"]);
+  });
+
+  it("handles names with dots and hyphens", () => {
+    expect(parseMentions("@user.name @another-user")).toEqual(["user.name", "another-user"]);
+  });
+
+  it("returns empty array when no mentions", () => {
+    expect(parseMentions("no mentions here")).toEqual([]);
+  });
+
+  it("handles empty string", () => {
+    expect(parseMentions("")).toEqual([]);
+  });
+});
+
+describe("extractMentionMatches", () => {
+  it("returns raw matches with @ prefix", () => {
+    expect(extractMentionMatches("@alice @bob")).toEqual(["@alice", "@bob"]);
+  });
+
+  it("returns empty array when no matches", () => {
+    expect(extractMentionMatches("plain text")).toEqual([]);
+  });
+});

--- a/claude-code-dmwork-ws/tests/session-store.test.ts
+++ b/claude-code-dmwork-ws/tests/session-store.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SessionStore } from "../src/session-store.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+describe("SessionStore", () => {
+  let store: SessionStore;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-test-"));
+    store = new SessionStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates new session", () => {
+    const session = store.getOrCreate("user1", "channel1", 1);
+    expect(session.peerId).toBe("user1");
+    expect(session.channelId).toBe("channel1");
+    expect(session.messages).toEqual([]);
+  });
+
+  it("appends and persists messages", () => {
+    const session = store.getOrCreate("user1", "channel1", 1);
+    store.appendUser(session, "hello");
+    store.appendAssistant(session, "hi there");
+    store.save(session);
+
+    const loaded = store.get("user1");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.messages).toHaveLength(2);
+    expect(loaded!.messages[0].role).toBe("user");
+    expect(loaded!.messages[0].content).toBe("hello");
+    expect(loaded!.messages[1].role).toBe("assistant");
+    expect(loaded!.messages[1].content).toBe("hi there");
+  });
+
+  it("returns existing session on getOrCreate", () => {
+    const session = store.getOrCreate("user1", "channel1", 1);
+    store.appendUser(session, "first");
+    store.save(session);
+
+    const again = store.getOrCreate("user1", "channel1", 1);
+    expect(again.messages).toHaveLength(1);
+  });
+
+  it("trims history beyond max limit", () => {
+    const session = store.getOrCreate("user1", "channel1", 1);
+    for (let i = 0; i < 50; i++) {
+      store.appendUser(session, `msg-${i}`);
+    }
+    store.save(session);
+
+    const loaded = store.get("user1");
+    expect(loaded!.messages.length).toBeLessThanOrEqual(40);
+    // Should keep the most recent messages
+    expect(loaded!.messages[loaded!.messages.length - 1].content).toBe("msg-49");
+  });
+
+  it("returns null for nonexistent session", () => {
+    expect(store.get("nonexistent")).toBeNull();
+  });
+
+  describe("buildHistoryPrefix", () => {
+    it("returns empty string for no history", () => {
+      const session = store.getOrCreate("user1", "channel1", 1);
+      store.appendUser(session, "current");
+      expect(store.buildHistoryPrefix(session)).toBe("");
+    });
+
+    it("builds history excluding last message", () => {
+      const session = store.getOrCreate("user1", "channel1", 1);
+      store.appendUser(session, "first");
+      store.appendAssistant(session, "reply");
+      store.appendUser(session, "current");
+
+      const prefix = store.buildHistoryPrefix(session);
+      expect(prefix).toContain("[Conversation history]");
+      expect(prefix).toContain("User: first");
+      expect(prefix).toContain("Assistant: reply");
+      expect(prefix).toContain("[Current message]");
+      expect(prefix).not.toContain("current");
+    });
+  });
+});

--- a/claude-code-dmwork-ws/tsconfig.json
+++ b/claude-code-dmwork-ws/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/claude-code-dmwork-ws/vitest.config.ts
+++ b/claude-code-dmwork-ws/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## What

Add a new WebSocket-based gateway adapter (`claude-code-dmwork-ws`) that connects Claude Agent SDK to DMWork messaging via the WuKongIM binary protocol.

## Why

The existing `claude-code-dmwork` adapter uses REST polling with higher latency and no group chat support. This gateway provides real-time WebSocket communication with full DM + group chat capabilities.

## How

- WuKongIM binary protocol with DH key exchange + AES-CBC encryption
- Streaming replies via DMWork stream API (with automatic fallback to regular messages)
- Session persistence with sliding window history (40 messages)
- Group chat context caching and @mention-based trigger
- Auto-reconnect with token refresh on connection rejection
- Configurable SDK tools, permissions, and system prompt
- Security documentation for settings loading and tool restrictions

## Testing

- [x] 28 unit tests (mentions, session store, group context, message splitting)
- [x] TypeScript strict mode — zero errors
- [x] E2E verified: bot registration → WebSocket connect → DM round-trip → reply delivery
- [x] Stream API fallback verified (graceful degradation to sendMessage)

AI tools used: Claude Code (code generation, testing, documentation)