### PR TITLE
fix: re-encode COS key in CDN URL to prevent 404 on non-ASCII filenames

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -548,7 +548,15 @@ export async function uploadFileToCOS(params: {
         let url: string;
         if (params.cdnBaseUrl) {
           const base = params.cdnBaseUrl.replace(/\/+$/, "");
-          url = `${base}/${params.key}`;
+          // Re-encode each path segment: COS keys may contain percent-encoded
+          // characters (e.g. Chinese filenames). Without double-encoding, the
+          // IM client decodes the URL once and requests a key with raw UTF-8
+          // characters that doesn't exist in COS (NoSuchKey / 404).
+          const reEncodedKey = params.key
+            .split("/")
+            .map((seg) => encodeURIComponent(seg))
+            .join("/");
+          url = `${base}/${reEncodedKey}`;
         } else {
           url = data.Location ? `https://${data.Location}` : "";
         }


### PR DESCRIPTION
## Summary

Fix COS CDN URL construction for files with non-ASCII filenames (e.g. Chinese characters) that result in `NoSuchKey` / 404 errors.

## Problem

The COS API returns keys with percent-encoded characters for non-ASCII filenames:
```
im-test-xming/chat/xxx/abc_KM%E4%BA%A7%E5%93%81%E8%A7%84%E5%88%92.pptx
```

The CDN URL was constructed by directly concatenating base + key:
```
https://cdn.deepminer.com.cn/.../abc_KM%E4%BA%A7%E5%93%81%E8%A7%84%E5%88%92.pptx
```

When the IM client opens this URL, it decodes the percent-encoded characters once, requesting a key with raw Chinese characters — which does not exist in COS.

## Fix

Re-encode each path segment of the COS key using `encodeURIComponent()`, so `%` becomes `%25`. After the client decodes once, the correct percent-encoded key is resolved:

```
Before: .../abc_KM%E4%BA%A7%E5%93%81.pptx        → client decodes → KM产品.pptx (404!)
After:  .../abc_KM%25E4%25BA%25A7%25E5%2593%2581.pptx → client decodes → KM%E4%BA%A7%E5%93%81.pptx (200 ✓)
```

## Testing

Manually verified: uploaded a 22MB `.pptx` file with Chinese filename, confirmed the re-encoded CDN URL resolves correctly and the file downloads successfully.

Fixes #124