### PR TITLE
fix: align plugin id in openclaw.plugin.json with index.ts export

### DIFF
--- a/openclaw-channel-dmwork/openclaw.plugin.json
+++ b/openclaw-channel-dmwork/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "openclaw-channel-dmwork",
+  "id": "dmwork",
   "channels": [
     "dmwork"
   ],


### PR DESCRIPTION
Fixes #105

`openclaw.plugin.json` had `id: "openclaw-channel-dmwork"` while `index.ts` and `channel.ts` both export `id: "dmwork"`. This mismatch causes the plugin to fail to load.

Changed `openclaw.plugin.json` id to `"dmwork"` to match the runtime exports.