### PR TITLE
fix: npm package 发布编译产物而非 TS 源码

### DIFF
--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -2,11 +2,11 @@
   "name": "openclaw-channel-dmwork",
   "version": "0.5.17",
   "description": "DMWork channel plugin for OpenClaw via WuKongIM WebSocket",
-  "main": "index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "files": [
-    "index.ts",
-    "src",
+    "dist",
     "openclaw.plugin.json"
   ],
   "scripts": {

--- a/openclaw-channel-dmwork/tsconfig.json
+++ b/openclaw-channel-dmwork/tsconfig.json
@@ -11,5 +11,5 @@
     "sourceMap": true
   },
   "include": ["index.ts", "src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## 问题

`@dev` 版本（如 `0.5.17-dev.91d4810`）安装后无法运行：
1. `main` 指向 `index.ts`（TypeScript 源码），Node.js 无法直接加载
2. `files` 只包含源码文件，`dist/` 编译产物未打包进 npm 包
3. 导致 `Cannot find module 'ws'` 等模块加载失败

## 修复

| 字段 | 修复前 | 修复后 |
|------|--------|--------|
| `main` | `index.ts` | `dist/index.js` |
| `types` | _(无)_ | `dist/index.d.ts` |
| `files` | `["index.ts", "src", ...]` | `["dist", ...]` |
| `tsconfig.exclude` | — | 新增 `**/*.test.ts` |

## 验证

- `npm run build` ✅ 编译正常
- `npm pack --dry-run` ✅ 包含 `dist/` 产物，不含测试文件
- CI 会自动触发 Build & Test