### PR TITLE
ci: npm 发布成功后通知企业微信群

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,28 @@ jobs:
         run: npm run build
 
       - name: 🏷️ Set dev version
+        id: dev-version
         run: |
           BASE_VER=$(node -p "require('./package.json').version")
           SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c1-7)
           DEV_VER="${BASE_VER}-dev.${SHORT_SHA}"
           npm version "$DEV_VER" --no-git-tag-version
+          echo "version=$DEV_VER" >> "$GITHUB_OUTPUT"
           echo "📦 Dev version: $DEV_VER"
 
       - name: 🚀 Publish to npm (dev tag)
         run: npm publish --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: 📢 Notify WeChat Work
+        if: success()
+        run: |
+          curl -s -X POST "${{ secrets.WECHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "msgtype": "markdown",
+              "markdown": {
+                "content": "## 📦 npm @dev 发布成功\n> **包名：** openclaw-channel-dmwork\n> **版本：** `${{ steps.dev-version.outputs.version }}`\n> **分支：** develop\n> **提交：** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})\n> **安装：** `npm i openclaw-channel-dmwork@dev`\n>\n> [查看 CI](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+              }
+            }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,15 @@ jobs:
           VERSION=${{ steps.version-check.outputs.local }}
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
+
+      - name: 📢 Notify WeChat Work
+        if: steps.version-check.outputs.skip == 'false' && success()
+        run: |
+          curl -s -X POST "${{ secrets.WECHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "msgtype": "markdown",
+              "markdown": {
+                "content": "## 🚀 npm @latest 正式发布\n> **包名：** openclaw-channel-dmwork\n> **版本：** `${{ steps.version-check.outputs.local }}`\n> **分支：** main\n> **提交：** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})\n> **安装：** `npm i openclaw-channel-dmwork`\n>\n> [查看 CI](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+              }
+            }'


### PR DESCRIPTION
## 改动

npm 发布成功后自动发送企业微信群通知。

### 通知内容

**@dev 发布（ci.yml）：**
```
📦 npm @dev 发布成功
包名：openclaw-channel-dmwork
版本：0.5.17-dev.xxx
分支：develop
安装：npm i openclaw-channel-dmwork@dev
```

**@latest 正式发布（release.yml）：**
```
🚀 npm @latest 正式发布
包名：openclaw-channel-dmwork
版本：0.5.18
分支：main
安装：npm i openclaw-channel-dmwork
```

### 前置条件

⚠️ 需要在仓库 Settings → Secrets 中添加：

- **Secret 名称：** `WECHAT_WEBHOOK_URL`
- **Secret 值：** 企业微信 Webhook 完整 URL