### PR TITLE
fix: align plugin id with npm package name to resolve startup warning

### DIFF
--- a/openclaw-channel-dmwork/index.ts
+++ b/openclaw-channel-dmwork/index.ts
@@ -16,7 +16,7 @@ const plugin: {
   description: string;
   register: (api: OpenClawPluginApi) => void;
 } = {
-  id: "dmwork",
+  id: "openclaw-channel-dmwork",
   name: "DMWork",
   description: "OpenClaw DMWork channel plugin via WuKongIM WebSocket",
   register(api) {

--- a/openclaw-channel-dmwork/openclaw.plugin.json
+++ b/openclaw-channel-dmwork/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "dmwork",
+  "id": "openclaw-channel-dmwork",
   "channels": [
     "dmwork"
   ],


### PR DESCRIPTION
## Summary

- Align `openclaw.plugin.json` `id` and `index.ts` exported id from `dmwork` to `openclaw-channel-dmwork` to match the npm package name
- Eliminates the plugin id mismatch warning on OpenClaw startup
- Channel name `dmwork` in the `channels` array is unchanged, so `channels.dmwork` user config is not affected

Fixes #122

## Test plan

- [ ] Start OpenClaw with the plugin installed and verify no `plugin id mismatch` warning appears
- [ ] Verify `channels.dmwork` configuration still works as expected
- [ ] Verify plugin loads and functions correctly under the new id