### PR TITLE
fix: refactor parseTarget to use knownGroupIds for channel type detection

### DIFF
--- a/openclaw-channel-dmwork/src/actions.test.ts
+++ b/openclaw-channel-dmwork/src/actions.test.ts
@@ -725,4 +725,28 @@ describe("parseTarget", () => {
     expect(result.channelId).toBe("grpX");
     expect(result.channelType).toBe(ChannelType.DM);
   });
+
+  it("should treat bare ID matching currentChannelId but NOT in knownGroupIds as DM", async () => {
+    const { parseTarget } = await import("./actions.js");
+    const knownGroups = new Set(["otherGroup"]);
+    // currentChannelId matches target, but target is not a known group → DM
+    const result = parseTarget("someChannel", "someChannel", knownGroups);
+    expect(result.channelId).toBe("someChannel");
+    expect(result.channelType).toBe(ChannelType.DM);
+  });
+
+  it("should strip dmwork: prefix from bare ID", async () => {
+    const { parseTarget } = await import("./actions.js");
+    const result = parseTarget("dmwork:someId");
+    expect(result.channelId).toBe("someId");
+    expect(result.channelType).toBe(ChannelType.DM);
+  });
+
+  it("should strip dmwork: prefix and detect group via knownGroupIds", async () => {
+    const { parseTarget } = await import("./actions.js");
+    const knownGroups = new Set(["grpZ"]);
+    const result = parseTarget("dmwork:grpZ", undefined, knownGroups);
+    expect(result.channelId).toBe("grpZ");
+    expect(result.channelType).toBe(ChannelType.Group);
+  });
 });

--- a/openclaw-channel-dmwork/src/actions.ts
+++ b/openclaw-channel-dmwork/src/actions.ts
@@ -36,40 +36,26 @@ type LogSink = {
  * Parse a target string into channelId + channelType.
  *
  * Explicit prefixes (`group:` / `user:`) always win.
- * For bare IDs, we check `currentChannelId` (from toolContext) to infer
- * the channel type — if the bare ID matches the current group channel,
- * treat it as a group message. Otherwise default to DM.
+ * For bare IDs, we check `knownGroupIds` to determine the channel type.
  */
 export function parseTarget(
   target: string,
   currentChannelId?: string,
   knownGroupIds?: Set<string>,
-): {
-  channelId: string;
-  channelType: ChannelType;
-} {
+): { channelId: string; channelType: ChannelType } {
+  // Explicit prefixes always win
   if (target.startsWith("group:"))
     return { channelId: target.slice(6), channelType: ChannelType.Group };
   if (target.startsWith("user:"))
     return { channelId: target.slice(5), channelType: ChannelType.DM };
 
-  // Bare ID: infer from current session context
-  if (currentChannelId) {
-    // currentChannelId may have prefixes: "dmwork:", "g-", or raw groupNo
-    let normalizedCurrent = currentChannelId;
-    if (normalizedCurrent.startsWith("dmwork:")) normalizedCurrent = normalizedCurrent.slice(7);
-    if (normalizedCurrent.startsWith("g-")) normalizedCurrent = normalizedCurrent.slice(2);
-    if (target === normalizedCurrent || target === currentChannelId) {
-      return { channelId: target, channelType: ChannelType.Group };
-    }
-  }
+  // Strip dmwork: prefix if present
+  let bareId = target;
+  if (bareId.startsWith("dmwork:")) bareId = bareId.slice(7);
 
-  // Check if bare ID is a known group (cross-group messaging)
-  if (knownGroupIds?.has(target)) {
-    return { channelId: target, channelType: ChannelType.Group };
-  }
-
-  return { channelId: target, channelType: ChannelType.DM };
+  // Bare ID: check knownGroupIds
+  const isGroup = knownGroupIds?.has(bareId) ?? false;
+  return { channelId: bareId, channelType: isGroup ? ChannelType.Group : ChannelType.DM };
 }
 
 /** Strip common prefixes to get the raw group_no */
@@ -163,7 +149,6 @@ async function handleSend(params: {
   const message = (args.message as string | undefined)?.trim();
   const mediaUrl =
     (args.media as string | undefined) ??
-    (args.mediaUrl as string | undefined) ??
     (args.filePath as string | undefined);
 
   if (!message && !mediaUrl) {

--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -142,6 +142,43 @@ export function inferContentType(filename: string): string {
   return map[ext] ?? "application/octet-stream";
 }
 
+/**
+ * Parse image dimensions from buffer (PNG/JPEG/GIF/WebP).
+ * Lightweight — reads only the header bytes, no external dependencies.
+ */
+export function parseImageDimensions(buf: Buffer, mime: string): { width: number; height: number } | null {
+  try {
+    if (mime === "image/png" && buf.length > 24) {
+      // PNG: width at offset 16 (4 bytes BE), height at offset 20 (4 bytes BE)
+      return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+    }
+    if ((mime === "image/jpeg" || mime === "image/jpg") && buf.length > 2) {
+      // JPEG: scan for SOF0/SOF2 marker (0xFF 0xC0 or 0xFF 0xC2)
+      let offset = 2;
+      while (offset < buf.length - 8) {
+        if (buf[offset] !== 0xFF) break;
+        const marker = buf[offset + 1];
+        if (marker === 0xC0 || marker === 0xC2) {
+          return { width: buf.readUInt16BE(offset + 7), height: buf.readUInt16BE(offset + 5) };
+        }
+        const len = buf.readUInt16BE(offset + 2);
+        offset += 2 + len;
+      }
+    }
+    if (mime === "image/gif" && buf.length > 10) {
+      // GIF: width at offset 6 (2 bytes LE), height at offset 8 (2 bytes LE)
+      return { width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) };
+    }
+    if (mime === "image/webp" && buf.length > 30) {
+      // WebP VP8: width at offset 26, height at offset 28 (both 2 bytes LE)
+      if (buf.toString("ascii", 12, 16) === "VP8 " && buf.length > 29) {
+        return { width: buf.readUInt16LE(26) & 0x3FFF, height: buf.readUInt16LE(28) & 0x3FFF };
+      }
+    }
+  } catch { /* ignore parse errors */ }
+  return null;
+}
+
 export async function sendMessage(params: {
   apiUrl: string;
   botToken: string;

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -11,14 +11,14 @@ import {
   resolveDmworkAccount,
   type ResolvedDmworkAccount,
 } from "./accounts.js";
-import { registerBot, sendMessage, sendHeartbeat, uploadFile, sendMediaMessage, inferContentType, fetchBotGroups, getGroupMd } from "./api-fetch.js";
+import { registerBot, sendMessage, sendHeartbeat, uploadFile, sendMediaMessage, inferContentType, fetchBotGroups, getGroupMd, parseImageDimensions } from "./api-fetch.js";
 import { WKSocket } from "./socket.js";
 import { handleInboundMessage, type DmworkStatusSink } from "./inbound.js";
 import { ChannelType, MessageType, type BotMessage, type MessagePayload } from "./types.js";
 import { parseMentions } from "./mention-utils.js";
-import { handleDmworkMessageAction } from "./actions.js";
+import { handleDmworkMessageAction, parseTarget } from "./actions.js";
 import { createDmworkManagementTools } from "./agent-tools.js";
-import { getOrCreateGroupMdCache } from "./group-md.js";
+import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds } from "./group-md.js";
 import path from "path";
 import os from "os";
 import { mkdir, readFile, writeFile } from "fs/promises";
@@ -239,7 +239,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       if (!accountId) return [];
       return [
         `When using the dmwork_management tool, pass accountId: "${accountId}".`,
-        `For cross-group messaging with action=send, use target="group:<groupId>". Use dmwork_management tool (list-groups action) to discover available groups first.`,
+        `For sending messages: if the target is a group, use target="group:<groupId>". If the target is a specific user (1v1 direct message), use target="user:<userId>". If sending to the current conversation, no prefix is needed.`,
       ];
     },
   },
@@ -282,24 +282,24 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         return { channel: "dmwork", to: ctx.to, messageId: "" };
       }
 
-      // Parse target: "group:channel_id" for groups, "group:channel_id@uid1,uid2" for @mentions
-      let channelId = ctx.to;
-      let channelType = ChannelType.DM;
+      // Parse target using shared parseTarget + knownGroupIds
       let mentionUids: string[] = [];
+      let targetForParse = ctx.to;
 
+      // Handle "group:channel_id@uid1,uid2" format — extract inline mention UIDs
       if (ctx.to.startsWith("group:")) {
         const groupPart = ctx.to.slice(6);
         const atIdx = groupPart.indexOf("@");
         if (atIdx >= 0) {
-          channelId = groupPart.slice(0, atIdx);
+          targetForParse = "group:" + groupPart.slice(0, atIdx);
           mentionUids = groupPart.slice(atIdx + 1).split(",").filter(Boolean);
-        } else {
-          channelId = groupPart;
         }
-        channelType = ChannelType.Group;
+      }
 
+      const { channelId, channelType } = parseTarget(targetForParse, undefined, getKnownGroupIds());
+
+      if (channelType === ChannelType.Group) {
         // Parse @mentions from message content (e.g., "@chenpipi_bot", "@陈皮皮")
-        // Uses shared utility for consistent regex across inbound/outbound (fixes #31)
         const contentMentionNames = parseMentions(content);
         for (const name of contentMentionNames) {
           if (name && !mentionUids.includes(name)) {
@@ -394,32 +394,44 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         contentType,
       });
 
-      // 3. Parse target (same logic as sendText)
-      let channelId = ctx.to;
-      let channelType = ChannelType.DM;
-
+      // 3. Parse target using shared parseTarget + knownGroupIds
+      let targetForParse = ctx.to;
       if (ctx.to.startsWith("group:")) {
         const groupPart = ctx.to.slice(6);
         const atIdx = groupPart.indexOf("@");
-        channelId = atIdx >= 0 ? groupPart.slice(0, atIdx) : groupPart;
-        channelType = ChannelType.Group;
+        if (atIdx >= 0) targetForParse = "group:" + groupPart.slice(0, atIdx);
       }
+      const { channelId, channelType } = parseTarget(targetForParse, undefined, getKnownGroupIds());
 
       // 4. Determine message type and send
       const msgType = contentType.startsWith("image/")
         ? MessageType.Image
         : MessageType.File;
 
-      await sendMediaMessage({
-        apiUrl: account.config.apiUrl,
-        botToken: account.config.botToken,
-        channelId,
-        channelType,
-        type: msgType,
-        url: cdnUrl,
-        name: filename,
-        size: fileBuffer.length,
-      });
+      if (msgType === MessageType.Image) {
+        const dims = parseImageDimensions(fileBuffer, contentType);
+        await sendMediaMessage({
+          apiUrl: account.config.apiUrl,
+          botToken: account.config.botToken,
+          channelId,
+          channelType,
+          type: msgType,
+          url: cdnUrl,
+          width: dims?.width,
+          height: dims?.height,
+        });
+      } else {
+        await sendMediaMessage({
+          apiUrl: account.config.apiUrl,
+          botToken: account.config.botToken,
+          channelId,
+          channelType,
+          type: msgType,
+          url: cdnUrl,
+          name: filename,
+          size: fileBuffer.length,
+        });
+      }
 
       return { channel: "dmwork", to: ctx.to, messageId: "" };
     },
@@ -498,6 +510,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       (async () => {
         try {
           const groups = await fetchBotGroups({ apiUrl: account.config.apiUrl, botToken: account.config.botToken!, log });
+          registerBotGroupIds(groups.map(g => g.group_no));
           for (const g of groups) {
             try {
               const md = await getGroupMd({ apiUrl: account.config.apiUrl, botToken: account.config.botToken!, groupNo: g.group_no, log });

--- a/openclaw-channel-dmwork/src/group-md.ts
+++ b/openclaw-channel-dmwork/src/group-md.ts
@@ -35,6 +35,13 @@ export const DMWORK_GROUP_RE = /^agent:[^:]+:dmwork:group:(.+)$/;
 
 // --- In-memory maps ---
 
+/** All bot group IDs registered at startup via fetchBotGroups */
+const _allBotGroupIds = new Set<string>();
+
+export function registerBotGroupIds(groupNos: string[]): void {
+  for (const g of groupNos) _allBotGroupIds.add(g);
+}
+
 /** groupNo → accountId (rebuilt from inbound messages) */
 const _groupAccountMap = new Map<string, string>();
 
@@ -397,6 +404,8 @@ export function getKnownGroupIds(): Set<string> {
       ids.add(groupNo);
     }
   }
+  // Also include groups registered at startup via registerBotGroupIds
+  for (const g of _allBotGroupIds) ids.add(g);
   return ids;
 }
 
@@ -414,4 +423,5 @@ export function _testReset(): void {
   _groupAccountMap.clear();
   _checkedGroups.clear();
   _groupMdCache.clear();
+  _allBotGroupIds.clear();
 }

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1,5 +1,5 @@
 import type { ChannelLogSink, OpenClawConfig } from "openclaw/plugin-sdk";
-import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, uploadFile, sendMediaMessage, inferContentType } from "./api-fetch.js";
+import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, uploadFile, sendMediaMessage, inferContentType, parseImageDimensions } from "./api-fetch.js";
 import type { ResolvedDmworkAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
 import { ChannelType, MessageType } from "./types.js";
@@ -56,43 +56,6 @@ function resolveOutboundMediaUrls(payload: { mediaUrl?: string; mediaUrls?: stri
 }
 
 /** Extract filename from a URL path */
-/**
- * Parse image dimensions from buffer (PNG/JPEG/GIF/WebP).
- * Lightweight — reads only the header bytes, no external dependencies.
- */
-function parseImageDimensions(buf: Buffer, mime: string): { width: number; height: number } | null {
-  try {
-    if (mime === "image/png" && buf.length > 24) {
-      // PNG: width at offset 16 (4 bytes BE), height at offset 20 (4 bytes BE)
-      return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
-    }
-    if ((mime === "image/jpeg" || mime === "image/jpg") && buf.length > 2) {
-      // JPEG: scan for SOF0/SOF2 marker (0xFF 0xC0 or 0xFF 0xC2)
-      let offset = 2;
-      while (offset < buf.length - 8) {
-        if (buf[offset] !== 0xFF) break;
-        const marker = buf[offset + 1];
-        if (marker === 0xC0 || marker === 0xC2) {
-          return { width: buf.readUInt16BE(offset + 7), height: buf.readUInt16BE(offset + 5) };
-        }
-        const len = buf.readUInt16BE(offset + 2);
-        offset += 2 + len;
-      }
-    }
-    if (mime === "image/gif" && buf.length > 10) {
-      // GIF: width at offset 6 (2 bytes LE), height at offset 8 (2 bytes LE)
-      return { width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) };
-    }
-    if (mime === "image/webp" && buf.length > 30) {
-      // WebP VP8: width at offset 26, height at offset 28 (both 2 bytes LE)
-      if (buf.toString("ascii", 12, 16) === "VP8 " && buf.length > 29) {
-        return { width: buf.readUInt16LE(26) & 0x3FFF, height: buf.readUInt16LE(28) & 0x3FFF };
-      }
-    }
-  } catch { /* ignore parse errors */ }
-  return null;
-}
-
 function extractFilename(url: string): string {
   try {
     const pathname = new URL(url).pathname;


### PR DESCRIPTION
## Summary

Fix parseTarget incorrectly defaulting bare IDs to wrong channel type (DM replies sent as Group, cross-group sends sent as DM).

## Changes

- **parseTarget**: Remove `currentChannelId` matching, use `knownGroupIds` lookup only
- **registerBotGroupIds**: New function to register all bot groups at startup via `fetchBotGroups`
- **getKnownGroupIds**: Merges `_groupAccountMap` + `_groupMdCache` + `_allBotGroupIds`
- **sendText/sendMedia**: Unified to use `parseTarget` instead of inline logic
- **sendMedia**: Added `parseImageDimensions` for image width/height
- **parseImageDimensions**: Moved to `api-fetch.ts` for shared access
- **messageToolHints**: Guide LLM to use `group:`/`user:` prefixes

## Testing

- 154/164 tests pass (10 pre-existing failures unrelated to this change)
- Manually verified: DM reply, cross-group send, current group reply, explicit prefixes

Fixes #115