### PR TITLE
feat: message read 增加 after/before 增量查询参数

### DIFF
--- a/openclaw-channel-dmwork/src/actions.ts
+++ b/openclaw-channel-dmwork/src/actions.ts
@@ -222,6 +222,10 @@ async function handleRead(params: {
   const rawLimit = Number(args.limit) || 20;
   const limit = Math.min(Math.max(rawLimit, 1), 100);
 
+  // after/before map to start_message_seq/end_message_seq (message sequence numbers)
+  const after = args.after != null ? Number(args.after) : undefined;
+  const before = args.before != null ? Number(args.before) : undefined;
+
   const { channelId, channelType } = parseTarget(target, currentChannelId, getKnownGroupIds());
 
   const messages = await getChannelMessages({
@@ -230,6 +234,8 @@ async function handleRead(params: {
     channelId,
     channelType,
     limit,
+    ...(after != null && !isNaN(after) ? { startMessageSeq: after } : {}),
+    ...(before != null && !isNaN(before) ? { endMessageSeq: before } : {}),
     log: log
       ? {
           info: (...a: unknown[]) => log.info?.(String(a[0])),

--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -400,6 +400,8 @@ export async function getChannelMessages(params: {
   channelId: string;
   channelType: ChannelType;
   limit?: number;
+  startMessageSeq?: number;
+  endMessageSeq?: number;
   signal?: AbortSignal;
   log?: { info?: (msg: string) => void; error?: (msg: string) => void };
 }): Promise<Array<{ from_uid: string; content: string; timestamp: number; type?: number; url?: string; name?: string }>> {
@@ -416,8 +418,8 @@ export async function getChannelMessages(params: {
         channel_id: params.channelId,
         channel_type: params.channelType,
         limit,
-        start_message_seq: 0,
-        end_message_seq: 0,
+        start_message_seq: params.startMessageSeq ?? 0,
+        end_message_seq: params.endMessageSeq ?? 0,
         pull_mode: 1,  // 1 = pull up (newer messages)
       }),
       signal: params.signal,


### PR DESCRIPTION
Closes #120

## 问题

`message read` 的 `after`/`before` 参数未生效，每次返回最新消息。`getChannelMessages()` 硬编码 `start_message_seq: 0, end_message_seq: 0`。

## 修复

### `src/api-fetch.ts` — `getChannelMessages()`
- 新增 `startMessageSeq?` 和 `endMessageSeq?` 可选参数
- 替换硬编码为 `params.startMessageSeq ?? 0`

### `src/actions.ts` — `handleRead()`
- 从 `args` 提取 `after`（→ `startMessageSeq`）和 `before`（→ `endMessageSeq`）
- 传递给 `getChannelMessages()`
- 未传参数时保持原有行为

## 改动量
2 文件, +10 -2