### PR TITLE
fix: large file download causes silent message loss and pipeline blocking

### DIFF
--- a/openclaw-channel-dmwork/src/inbound.test.ts
+++ b/openclaw-channel-dmwork/src/inbound.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ChannelType, MessageType, type MentionPayload } from "./types.js";
 import { DEFAULT_HISTORY_PROMPT_TEMPLATE } from "./config-schema.js";
-import { resolveInnerMessageText, resolveApiMessagePlaceholder, resolveMultipleForwardText } from "./inbound.js";
+import {
+  resolveInnerMessageText,
+  resolveApiMessagePlaceholder,
+  resolveMultipleForwardText,
+  calcDownloadTimeout,
+  formatSize,
+  resolveFileContentWithRetry,
+  downloadToTemp,
+  uploadAndSendMedia,
+  type ResolveFileResult,
+} from "./inbound.js";
 
 /**
  * Tests for mention.all detection logic.
@@ -327,5 +337,290 @@ describe("GROUP.md event detection", () => {
 
   it("should NOT detect when payload is undefined", () => {
     expect(isGroupMdEvent(undefined)).toBe(false);
+  });
+});
+
+/**
+ * Tests for calcDownloadTimeout — calls the real exported function.
+ */
+describe("calcDownloadTimeout", () => {
+  it("should return minimum 5 minutes for small files", () => {
+    expect(calcDownloadTimeout(1024)).toBe(300_000);
+  });
+
+  it("should scale timeout based on file size (512KB/s baseline)", () => {
+    // 10MB file: ceil(10*1024*1024 / (512*1024)) * 1000 = ceil(20) * 1000 = 20_000
+    // But min is 300_000
+    expect(calcDownloadTimeout(10 * 1024 * 1024)).toBe(300_000);
+  });
+
+  it("should cap at 30 minutes max", () => {
+    expect(calcDownloadTimeout(1024 * 1024 * 1024)).toBe(1_800_000);
+  });
+
+  it("should assume 256MB when size is unknown", () => {
+    const timeout = calcDownloadTimeout(undefined);
+    // 256MB / (512*1024) * 1000 = 512 * 1000 = 512_000
+    expect(timeout).toBeGreaterThanOrEqual(300_000);
+    expect(timeout).toBeLessThanOrEqual(1_800_000);
+  });
+
+  it("should return computed timeout for large files", () => {
+    // 500MB: ceil(500*1024*1024 / (512*1024)) * 1000 = ceil(1000) * 1000 = 1_000_000
+    const timeout = calcDownloadTimeout(500 * 1024 * 1024);
+    expect(timeout).toBe(1_000_000);
+  });
+});
+
+/**
+ * Tests for formatSize — calls the real exported function.
+ */
+describe("formatSize", () => {
+  it("should format bytes", () => {
+    expect(formatSize(500)).toBe("500B");
+  });
+
+  it("should format kilobytes", () => {
+    expect(formatSize(20 * 1024)).toBe("20.0KB");
+  });
+
+  it("should format megabytes", () => {
+    expect(formatSize(52 * 1024 * 1024)).toBe("52.0MB");
+  });
+
+  it("should format gigabytes", () => {
+    expect(formatSize(2 * 1024 * 1024 * 1024)).toBe("2.0GB");
+  });
+});
+
+/**
+ * Tests for resolveFileContentWithRetry — mocks global fetch, calls the real function.
+ */
+describe("resolveFileContentWithRetry", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("should return null for non-text file extensions", async () => {
+    const result = await resolveFileContentWithRetry(
+      "https://example.com/photo.png",
+      "token",
+      "photo.png",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("should inline small text files (< 20KB)", async () => {
+    const smallContent = "Hello, world!";
+    const encoded = new TextEncoder().encode(smallContent);
+
+    globalThis.fetch = (vi.fn() as any)
+      // HEAD request
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": String(encoded.byteLength) }),
+      } as any)
+      // GET request
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": String(encoded.byteLength) }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoded);
+            controller.close();
+          },
+        }),
+      } as any);
+
+    const result = await resolveFileContentWithRetry(
+      "https://example.com/file.txt",
+      "token",
+      "file.txt",
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("inline", smallContent);
+  });
+
+  it("should return description for file > 20KB with Content-Length", async () => {
+    const largeSize = 25 * 1024;
+
+    globalThis.fetch = (vi.fn() as any)
+      // HEAD request reports large file
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": String(largeSize) }),
+      } as any)
+      // downloadToTemp GET request — simulate failure to keep test simple
+      .mockRejectedValueOnce(new Error("HTTP 500"));
+
+    const result = await resolveFileContentWithRetry(
+      "https://example.com/large.txt",
+      "token",
+      "large.txt",
+      { knownSize: largeSize, maxRetries: 1 },
+    );
+    // Should not be null (text extension), and should not be inline
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty("inline");
+  });
+
+  it("should reject file exceeding 500MB hard cap via HEAD without downloading", async () => {
+    const hugeSize = 600 * 1024 * 1024; // 600MB
+
+    globalThis.fetch = (vi.fn() as any)
+      // HEAD request reports 600MB
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": String(hugeSize) }),
+      } as any);
+
+    // Do NOT pass knownSize — let HEAD discovery trigger the 500MB check
+    const result = await resolveFileContentWithRetry(
+      "https://example.com/huge.csv",
+      "token",
+      "huge.csv",
+      { maxRetries: 3 },
+    );
+    // Should return error description, NOT attempt download
+    expect(result).toHaveProperty("description");
+    expect((result as any).description).toContain("500.0MB");
+    expect((result as any).description).toContain("最大下载限制");
+    // Only HEAD request, no GET — verify no download attempted
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fall back to GET streaming when HEAD fails", async () => {
+    const content = "fallback content";
+    const encoded = new TextEncoder().encode(content);
+
+    globalThis.fetch = (vi.fn() as any)
+      // HEAD request fails
+      .mockRejectedValueOnce(new Error("HEAD not supported"))
+      // GET request succeeds
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": String(encoded.byteLength) }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoded);
+            controller.close();
+          },
+        }),
+      } as any);
+
+    const result = await resolveFileContentWithRetry(
+      "https://example.com/data.json",
+      "token",
+      "data.json",
+    );
+    expect(result).toHaveProperty("inline", content);
+  });
+
+  it("should return error description on HTTP 404 and NOT retry", async () => {
+    globalThis.fetch = (vi.fn() as any)
+      // HEAD request
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": "100" }),
+      } as any)
+      // GET returns 404
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+      } as any);
+
+    const result = await resolveFileContentWithRetry(
+      "https://example.com/missing.txt",
+      "token",
+      "missing.txt",
+      { maxRetries: 3 },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("description");
+    expect((result as { description: string }).description).toContain("HTTP 404");
+    // Should only have called fetch twice (HEAD + one GET), not retried
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("should retry on timeout and return error description", async () => {
+    globalThis.fetch = (vi.fn() as any)
+      // HEAD request
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": "100" }),
+      } as any)
+      // All GET attempts timeout
+      .mockRejectedValueOnce(new Error("TimeoutError"))
+      .mockRejectedValueOnce(new Error("TimeoutError"));
+
+    const result = await resolveFileContentWithRetry(
+      "https://example.com/slow.txt",
+      "token",
+      "slow.txt",
+      { maxRetries: 2 },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("description");
+    expect((result as { description: string }).description).toContain("下载失败");
+  });
+});
+
+/**
+ * Tests for uploadAndSendMedia timeout signal.
+ *
+ * Verifies that the fetch call to download media includes a timeout signal
+ * by inspecting the function's behavior with a mocked global fetch.
+ */
+describe("uploadAndSendMedia timeout", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("should pass timeout signal to fetch", async () => {
+    const calls: Array<{ url: string; method?: string; signal?: AbortSignal }> = [];
+    const { Readable } = await import("node:stream");
+    vi.stubGlobal("fetch", async (url: string, opts?: any) => {
+      calls.push({ url, method: opts?.method, signal: opts?.signal });
+      if (opts?.method === "HEAD") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-length": "8" }),
+        };
+      }
+      // GET request — return a readable stream body
+      const body = new Readable({ read() { this.push(Buffer.alloc(8)); this.push(null); } });
+      return {
+        ok: true,
+        headers: new Headers({ "content-type": "image/png" }),
+        body,
+      };
+    });
+
+    // Call uploadAndSendMedia — it will use the mocked fetch for HEAD + GET,
+    // then fail on getUploadCredentials (which also uses fetch but posts to API)
+    let caughtError: unknown;
+    try {
+      await uploadAndSendMedia({
+        mediaUrl: "https://example.com/img.png",
+        apiUrl: "https://api.example.com",
+        botToken: "token",
+        channelId: "ch1",
+        channelType: ChannelType.DM,
+      });
+    } catch (err) {
+      caughtError = err;
+    }
+
+    // calls[0] is HEAD (no signal), calls[1] is GET with timeout signal
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls[0].method).toBe("HEAD");
+    expect(calls[1].signal).toBeDefined();
   });
 });

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -7,6 +7,10 @@ import { getDmworkRuntime } from "./runtime.js";
 import { DEFAULT_HISTORY_PROMPT_TEMPLATE } from "./config-schema.js";
 import { extractMentionMatches } from "./mention-utils.js";
 import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate } from "./group-md.js";
+import { createWriteStream } from "node:fs";
+import { mkdir, unlink, readdir, stat } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { randomUUID } from "node:crypto";
 
 // Defensive imports — these may not exist in older OpenClaw versions
 // History context managed manually for cross-SDK compatibility
@@ -103,7 +107,9 @@ export async function uploadAndSendMedia(params: {
     const cl = Number(head.headers.get("content-length") || 0);
     if (cl > MAX_UPLOAD) throw new Error(`File too large (${cl} bytes, max ${MAX_UPLOAD})`);
 
-    const resp = await fetch(mediaUrl);
+    const resp = await fetch(mediaUrl, {
+      signal: AbortSignal.timeout(300_000),
+    });
     if (!resp.ok) throw new Error(`Failed to fetch media: ${resp.status}`);
     contentType = resp.headers.get("content-type") || "application/octet-stream";
 
@@ -378,30 +384,291 @@ async function fetchAsDataUrl(
   }
 }
 
-async function resolveFileContent(
+/** Format bytes as human-readable size string */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`;
+}
+
+/** Calculate dynamic timeout based on file size (512KB/s baseline, min 5min, max 30min) */
+export function calcDownloadTimeout(fileSize?: number): number {
+  const MIN_TIMEOUT = 300_000;    // 5 minutes
+  const MAX_TIMEOUT = 1_800_000;  // 30 minutes
+  const ASSUMED_SIZE = 256 * 1024 * 1024; // 256MB if unknown
+  const size = fileSize ?? ASSUMED_SIZE;
+  const computed = Math.ceil(size / (512 * 1024)) * 1000; // 512KB/s baseline
+  return Math.min(MAX_TIMEOUT, Math.max(MIN_TIMEOUT, computed));
+}
+
+const TEMP_DIR = join("/tmp", "dmwork-files");
+const MAX_DOWNLOAD_SIZE = 500 * 1024 * 1024; // 500MB hard cap
+
+/** Best-effort cleanup of temp files older than 1 hour */
+async function cleanupTempFiles(): Promise<void> {
+  try {
+    const entries = await readdir(TEMP_DIR);
+    const cutoff = Date.now() - 60 * 60 * 1000;
+    for (const entry of entries) {
+      try {
+        const filePath = join(TEMP_DIR, entry);
+        const info = await stat(filePath);
+        if (info.mtimeMs < cutoff) {
+          await unlink(filePath);
+        }
+      } catch {}
+    }
+  } catch {}
+}
+
+/** Download a file to a temp path, streaming to disk with size limit.
+ *  Returns the local path on success. */
+export async function downloadToTemp(
   url: string,
   botToken: string,
-  maxBytes = 5 * 1024 * 1024,
-): Promise<string | null> {
+  filename: string,
+  opts?: { knownSize?: number; log?: ChannelLogSink },
+): Promise<string> {
+  await mkdir(TEMP_DIR, { recursive: true });
+  // Non-blocking cleanup of old temp files
+  cleanupTempFiles().catch(() => {});
+
+  const safeName = basename(filename).replace(/[^a-zA-Z0-9._-]/g, '_') || 'file';
+  const localPath = join(TEMP_DIR, `${randomUUID()}-${safeName}`);
+  const timeout = calcDownloadTimeout(opts?.knownSize);
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${botToken}` },
+    signal: AbortSignal.timeout(timeout),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  if (!resp.body) throw new Error("no response body");
+
+  const ws = createWriteStream(localPath);
+  let totalBytes = 0;
   try {
-    const ext = url.split(".").pop()?.toLowerCase() ?? "";
-    if (!TEXT_FILE_EXTENSIONS.has(ext)) return null;
-
-    const resp = await fetch(url, {
-      headers: { Authorization: `Bearer ${botToken}` },
-      signal: AbortSignal.timeout(30_000),
+    const reader = (resp.body as any).getReader() as ReadableStreamDefaultReader<Uint8Array>;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_DOWNLOAD_SIZE) {
+        reader.cancel();
+        throw new Error(`file exceeds max download size (${formatSize(MAX_DOWNLOAD_SIZE)})`);
+      }
+      if (!ws.write(value)) {
+        await new Promise<void>(r => ws.once('drain', r));
+      }
+    }
+    ws.end();
+    await new Promise<void>((resolve, reject) => {
+      ws.on("finish", resolve);
+      ws.on("error", reject);
     });
-    if (!resp.ok || !resp.body) return null;
-
-    const contentLength = resp.headers.get("content-length");
-    if (contentLength && parseInt(contentLength, 10) > maxBytes) return null;
-
-    const buffer = await resp.arrayBuffer();
-    if (buffer.byteLength > maxBytes) return null;
-    return new TextDecoder().decode(buffer);
-  } catch {
-    return null;
+  } catch (err) {
+    ws.destroy();
+    // Best-effort cleanup
+    try { await unlink(localPath); } catch {}
+    throw err;
   }
+  opts?.log?.info?.(`dmwork: file downloaded to temp: ${localPath}`);
+  return localPath;
+}
+
+/**
+ * Attempt to resolve file content for inline display.
+ *
+ * - Only attempts inline for text-like file extensions
+ * - Threshold reduced to 20KB to avoid blowing up LLM context
+ * - Sends HEAD request first to check size before downloading
+ * - Streams the body with a size guard instead of buffering entirely
+ * - For files above inline threshold, streams to a temp file on disk
+ * - Returns error description string on failure (never silent null)
+ *
+ * Return value:
+ *   { inline: string }             – file content was inlined
+ *   { tempPath: string }           – file was saved to temp
+ *   { description: string }        – download skipped or failed; embed this in message
+ *   null                           – non-text extension, no action needed
+ */
+export type ResolveFileResult =
+  | { inline: string }
+  | { tempPath: string }
+  | { description: string }
+  | null;
+
+export async function resolveFileContentWithRetry(
+  url: string,
+  botToken: string,
+  filename: string,
+  opts?: { knownSize?: number; maxRetries?: number; log?: ChannelLogSink },
+): Promise<ResolveFileResult> {
+  let ext = "";
+  try {
+    ext = new URL(url).pathname.split(".").pop()?.toLowerCase() ?? "";
+  } catch {
+    ext = url.split(".").pop()?.toLowerCase() ?? "";
+  }
+  if (!TEXT_FILE_EXTENSIONS.has(ext)) return null;
+
+  const maxBytes = 20 * 1024; // 20KB inline threshold
+  const knownSize = opts?.knownSize;
+  const maxRetries = opts?.maxRetries ?? 3;
+  const log = opts?.log;
+
+  // If we already know the file is too large for inline, stream to temp
+  if (knownSize != null && knownSize > maxBytes) {
+    log?.info?.(`dmwork: file too large for inline (${formatSize(knownSize)}), streaming to temp`);
+    return await downloadLargeFileWithRetry(url, botToken, filename, { knownSize, maxRetries, log });
+  }
+
+  // HEAD pre-check to get Content-Length without downloading
+  let headSize: number | undefined;
+  try {
+    const headResp = await fetch(url, {
+      method: "HEAD",
+      headers: { Authorization: `Bearer ${botToken}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (headResp.ok) {
+      const cl = headResp.headers.get("content-length");
+      if (cl) headSize = parseInt(cl, 10);
+    }
+  } catch {
+    // HEAD failed — proceed with streaming download
+  }
+
+  // Reject files exceeding hard cap before any download attempt
+  if (headSize != null && headSize > MAX_DOWNLOAD_SIZE) {
+    log?.info?.(`dmwork: HEAD reports ${formatSize(headSize)}, exceeds max download size (${formatSize(MAX_DOWNLOAD_SIZE)}), skipping`);
+    return { description: `[文件: ${filename} (${formatSize(headSize)}) - 文件超过最大下载限制(${formatSize(MAX_DOWNLOAD_SIZE)})]` };
+  }
+
+  if (headSize != null && headSize > maxBytes) {
+    log?.info?.(`dmwork: HEAD reports ${formatSize(headSize)}, exceeds inline threshold, streaming to temp`);
+    return await downloadLargeFileWithRetry(url, botToken, filename, { knownSize: headSize, maxRetries, log });
+  }
+
+  // Attempt inline download with streaming size guard
+  let lastError: string | undefined;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const timeout = calcDownloadTimeout(headSize ?? knownSize);
+      const resp = await fetch(url, {
+        headers: { Authorization: `Bearer ${botToken}` },
+        signal: AbortSignal.timeout(timeout),
+      });
+      if (!resp.ok) {
+        lastError = `HTTP ${resp.status}`;
+        log?.warn?.(`dmwork: resolveFileContent attempt ${attempt}/${maxRetries} failed: ${lastError}`);
+        if (resp.status >= 400 && resp.status < 500) break;
+        if (attempt < maxRetries) await sleep(1000 * attempt);
+        continue;
+      }
+      if (!resp.body) {
+        lastError = "no response body";
+        break;
+      }
+
+      // Check Content-Length from GET response
+      const cl = resp.headers.get("content-length");
+      if (cl && parseInt(cl, 10) > maxBytes) {
+        log?.info?.(`dmwork: GET Content-Length ${cl} exceeds inline threshold, streaming to temp`);
+        // Cancel this response; download to temp instead
+        try { resp.body.cancel(); } catch {}
+        return await downloadLargeFileWithRetry(url, botToken, filename, { knownSize: parseInt(cl, 10), maxRetries: maxRetries - attempt + 1, log });
+      }
+
+      // Stream body with size guard
+      const reader = (resp.body as any).getReader() as ReadableStreamDefaultReader<Uint8Array>;
+      const chunks: Uint8Array[] = [];
+      let totalBytes = 0;
+      let exceededInline = false;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+          exceededInline = true;
+          reader.cancel();
+          break;
+        }
+        chunks.push(value);
+      }
+
+      if (exceededInline) {
+        log?.info?.(`dmwork: file exceeded inline threshold during stream (${formatSize(totalBytes)}+), streaming to temp`);
+        return await downloadLargeFileWithRetry(url, botToken, filename, { knownSize: totalBytes, maxRetries: maxRetries - attempt + 1, log });
+      }
+
+      // Inline the content
+      const combined = new Uint8Array(totalBytes);
+      let offset = 0;
+      for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      const text = new TextDecoder().decode(combined);
+      log?.info?.(`dmwork: file inlined (${formatSize(totalBytes)})`);
+      return { inline: text };
+    } catch (err) {
+      const errMsg = String(err);
+      lastError = errMsg.includes("TimeoutError") || errMsg.includes("abort") ? "下载超时" : `网络错误`;
+      log?.warn?.(`dmwork: resolveFileContent attempt ${attempt}/${maxRetries} error: ${errMsg}`);
+      if (attempt < maxRetries) await sleep(1000 * attempt);
+    }
+  }
+
+  const sizeInfo = knownSize != null ? ` (${formatSize(knownSize)})` : headSize != null ? ` (${formatSize(headSize)})` : "";
+  return { description: `[文件: ${filename}${sizeInfo} - 下载失败: ${lastError ?? "未知错误"}]` };
+}
+
+/** Download large file to temp with retry + exponential backoff */
+async function downloadLargeFileWithRetry(
+  url: string,
+  botToken: string,
+  filename: string,
+  opts: { knownSize?: number; maxRetries: number; log?: ChannelLogSink },
+): Promise<ResolveFileResult> {
+  const { knownSize, maxRetries, log } = opts;
+
+  // Reject files exceeding hard cap before any download attempt
+  if (knownSize != null && knownSize > MAX_DOWNLOAD_SIZE) {
+    log?.info?.(`dmwork: file size ${formatSize(knownSize)} exceeds max download size (${formatSize(MAX_DOWNLOAD_SIZE)}), skipping`);
+    return { description: `[文件: ${filename} (${formatSize(knownSize)}) - 文件超过最大下载限制(${formatSize(MAX_DOWNLOAD_SIZE)})]` };
+  }
+
+  let lastError: string | undefined;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const start = Date.now();
+      const tempPath = await downloadToTemp(url, botToken, filename, { knownSize, log });
+      const duration = ((Date.now() - start) / 1000).toFixed(1);
+      log?.info?.(`dmwork: large file downloaded in ${duration}s: ${filename}`);
+      return { tempPath };
+    } catch (err) {
+      const errMsg = String(err);
+      lastError = errMsg.includes("TimeoutError") || errMsg.includes("abort")
+        ? `下载超时，已重试${attempt}次失败`
+        : errMsg.includes("HTTP ")
+        ? errMsg
+        : "网络错误";
+      log?.warn?.(`dmwork: downloadToTemp attempt ${attempt}/${maxRetries} failed: ${errMsg}`);
+      // 4xx errors are permanent — do not retry
+      const httpMatch = errMsg.match(/HTTP (\d+)/);
+      if (httpMatch) {
+        const status = parseInt(httpMatch[1], 10);
+        if (status >= 400 && status < 500) break;
+      }
+      if (attempt < maxRetries) await sleep(1000 * attempt * 2);
+    }
+  }
+  const sizeInfo = knownSize != null ? ` (${formatSize(knownSize)})` : "";
+  return { description: `[文件: ${filename}${sizeInfo} - ${lastError ?? "下载失败"}]` };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /** Placeholder text for non-text API history messages */
@@ -643,14 +910,33 @@ export async function handleInboundMessage(params: {
   const resolved = resolveContent(message.payload, account.config.apiUrl, log, account.config.cdnUrl);
   let rawBody = resolved.text;
   let inboundMediaUrl = resolved.mediaUrl;
-  // Inline text file content if possible
+  // Inline text file content if possible, or stream large files to temp
   const isFileMessage = message.payload?.type === MessageType.File;
   if (isFileMessage && resolved.mediaUrl) {
-    const fileContent = await resolveFileContent(resolved.mediaUrl, account.config.botToken ?? "");
-    if (fileContent) {
-      rawBody = `[文件: ${message.payload.name ?? "未知文件"}]\n\n--- 文件内容 ---\n${fileContent}\n--- 文件结束 ---`;
+    const payloadSize = typeof message.payload.size === "number" ? message.payload.size : undefined;
+    const fileName = (message.payload.name as string) ?? "未知文件";
+    if (payloadSize != null) {
+      log?.info?.(`dmwork: file message: ${fileName}, payload.size=${formatSize(payloadSize)}`);
+    }
+    const fileResult = await resolveFileContentWithRetry(
+      resolved.mediaUrl,
+      account.config.botToken ?? "",
+      fileName,
+      { knownSize: payloadSize, log },
+    );
+    if (fileResult && "inline" in fileResult) {
+      rawBody = `[文件: ${fileName}]\n\n--- 文件内容 ---\n${fileResult.inline}\n--- 文件结束 ---`;
+      inboundMediaUrl = undefined;
+    } else if (fileResult && "tempPath" in fileResult) {
+      // tempPath is intentionally included in the message body so the agent can read the file
+      const sizeStr = payloadSize != null ? ` (${formatSize(payloadSize)})` : "";
+      rawBody = `[文件: ${fileName}${sizeStr} - 已下载到本地: ${fileResult.tempPath}]`;
+      inboundMediaUrl = undefined;
+    } else if (fileResult && "description" in fileResult) {
+      rawBody = fileResult.description;
       inboundMediaUrl = undefined;
     }
+    // fileResult === null means non-text extension, keep original resolveContent result
   }
 
   // Media URLs are passed directly to the Agent (storage is public-read, no auth needed)
@@ -739,6 +1025,7 @@ export async function handleInboundMessage(params: {
         sender: message.from_uid,
         body: rawBody,
         mediaUrl: inboundMediaUrl,
+        msgType: message.payload?.type,
         timestamp: message.timestamp ? message.timestamp * 1000 : Date.now(),
       });
       const historyLimit = account.config.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT;
@@ -789,6 +1076,7 @@ export async function handleInboundMessage(params: {
           const entry: any = {
             sender: m.from_uid,
             body,
+            msgType: m.type,
             timestamp: m.timestamp,
           };
           // For media message types, resolve the URL directly (storage is public-read)
@@ -811,6 +1099,7 @@ export async function handleInboundMessage(params: {
     // Build history context manually (JSON format)
     // Collect media URLs from history entries for attachment to the inbound context
     historyMediaUrls = entries
+      .filter((e: any) => e.msgType !== MessageType.File)
       .map((e: any) => e.mediaUrl)
       .filter((url: string | undefined): url is string => Boolean(url));
 
@@ -907,9 +1196,10 @@ export async function handleInboundMessage(params: {
     BodyForAgent: body,  // ← 关键！AI 实际读取的是这个字段！
     RawBody: rawBody,
     CommandBody: rawBody,
-    MediaUrl: inboundMediaUrl,
+    MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
     MediaUrls: (() => {
-      const urls = [...(inboundMediaUrl ? [inboundMediaUrl] : []), ...historyMediaUrls];
+      const current = isFileMessage ? undefined : inboundMediaUrl;
+      const urls = [...(current ? [current] : []), ...historyMediaUrls];
       return urls.length > 0 ? urls : undefined;
     })(),
     MediaTypes: resolved.mediaType ? [resolved.mediaType] : undefined,


### PR DESCRIPTION
Closes #127

## Summary

- Reduce inline threshold from 5MB to 20KB
- Add HEAD pre-check for file size
- Replace full-buffer download with streaming + size guard
- Stream large files to temp directory
- Dynamic timeout based on file size (512KB/s baseline)
- Retry with exponential backoff (max 3 attempts, skip 4xx)
- Expose download failures to model instead of silent null
- 500MB hard cap with pre-check (HEAD + payload.size + streaming)
- Sanitize filenames (path traversal prevention)
- Backpressure handling on write stream
- Temp file cleanup (1 hour TTL)
- Add 5-minute timeout to uploadAndSendMedia fetch
- Robust URL extension parsing via URL pathname
- File type messages no longer set MediaUrl (prevents OpenClaw Core media understanding from processing unsupported binary files)
- 19 new test cases