### PR TITLE
ci: add @dev auto-publish on develop push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,41 @@ jobs:
 
       - name: 🏗️ Build
         run: npm run build
+
+  publish-dev:
+    name: Publish @dev
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    defaults:
+      run:
+        working-directory: openclaw-channel-dmwork
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: openclaw-channel-dmwork/package-lock.json
+
+      - name: 📦 Install
+        run: npm ci
+
+      - name: 🏗️ Build
+        run: npm run build
+
+      - name: 🏷️ Set dev version
+        run: |
+          BASE_VER=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c1-7)
+          DEV_VER="${BASE_VER}-dev.${SHORT_SHA}"
+          npm version "$DEV_VER" --no-git-tag-version
+          echo "📦 Dev version: $DEV_VER"
+
+      - name: 🚀 Publish to npm (dev tag)
+        run: npm publish --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 改动

在 CI workflow 中增加 `publish-dev` job，develop 分支每次 push 自动发布 `@dev` 版本。

### 工作流程

1. develop push → test job 跑测试
2. 测试通过 → publish-dev job 自动发布
3. 版本号格式：`x.y.z-dev.<commit-hash>`（如 `0.5.17-dev.ff3d31a`）
4. 使用 `--tag dev` 发布，不影响 `@latest`

### 安装方式

```bash
# 测试版
npm install openclaw-channel-dmwork@dev

# 正式版（不受影响）
npm install openclaw-channel-dmwork
```

### 注意

- 需要 repo secrets 中已配置 `NPM_TOKEN`（release.yml 已在用，无需额外配置）
- 合并后，PR #153 的下一次 develop push 将自动触发首次 @dev 发布