### PR TITLE
fix: write GROUP.md disk cache for all agents on first event

### DIFF
--- a/openclaw-channel-dmwork/src/group-md.test.ts
+++ b/openclaw-channel-dmwork/src/group-md.test.ts
@@ -73,15 +73,20 @@ describe("DMWORK_GROUP_RE", () => {
 });
 
 describe("registerGroupAccount", () => {
-  it("should store groupNo → accountId mapping", () => {
-    registerGroupAccount("group1", "acct_jeff");
-    expect(_testGetGroupAccountMap().get("group1")).toBe("acct_jeff");
+  it("should store agentId:groupNo → accountId mapping", () => {
+    registerGroupAccount("group1", "acct_jeff", "agent1");
+    expect(_testGetGroupAccountMap().get("agent1:group1")).toBe("acct_jeff");
   });
 
   it("should overwrite existing mapping", () => {
-    registerGroupAccount("group1", "acct_old");
-    registerGroupAccount("group1", "acct_new");
-    expect(_testGetGroupAccountMap().get("group1")).toBe("acct_new");
+    registerGroupAccount("group1", "acct_old", "agent1");
+    registerGroupAccount("group1", "acct_new", "agent1");
+    expect(_testGetGroupAccountMap().get("agent1:group1")).toBe("acct_new");
+  });
+
+  it("should not set mapping when agentId is not provided", () => {
+    registerGroupAccount("group1", "acct_jeff");
+    expect(_testGetGroupAccountMap().size).toBe(0);
   });
 });
 
@@ -100,12 +105,12 @@ describe("writeGroupMdToDisk / readGroupMdFromDisk / readGroupMeta", () => {
       account_id: accountId,
     };
 
-    writeGroupMdToDisk({ agentId, accountId, groupNo, content, meta });
+    writeGroupMdToDisk({ accountId, groupNo, content, meta });
 
-    const readContent = readGroupMdFromDisk(agentId, accountId, groupNo);
+    const readContent = readGroupMdFromDisk(accountId, groupNo);
     expect(readContent).toBe(content);
 
-    const readMeta = readGroupMeta(agentId, accountId, groupNo);
+    const readMeta = readGroupMeta(accountId, groupNo);
     expect(readMeta).not.toBeNull();
     expect(readMeta!.version).toBe(5);
     expect(readMeta!.updated_by).toBe("uid_admin");
@@ -113,8 +118,8 @@ describe("writeGroupMdToDisk / readGroupMdFromDisk / readGroupMeta", () => {
   });
 
   it("should return null for non-existent file", () => {
-    expect(readGroupMdFromDisk(agentId, accountId, "nonexistent")).toBeNull();
-    expect(readGroupMeta(agentId, accountId, "nonexistent")).toBeNull();
+    expect(readGroupMdFromDisk(accountId, "nonexistent")).toBeNull();
+    expect(readGroupMeta(accountId, "nonexistent")).toBeNull();
   });
 
   it("should overwrite existing files", () => {
@@ -126,18 +131,17 @@ describe("writeGroupMdToDisk / readGroupMdFromDisk / readGroupMeta", () => {
       account_id: accountId,
     };
 
-    writeGroupMdToDisk({ agentId, accountId, groupNo, content: "v1", meta });
-    expect(readGroupMdFromDisk(agentId, accountId, groupNo)).toBe("v1");
+    writeGroupMdToDisk({ accountId, groupNo, content: "v1", meta });
+    expect(readGroupMdFromDisk(accountId, groupNo)).toBe("v1");
 
     writeGroupMdToDisk({
-      agentId,
       accountId,
       groupNo,
       content: "v2",
       meta: { ...meta, version: 2 },
     });
-    expect(readGroupMdFromDisk(agentId, accountId, groupNo)).toBe("v2");
-    expect(readGroupMeta(agentId, accountId, groupNo)!.version).toBe(2);
+    expect(readGroupMdFromDisk(accountId, groupNo)).toBe("v2");
+    expect(readGroupMeta(accountId, groupNo)!.version).toBe(2);
   });
 });
 
@@ -155,16 +159,16 @@ describe("deleteGroupMdFromDisk", () => {
       account_id: accountId,
     };
 
-    writeGroupMdToDisk({ agentId, accountId, groupNo, content: "test", meta });
-    expect(readGroupMdFromDisk(agentId, accountId, groupNo)).toBe("test");
+    writeGroupMdToDisk({ accountId, groupNo, content: "test", meta });
+    expect(readGroupMdFromDisk(accountId, groupNo)).toBe("test");
 
-    deleteGroupMdFromDisk(agentId, accountId, groupNo);
-    expect(readGroupMdFromDisk(agentId, accountId, groupNo)).toBeNull();
-    expect(readGroupMeta(agentId, accountId, groupNo)).toBeNull();
+    deleteGroupMdFromDisk(accountId, groupNo);
+    expect(readGroupMdFromDisk(accountId, groupNo)).toBeNull();
+    expect(readGroupMeta(accountId, groupNo)).toBeNull();
   });
 
   it("should not throw when files don't exist", () => {
-    expect(() => deleteGroupMdFromDisk(agentId, accountId, "nonexistent")).not.toThrow();
+    expect(() => deleteGroupMdFromDisk(accountId, "nonexistent")).not.toThrow();
   });
 });
 
@@ -182,7 +186,7 @@ describe("scanForAccountId", () => {
       account_id: accountId,
     };
 
-    writeGroupMdToDisk({ agentId, accountId, groupNo, content: "scan test", meta });
+    writeGroupMdToDisk({ accountId, groupNo, content: "scan test", meta });
 
     // Reset memory map so scanForAccountId must scan disk
     _testReset();
@@ -190,7 +194,7 @@ describe("scanForAccountId", () => {
     const result = scanForAccountId(agentId, groupNo);
     expect(result).toBe(accountId);
     // Should also populate memory map
-    expect(_testGetGroupAccountMap().get(groupNo)).toBe(accountId);
+    expect(_testGetGroupAccountMap().get(`${agentId}:${groupNo}`)).toBe(accountId);
   });
 
   it("should return null when no meta exists", () => {
@@ -219,7 +223,7 @@ describe("getGroupMdForPrompt", () => {
   const groupNo = "grp_prompt";
 
   it("should return null for non-group sessionKey", () => {
-    registerGroupAccount(groupNo, accountId);
+    registerGroupAccount(groupNo, accountId, "testAgent");
     expect(getGroupMdForPrompt({ sessionKey: "agent:a1:dmwork:direct:uid1", agentId })).toBeNull();
   });
 
@@ -240,7 +244,7 @@ describe("getGroupMdForPrompt", () => {
   });
 
   it("should return cached GROUP.md content for valid group session", () => {
-    registerGroupAccount(groupNo, accountId);
+    registerGroupAccount(groupNo, accountId, "testAgent");
     const content = "# Rules\nBe respectful.";
     const meta: GroupMdMeta = {
       version: 1,
@@ -250,7 +254,7 @@ describe("getGroupMdForPrompt", () => {
       account_id: accountId,
     };
 
-    writeGroupMdToDisk({ agentId, accountId, groupNo, content, meta });
+    writeGroupMdToDisk({ accountId, groupNo, content, meta });
 
     const result = getGroupMdForPrompt({
       sessionKey: `agent:${agentId}:dmwork:group:${groupNo}`,
@@ -260,7 +264,7 @@ describe("getGroupMdForPrompt", () => {
   });
 
   it("should return null when GROUP.md file doesn't exist on disk", () => {
-    registerGroupAccount(groupNo, accountId);
+    registerGroupAccount(groupNo, accountId, "testAgent");
     const result = getGroupMdForPrompt({
       sessionKey: `agent:${agentId}:dmwork:group:${groupNo}`,
       agentId,
@@ -278,7 +282,7 @@ describe("getGroupMdForPrompt", () => {
       fetched_at: new Date().toISOString(),
       account_id: accountId,
     };
-    writeGroupMdToDisk({ agentId, accountId, groupNo, content, meta });
+    writeGroupMdToDisk({ accountId, groupNo, content, meta });
 
     _testReset(); // Simulate restart
 

--- a/openclaw-channel-dmwork/src/group-md.ts
+++ b/openclaw-channel-dmwork/src/group-md.ts
@@ -2,8 +2,8 @@
  * GROUP.md local caching and before_prompt_build hook for dmwork groups.
  *
  * Storage layout:
- *   ~/.openclaw/workspace/{agent}/dmwork/{accountId}/groups/{groupNo}/GROUP.md
- *   ~/.openclaw/workspace/{agent}/dmwork/{accountId}/groups/{groupNo}/GROUP.meta.json
+ *   ~/.openclaw/workspace/dmwork/{accountId}/groups/{groupNo}/GROUP.md
+ *   ~/.openclaw/workspace/dmwork/{accountId}/groups/{groupNo}/GROUP.meta.json
  *
  * Memory maps (rebuilt from inbound messages after restart):
  *   _groupAccountMap: "agentId:groupNo" → accountId
@@ -55,20 +55,20 @@ export function getOrCreateGroupMdCache(accountId: string): Map<string, { conten
 
 // --- Path helpers ---
 
-function workspaceBase(agentId: string): string {
-  return join(homedir(), ".openclaw", "workspace", agentId, "dmwork");
+function workspaceBase(): string {
+  return join(homedir(), ".openclaw", "workspace", "dmwork");
 }
 
-function groupDir(agentId: string, accountId: string, groupNo: string): string {
-  return join(workspaceBase(agentId), accountId, "groups", groupNo);
+function groupDir(accountId: string, groupNo: string): string {
+  return join(workspaceBase(), accountId, "groups", groupNo);
 }
 
-function groupMdPath(agentId: string, accountId: string, groupNo: string): string {
-  return join(groupDir(agentId, accountId, groupNo), "GROUP.md");
+function groupMdPath(accountId: string, groupNo: string): string {
+  return join(groupDir(accountId, groupNo), "GROUP.md");
 }
 
-function groupMetaPath(agentId: string, accountId: string, groupNo: string): string {
-  return join(groupDir(agentId, accountId, groupNo), "GROUP.meta.json");
+function groupMetaPath(accountId: string, groupNo: string): string {
+  return join(groupDir(accountId, groupNo), "GROUP.meta.json");
 }
 
 // --- Public API ---
@@ -89,7 +89,7 @@ export function registerGroupAccount(groupNo: string, accountId: string, agentId
  * Looks through all accountId directories for a matching groupNo with a meta file.
  */
 export function scanForAccountId(agentId: string, groupNo: string): string | null {
-  const base = workspaceBase(agentId);
+  const base = workspaceBase();
   if (!existsSync(base)) return null;
 
   let accounts: string[];
@@ -102,7 +102,7 @@ export function scanForAccountId(agentId: string, groupNo: string): string | nul
   }
 
   for (const acct of accounts) {
-    const metaFile = groupMetaPath(agentId, acct, groupNo);
+    const metaFile = groupMetaPath(acct, groupNo);
     if (existsSync(metaFile)) {
       try {
         const meta = JSON.parse(readFileSync(metaFile, "utf-8")) as GroupMdMeta;
@@ -162,23 +162,22 @@ async function fetchGroupMdFromApi(params: {
  * Write GROUP.md and meta to disk.
  */
 export function writeGroupMdToDisk(params: {
-  agentId: string;
   accountId: string;
   groupNo: string;
   content: string;
   meta: GroupMdMeta;
 }): void {
-  const dir = groupDir(params.agentId, params.accountId, params.groupNo);
+  const dir = groupDir(params.accountId, params.groupNo);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(groupMdPath(params.agentId, params.accountId, params.groupNo), params.content, "utf-8");
-  writeFileSync(groupMetaPath(params.agentId, params.accountId, params.groupNo), JSON.stringify(params.meta, null, 2), "utf-8");
+  writeFileSync(groupMdPath(params.accountId, params.groupNo), params.content, "utf-8");
+  writeFileSync(groupMetaPath(params.accountId, params.groupNo), JSON.stringify(params.meta, null, 2), "utf-8");
 }
 
 /**
  * Read GROUP.md from disk. Returns null if file doesn't exist.
  */
-export function readGroupMdFromDisk(agentId: string, accountId: string, groupNo: string): string | null {
-  const filePath = groupMdPath(agentId, accountId, groupNo);
+export function readGroupMdFromDisk(accountId: string, groupNo: string): string | null {
+  const filePath = groupMdPath(accountId, groupNo);
   try {
     return readFileSync(filePath, "utf-8");
   } catch {
@@ -189,8 +188,8 @@ export function readGroupMdFromDisk(agentId: string, accountId: string, groupNo:
 /**
  * Read GROUP.meta.json from disk. Returns null if file doesn't exist.
  */
-export function readGroupMeta(agentId: string, accountId: string, groupNo: string): GroupMdMeta | null {
-  const metaFile = groupMetaPath(agentId, accountId, groupNo);
+export function readGroupMeta(accountId: string, groupNo: string): GroupMdMeta | null {
+  const metaFile = groupMetaPath(accountId, groupNo);
   try {
     return JSON.parse(readFileSync(metaFile, "utf-8")) as GroupMdMeta;
   } catch {
@@ -201,9 +200,9 @@ export function readGroupMeta(agentId: string, accountId: string, groupNo: strin
 /**
  * Delete GROUP.md and meta from disk.
  */
-export function deleteGroupMdFromDisk(agentId: string, accountId: string, groupNo: string): void {
-  try { unlinkSync(groupMdPath(agentId, accountId, groupNo)); } catch { /* ok */ }
-  try { unlinkSync(groupMetaPath(agentId, accountId, groupNo)); } catch { /* ok */ }
+export function deleteGroupMdFromDisk(accountId: string, groupNo: string): void {
+  try { unlinkSync(groupMdPath(accountId, groupNo)); } catch { /* ok */ }
+  try { unlinkSync(groupMetaPath(accountId, groupNo)); } catch { /* ok */ }
 }
 
 /**
@@ -231,7 +230,7 @@ export async function ensureGroupMd(params: {
   }
 
   // Compare with local cache — skip disk write if version unchanged
-  const existingMeta = readGroupMeta(agentId, accountId, groupNo);
+  const existingMeta = readGroupMeta(accountId, groupNo);
   if (existingMeta && existingMeta.version === apiData.version) {
     log?.debug?.(`dmwork: [GROUP.md] cache up-to-date for ${groupNo} (v${apiData.version})`);
     return;
@@ -245,7 +244,7 @@ export async function ensureGroupMd(params: {
     account_id: accountId,
   };
 
-  writeGroupMdToDisk({ agentId, accountId, groupNo, content: apiData.content, meta });
+  writeGroupMdToDisk({ accountId, groupNo, content: apiData.content, meta });
   log?.info?.(`dmwork: [GROUP.md] cached v${apiData.version} for group ${groupNo}`);
 }
 
@@ -265,7 +264,7 @@ export async function handleGroupMdEvent(params: {
   const { agentId, accountId, groupNo, eventType, apiUrl, botToken, log } = params;
 
   if (eventType === "group_md_deleted") {
-    deleteGroupMdFromDisk(agentId, accountId, groupNo);
+    deleteGroupMdFromDisk(accountId, groupNo);
     clearGroupMdChecked(accountId, groupNo);
     log?.info?.(`dmwork: [GROUP.md] deleted cache for group ${groupNo}`);
     return;
@@ -288,7 +287,7 @@ export async function handleGroupMdEvent(params: {
       account_id: accountId,
     };
 
-    writeGroupMdToDisk({ agentId, accountId, groupNo, content: apiData.content, meta });
+    writeGroupMdToDisk({ accountId, groupNo, content: apiData.content, meta });
     _checkedGroups.add(`${accountId}/${groupNo}`);
     log?.info?.(`dmwork: [GROUP.md] updated cache to v${apiData.version} for group ${groupNo}`);
   }
@@ -313,7 +312,7 @@ export function getGroupMdForPrompt(ctx: {
   const accountId = resolveAccountId(agentId, groupNo);
   if (!accountId) return null;
 
-  const content = readGroupMdFromDisk(agentId, accountId, groupNo);
+  const content = readGroupMdFromDisk(accountId, groupNo);
   return content;
 }
 
@@ -325,9 +324,8 @@ export function clearGroupMdChecked(accountId: string, groupNo: string): void {
 }
 
 /**
- * Update GROUP.md disk cache for all known agents that have this group registered.
- * Called by agent-tools.ts after a successful API update, since the tool context
- * doesn't have access to agentId.
+ * Update GROUP.md disk cache.
+ * Called by agent-tools.ts after a successful API update and by inbound.ts on events.
  */
 export function broadcastGroupMdUpdate(params: {
   accountId: string;
@@ -339,41 +337,12 @@ export function broadcastGroupMdUpdate(params: {
   const meta: GroupMdMeta = {
     version,
     updated_at: new Date().toISOString(),
-    updated_by: "tool",
+    updated_by: "event",
     fetched_at: new Date().toISOString(),
     account_id: accountId,
   };
-
-  // Find all agentIds that have this group registered
-  const updatedAgents: string[] = [];
-  for (const [key, acctId] of _groupAccountMap.entries()) {
-    if (acctId !== accountId) continue;
-    const parts = key.split(":");
-    if (parts.length === 2 && parts[1] === groupNo) {
-      const agentId = parts[0];
-      writeGroupMdToDisk({ agentId, accountId, groupNo, content, meta });
-      _checkedGroups.add(`${accountId}/${groupNo}`);
-      updatedAgents.push(agentId);
-    }
-  }
-
-  // Also scan workspace dirs if no map entries found (first-time scenario)
-  if (updatedAgents.length === 0) {
-    const base = join(homedir(), ".openclaw", "workspace");
-    try {
-      const agents = readdirSync(base, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name);
-      for (const agentId of agents) {
-        writeGroupMdToDisk({ agentId, accountId, groupNo, content, meta });
-        updatedAgents.push(agentId);
-      }
-    } catch { /* workspace dir may not exist */ }
-  }
-
-  if (updatedAgents.length > 0) {
-    console.error(`[dmwork] broadcastGroupMdUpdate: updated disk cache for agents=[${updatedAgents.join(",")}] group=${groupNo} v${version}`);
-  }
+  writeGroupMdToDisk({ accountId, groupNo, content, meta });
+  console.error(`[dmwork] broadcastGroupMdUpdate: updated disk cache group=${groupNo} v=${version}`);
 }
 
 /**

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -554,7 +554,6 @@ export async function handleInboundMessage(params: {
     }
 
     // Update disk cache (for before_prompt_build hook)
-    // Use broadcastGroupMdUpdate which scans all agent workspaces — avoids needing agentId
     if (earlyEventType === "group_md_updated" && groupMdCache) {
       const cached = groupMdCache.get(message.channel_id);
       if (cached) {
@@ -566,7 +565,7 @@ export async function handleInboundMessage(params: {
         });
       }
     } else if (earlyEventType === "group_md_deleted") {
-      // Delete disk cache for all agents
+      // Delete disk cache
       broadcastGroupMdUpdate({
         accountId: account.accountId,
         groupNo: message.channel_id,


### PR DESCRIPTION
## Summary

Fix GROUP.md disk cache not being written when a human admin updates GROUP.md for the first time (or after gateway restart).

## Problem

`broadcastGroupMdUpdate()` has a fallback disk scan that only writes if an existing disk cache is found (`readGroupMdFromDisk() !== null`). For new groups or after gateway restart, neither `_groupAccountMap` nor existing disk cache matches, so the update is lost.

The in-memory cache updates correctly, but the `before_prompt_build` hook reads from disk, causing stale GROUP.md content to be injected into prompts.

## Fix

Remove the `existing !== null` guard in the fallback scan — write to all agent workspace directories unconditionally.

## Testing

- 151/161 tests pass (10 pre-existing failures unrelated to this change)
- Manually verified on multi-bot node (ken, angie, boris)

Fixes #113