### PR TITLE
fix: resolve media URLs in nested MultipleForward messages (#120)

### DIFF
--- a/openclaw-channel-dmwork/src/inbound.test.ts
+++ b/openclaw-channel-dmwork/src/inbound.test.ts
@@ -5,6 +5,7 @@ import {
   resolveInnerMessageText,
   resolveApiMessagePlaceholder,
   resolveMultipleForwardText,
+  buildMediaUrl,
   calcDownloadTimeout,
   formatSize,
   resolveFileContentWithRetry,
@@ -863,5 +864,206 @@ describe("buildMemberListPrefix", () => {
     const result = buildMemberListPrefix(map);
     expect(result).toContain("[Group Info]");
     expect(result).toContain("50 members");
+  });
+});
+
+/**
+ * Tests for buildMediaUrl — exported module-level URL builder.
+ */
+describe("buildMediaUrl", () => {
+  it("should return undefined for empty url", () => {
+    expect(buildMediaUrl(undefined)).toBeUndefined();
+    expect(buildMediaUrl("")).toBeUndefined();
+  });
+
+  it("should return absolute URL as-is", () => {
+    expect(buildMediaUrl("https://cdn.example.com/img.jpg")).toBe("https://cdn.example.com/img.jpg");
+    expect(buildMediaUrl("http://example.com/file.pdf")).toBe("http://example.com/file.pdf");
+  });
+
+  it("should use cdnUrl when provided", () => {
+    expect(buildMediaUrl("upload/abc123.jpg", "https://api.example.com", "https://cdn.example.com"))
+      .toBe("https://cdn.example.com/upload/abc123.jpg");
+  });
+
+  it("should strip trailing slashes from cdnUrl", () => {
+    expect(buildMediaUrl("upload/abc.jpg", undefined, "https://cdn.example.com///"))
+      .toBe("https://cdn.example.com/upload/abc.jpg");
+  });
+
+  it("should strip file/preview/ prefix with cdnUrl", () => {
+    expect(buildMediaUrl("file/preview/bucket/img.jpg", undefined, "https://cdn.example.com"))
+      .toBe("https://cdn.example.com/bucket/img.jpg");
+  });
+
+  it("should strip file/ prefix with cdnUrl", () => {
+    expect(buildMediaUrl("file/bucket/img.jpg", undefined, "https://cdn.example.com"))
+      .toBe("https://cdn.example.com/bucket/img.jpg");
+  });
+
+  it("should fall back to apiUrl when cdnUrl is not provided", () => {
+    expect(buildMediaUrl("upload/abc123.jpg", "https://api.example.com"))
+      .toBe("https://api.example.com/file/upload/abc123.jpg");
+  });
+
+  it("should strip trailing slashes from apiUrl", () => {
+    expect(buildMediaUrl("upload/abc.jpg", "https://api.example.com/"))
+      .toBe("https://api.example.com/file/upload/abc.jpg");
+  });
+
+  it("should strip file/ prefix with apiUrl fallback", () => {
+    expect(buildMediaUrl("file/bucket/img.jpg", "https://api.example.com"))
+      .toBe("https://api.example.com/file/bucket/img.jpg");
+  });
+
+  it("should return /file/path when neither cdnUrl nor apiUrl provided", () => {
+    expect(buildMediaUrl("upload/abc.jpg")).toBe("/file/upload/abc.jpg");
+  });
+});
+
+/**
+ * Tests for resolveInnerMessageText with buildUrl parameter.
+ */
+describe("resolveInnerMessageText with buildUrl", () => {
+  const mockBuildUrl = (url?: string) => url ? `https://cdn.example.com/${url}` : undefined;
+
+  it("should append URL for Image when buildUrl is provided", () => {
+    const result = resolveInnerMessageText(
+      { type: MessageType.Image, url: "img.jpg" },
+      mockBuildUrl,
+    );
+    expect(result).toBe("[图片]\nhttps://cdn.example.com/img.jpg");
+  });
+
+  it("should append URL for GIF when buildUrl is provided", () => {
+    const result = resolveInnerMessageText(
+      { type: MessageType.GIF, url: "anim.gif" },
+      mockBuildUrl,
+    );
+    expect(result).toBe("[GIF]\nhttps://cdn.example.com/anim.gif");
+  });
+
+  it("should append URL for Voice when buildUrl is provided", () => {
+    const result = resolveInnerMessageText(
+      { type: MessageType.Voice, url: "voice.mp3" },
+      mockBuildUrl,
+    );
+    expect(result).toBe("[语音]\nhttps://cdn.example.com/voice.mp3");
+  });
+
+  it("should append URL for Video when buildUrl is provided", () => {
+    const result = resolveInnerMessageText(
+      { type: MessageType.Video, url: "clip.mp4" },
+      mockBuildUrl,
+    );
+    expect(result).toBe("[视频]\nhttps://cdn.example.com/clip.mp4");
+  });
+
+  it("should append URL for File when buildUrl is provided", () => {
+    const result = resolveInnerMessageText(
+      { type: MessageType.File, name: "report.pdf", url: "report.pdf" },
+      mockBuildUrl,
+    );
+    expect(result).toBe("[文件: report.pdf]\nhttps://cdn.example.com/report.pdf");
+  });
+
+  it("should return placeholder without URL when buildUrl is not provided", () => {
+    expect(resolveInnerMessageText({ type: MessageType.Image, url: "img.jpg" })).toBe("[图片]");
+    expect(resolveInnerMessageText({ type: MessageType.GIF, url: "anim.gif" })).toBe("[GIF]");
+    expect(resolveInnerMessageText({ type: MessageType.Voice, url: "voice.mp3" })).toBe("[语音]");
+    expect(resolveInnerMessageText({ type: MessageType.Video, url: "clip.mp4" })).toBe("[视频]");
+    expect(resolveInnerMessageText({ type: MessageType.File, name: "doc.pdf", url: "doc.pdf" })).toBe("[文件: doc.pdf]");
+  });
+
+  it("should return placeholder when payload.url is missing even with buildUrl", () => {
+    expect(resolveInnerMessageText({ type: MessageType.Image }, mockBuildUrl)).toBe("[图片]");
+    expect(resolveInnerMessageText({ type: MessageType.Voice }, mockBuildUrl)).toBe("[语音]");
+    expect(resolveInnerMessageText({ type: MessageType.File, name: "doc.pdf" }, mockBuildUrl)).toBe("[文件: doc.pdf]");
+  });
+});
+
+/**
+ * Tests for resolveMultipleForwardText with apiUrl/cdnUrl — nested media URL resolution.
+ */
+describe("resolveMultipleForwardText with URL resolution", () => {
+  it("should include full URLs for media messages when apiUrl is provided", () => {
+    const payload = {
+      type: MessageType.MultipleForward,
+      users: [{ uid: "user1", name: "Alice" }],
+      msgs: [
+        { from_uid: "user1", payload: { type: MessageType.Image, url: "upload/img.jpg" } },
+        { from_uid: "user1", payload: { type: MessageType.File, name: "doc.pdf", url: "upload/doc.pdf" } },
+      ],
+    };
+
+    const result = resolveMultipleForwardText(payload, "https://api.example.com");
+    expect(result).toContain("Alice: [图片]\nhttps://api.example.com/file/upload/img.jpg");
+    expect(result).toContain("Alice: [文件: doc.pdf]\nhttps://api.example.com/file/upload/doc.pdf");
+  });
+
+  it("should use cdnUrl when provided", () => {
+    const payload = {
+      type: MessageType.MultipleForward,
+      users: [{ uid: "user1", name: "Bob" }],
+      msgs: [
+        { from_uid: "user1", payload: { type: MessageType.Video, url: "upload/clip.mp4" } },
+      ],
+    };
+
+    const result = resolveMultipleForwardText(payload, "https://api.example.com", "https://cdn.example.com");
+    expect(result).toContain("Bob: [视频]\nhttps://cdn.example.com/upload/clip.mp4");
+  });
+
+  it("should recursively resolve nested MultipleForward with URLs", () => {
+    const payload = {
+      type: MessageType.MultipleForward,
+      users: [{ uid: "user1", name: "张三" }],
+      msgs: [
+        {
+          from_uid: "user1",
+          payload: {
+            type: MessageType.MultipleForward,
+            users: [{ uid: "user2", name: "李四" }],
+            msgs: [
+              { from_uid: "user2", payload: { type: MessageType.File, name: "secret.docx", url: "upload/secret.docx" } },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = resolveMultipleForwardText(payload, "https://api.example.com");
+    expect(result).toContain("张三: [合并转发]");
+    expect(result).toContain("[合并转发: 聊天记录]");
+    expect(result).toContain("李四: [文件: secret.docx]\nhttps://api.example.com/file/upload/secret.docx");
+  });
+
+  it("should keep placeholders when no apiUrl or cdnUrl provided", () => {
+    const payload = {
+      type: MessageType.MultipleForward,
+      users: [{ uid: "user1", name: "Test" }],
+      msgs: [
+        { from_uid: "user1", payload: { type: MessageType.Image, url: "upload/img.jpg" } },
+      ],
+    };
+
+    const result = resolveMultipleForwardText(payload);
+    expect(result).toBe("[合并转发: 聊天记录]\nTest: [图片]");
+  });
+
+  it("should handle payload.url being empty in nested messages", () => {
+    const payload = {
+      type: MessageType.MultipleForward,
+      users: [{ uid: "user1", name: "Test" }],
+      msgs: [
+        { from_uid: "user1", payload: { type: MessageType.Image } },
+        { from_uid: "user1", payload: { type: MessageType.File, name: "doc.pdf" } },
+      ],
+    };
+
+    const result = resolveMultipleForwardText(payload, "https://api.example.com");
+    expect(result).toContain("Test: [图片]");
+    expect(result).toContain("Test: [文件: doc.pdf]");
+    expect(result).not.toContain("https://");
   });
 });

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -243,26 +243,50 @@ export interface ForwardMessage {
   };
 }
 
+/** Build a full media URL from a relative storage path */
+export function buildMediaUrl(relUrl?: string, apiUrl?: string, cdnUrl?: string): string | undefined {
+  if (!relUrl) return undefined;
+  if (relUrl.startsWith("http")) return relUrl;
+  let storagePath = relUrl;
+  if (storagePath.startsWith("file/preview/")) {
+    storagePath = storagePath.substring("file/preview/".length);
+  } else if (storagePath.startsWith("file/")) {
+    storagePath = storagePath.substring("file/".length);
+  }
+  if (cdnUrl) {
+    const base = cdnUrl.replace(/\/+$/, "");
+    return `${base}/${storagePath}`;
+  }
+  const baseUrl = apiUrl?.replace(/\/+$/, "") ?? "";
+  return `${baseUrl}/file/${storagePath}`;
+}
+
 /** Resolve inner message type to display text for MultipleForward */
-export function resolveInnerMessageText(payload: ForwardMessage["payload"]): string {
+export function resolveInnerMessageText(
+  payload: ForwardMessage["payload"],
+  buildUrl?: (url?: string) => string | undefined,
+): string {
   if (!payload) return "";
+  const fullUrl = buildUrl?.(payload.url);
   switch (payload.type) {
     case MessageType.Text:
       return payload.content ?? "";
     case MessageType.Image:
-      return "[图片]";
+      return fullUrl ? `[图片]\n${fullUrl}` : "[图片]";
     case MessageType.GIF:
-      return "[GIF]";
+      return fullUrl ? `[GIF]\n${fullUrl}` : "[GIF]";
     case MessageType.Voice:
-      return "[语音]";
+      return fullUrl ? `[语音]\n${fullUrl}` : "[语音]";
     case MessageType.Video:
-      return "[视频]";
+      return fullUrl ? `[视频]\n${fullUrl}` : "[视频]";
     case MessageType.Location:
       return "[位置信息]";
     case MessageType.Card:
       return "[名片]";
-    case MessageType.File:
-      return payload.name ? `[文件: ${payload.name}]` : "[文件]";
+    case MessageType.File: {
+      const label = payload.name ? `[文件: ${payload.name}]` : "[文件]";
+      return fullUrl ? `${label}\n${fullUrl}` : label;
+    }
     case MessageType.MultipleForward:
       return "[合并转发]";
     default:
@@ -271,18 +295,27 @@ export function resolveInnerMessageText(payload: ForwardMessage["payload"]): str
 }
 
 /** Resolve MultipleForward payload into readable text */
-export function resolveMultipleForwardText(payload: any): string {
+export function resolveMultipleForwardText(payload: any, apiUrl?: string, cdnUrl?: string): string {
   const users: ForwardUser[] = payload?.users ?? [];
   const msgs: ForwardMessage[] = payload?.msgs ?? [];
   const userMap = new Map<string, string>();
   for (const u of users) {
     if (u.uid && u.name) userMap.set(u.uid, u.name);
   }
+  const buildUrl = (apiUrl || cdnUrl)
+    ? (url?: string) => buildMediaUrl(url, apiUrl, cdnUrl)
+    : undefined;
   const lines: string[] = ["[合并转发: 聊天记录]"];
   for (const m of msgs) {
     const senderName = userMap.get(m.from_uid) ?? m.from_uid;
-    const content = resolveInnerMessageText(m.payload);
-    lines.push(`${senderName}: ${content}`);
+    if (m.payload?.type === MessageType.MultipleForward) {
+      const nested = resolveMultipleForwardText(m.payload, apiUrl, cdnUrl);
+      lines.push(`${senderName}: [合并转发]`);
+      lines.push(nested);
+    } else {
+      const content = resolveInnerMessageText(m.payload, buildUrl);
+      lines.push(`${senderName}: ${content}`);
+    }
   }
   return lines.join("\n");
 }
@@ -290,26 +323,7 @@ export function resolveMultipleForwardText(payload: any): string {
 function resolveContent(payload: BotMessage["payload"], apiUrl?: string, log?: ChannelLogSink, cdnUrl?: string): ResolvedContent {
   if (!payload) return { text: "" };
 
-  const makeFullUrl = (relUrl?: string) => {
-    if (!relUrl) return undefined;
-    if (relUrl.startsWith("http")) return relUrl;
-    // Strip common path prefixes to get the raw storage path
-    let storagePath = relUrl;
-    // Remove "file/preview/" or "file/" prefix
-    if (storagePath.startsWith("file/preview/")) {
-      storagePath = storagePath.substring("file/preview/".length);
-    } else if (storagePath.startsWith("file/")) {
-      storagePath = storagePath.substring("file/".length);
-    }
-    if (cdnUrl) {
-      // CDN direct: public-read, no auth needed, LLM can access directly
-      const base = cdnUrl.replace(/\/+$/, "");
-      return `${base}/${storagePath}`;
-    }
-    // Fallback: Nginx public /file/ path (no auth)
-    const baseUrl = apiUrl?.replace(/\/+$/, "") ?? "";
-    return `${baseUrl}/file/${storagePath}`;
-  };
+  const makeFullUrl = (relUrl?: string) => buildMediaUrl(relUrl, apiUrl, cdnUrl);
 
   switch (payload.type) {
     case MessageType.Text:
@@ -353,7 +367,7 @@ function resolveContent(payload: BotMessage["payload"], apiUrl?: string, log?: C
       return { text: cardText };
     }
     case MessageType.MultipleForward: {
-      return { text: resolveMultipleForwardText(payload) };
+      return { text: resolveMultipleForwardText(payload, apiUrl, cdnUrl) };
     }
     default:
       return { text: payload.content ?? payload.url ?? "" };
@@ -1188,7 +1202,7 @@ export async function handleInboundMessage(params: {
           let body = m.content || resolveApiMessagePlaceholder(m.type, m.name);
           // For MultipleForward, expand the nested messages from full payload
           if (m.type === MessageType.MultipleForward && m.payload) {
-            body = resolveMultipleForwardText(m.payload);
+            body = resolveMultipleForwardText(m.payload, account.config.apiUrl, account.config.cdnUrl);
           }
           const entry: any = {
             sender: m.from_uid,


### PR DESCRIPTION
## Summary

Fix media URLs missing in nested MultipleForward (合并转发) messages.

**Root cause:** `resolveInnerMessageText` only returned placeholder text like `[图片]`, `[文件: name]` without appending the `payload.url`. Additionally, `resolveMultipleForwardText` was called without `apiUrl`/`cdnUrl` parameters in the history message path.

**Changes:**
- Extract `buildMediaUrl` as a module-level utility shared by `resolveContent` and `resolveInnerMessageText`
- Pass `apiUrl`/`cdnUrl` through `resolveMultipleForwardText` → `resolveInnerMessageText` to construct full CDN URLs
- Support recursive expansion of nested MultipleForward messages
- Pass `apiUrl`/`cdnUrl` in the history message code path (`buildInboundUserContextPrefix`)
- Add 22 test cases covering `buildMediaUrl` and `resolveInnerMessageText`

**Tested:** Local deployment verified — Allen confirmed all 6 files/images in merged forward show complete CDN URLs and are accessible.

Fixes dmwork-org/dmwork-pool#120