### PR TITLE
feat: add voice context actions to dmwork_management tool

### DIFF
--- a/openclaw-channel-dmwork/src/agent-tools.test.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.test.ts
@@ -286,6 +286,7 @@ describe("createDmworkManagementTools", () => {
   // -----------------------------------------------------------------------
   describe("accountId resolution", () => {
     it("uses provided accountId", async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["default", "acct2"]);
       vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => ({
         accountId: accountId ?? "default",
         enabled: true,
@@ -596,6 +597,7 @@ describe("createDmworkManagementTools", () => {
     // Multi-account tests
 
     it("voice-context-read uses specified accountId", async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["primary", "secondary"]);
       vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => {
         if (accountId === "secondary") {
           return {
@@ -641,6 +643,7 @@ describe("createDmworkManagementTools", () => {
     });
 
     it("voice-context-update uses specified accountId", async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["primary", "secondary"]);
       vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => {
         if (accountId === "secondary") {
           return {
@@ -684,6 +687,7 @@ describe("createDmworkManagementTools", () => {
     });
 
     it("voice-context-delete uses specified accountId", async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["primary", "secondary"]);
       vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => {
         if (accountId === "secondary") {
           return {
@@ -750,6 +754,54 @@ describe("createDmworkManagementTools", () => {
       });
 
       expect(result.content[0].text).not.toContain("tok-secondary-secret-123");
+    });
+
+    // -- strict accountId validation --
+
+    it("voice-context-read with non-existent accountId returns error", async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["primary", "secondary"]);
+      const execute = getExecute();
+
+      const result = await execute("tc", {
+        action: "voice-context-read",
+        accountId: "nonexistent",
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.error).toContain("Account not found");
+      expect(parsed.error).toContain("nonexistent");
+      expect(getVoiceContext).not.toHaveBeenCalled();
+    });
+
+    it("voice-context-update with non-existent accountId returns error", async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["primary", "secondary"]);
+      const execute = getExecute();
+
+      const result = await execute("tc", {
+        action: "voice-context-update",
+        content: "some terms",
+        accountId: "nonexistent",
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.error).toContain("Account not found");
+      expect(parsed.error).toContain("nonexistent");
+      expect(updateVoiceContext).not.toHaveBeenCalled();
+    });
+
+    it("voice-context-delete with non-existent accountId returns error", async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["primary", "secondary"]);
+      const execute = getExecute();
+
+      const result = await execute("tc", {
+        action: "voice-context-delete",
+        accountId: "nonexistent",
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.error).toContain("Account not found");
+      expect(parsed.error).toContain("nonexistent");
+      expect(deleteVoiceContext).not.toHaveBeenCalled();
     });
 
     // -- botToken not configured --

--- a/openclaw-channel-dmwork/src/agent-tools.test.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.test.ts
@@ -12,6 +12,9 @@ vi.mock("./api-fetch.js", () => ({
   getGroupMembers: vi.fn(),
   getGroupMd: vi.fn(),
   updateGroupMd: vi.fn(),
+  getVoiceContext: vi.fn(),
+  updateVoiceContext: vi.fn(),
+  deleteVoiceContext: vi.fn(),
 }));
 
 vi.mock("./group-md.js", () => ({
@@ -30,6 +33,9 @@ import {
   getGroupMembers,
   getGroupMd,
   updateGroupMd,
+  getVoiceContext,
+  updateVoiceContext,
+  deleteVoiceContext,
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate } from "./group-md.js";
 
@@ -399,6 +405,382 @@ describe("createDmworkManagementTools", () => {
       });
       const result = await execute("tc", { action: "list-groups" });
       expect(result.content[0].text).not.toContain("tok-secret");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // voice-context actions
+  // -----------------------------------------------------------------------
+  describe("voice-context actions", () => {
+    // -- Schema tests --
+
+    it("tool schema includes voice-context-* actions", () => {
+      const tools = createDmworkManagementTools({ cfg: mockCfg });
+      const schema = tools[0].parameters;
+      const actionEnum = schema.properties.action.enum;
+      expect(actionEnum).toContain("voice-context-read");
+      expect(actionEnum).toContain("voice-context-update");
+      expect(actionEnum).toContain("voice-context-delete");
+    });
+
+    it("tool description mentions voice correction context", () => {
+      const tools = createDmworkManagementTools({ cfg: mockCfg });
+      expect(tools[0].description).toContain("voice correction context");
+    });
+
+    // Token leak prevention
+    it("tool schema does not contain botToken", () => {
+      const tools = createDmworkManagementTools({ cfg: mockCfg });
+      const schema = JSON.stringify(tools[0].parameters);
+      expect(schema).not.toContain("botToken");
+      expect(schema).not.toContain("tok-secret");
+    });
+
+    // -- voice-context-read tests --
+
+    it("voice-context-read returns normalized result", async () => {
+      vi.mocked(getVoiceContext).mockResolvedValue({
+        has_context: true,
+        context: "correction terms",
+        updated_at: "2026-04-09T13:00:00+08:00",
+      });
+
+      const result = await getExecute()("tc", { action: "voice-context-read" });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.has_context).toBe(true);
+      expect(parsed.context).toBe("correction terms");
+      expect(parsed.updated_at).toBe("2026-04-09T13:00:00+08:00");
+      // No status field in result
+      expect(parsed.status).toBeUndefined();
+    });
+
+    it("voice-context-read calls getVoiceContext with correct params", async () => {
+      vi.mocked(getVoiceContext).mockResolvedValue({
+        has_context: false,
+        context: "",
+        updated_at: "",
+      });
+
+      await getExecute()("tc", { action: "voice-context-read" });
+
+      expect(getVoiceContext).toHaveBeenCalledWith({
+        apiUrl: "http://api.test",
+        botToken: "tok-secret",
+      });
+    });
+
+    it("voice-context-read result does not leak botToken", async () => {
+      vi.mocked(getVoiceContext).mockResolvedValue({
+        has_context: true,
+        context: "terms",
+        updated_at: "",
+      });
+
+      const result = await getExecute()("tc", { action: "voice-context-read" });
+      expect(result.content[0].text).not.toContain("tok-secret");
+    });
+
+    it("voice-context-read wraps API errors in makeError", async () => {
+      vi.mocked(getVoiceContext).mockRejectedValue(
+        new Error("Bot API GET /v1/bot/voice/context failed (401): invalid token"),
+      );
+
+      const result = await getExecute()("tc", { action: "voice-context-read" });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.error).toContain("voice-context-read failed");
+      // Error must not leak token
+      expect(parsed.error).not.toContain("tok-secret");
+    });
+
+    // -- voice-context-update tests --
+
+    it("voice-context-update succeeds with valid content", async () => {
+      vi.mocked(updateVoiceContext).mockResolvedValue(undefined);
+
+      const result = await getExecute()("tc", {
+        action: "voice-context-update",
+        content: "new correction terms",
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.updated).toBe(true);
+      expect(updateVoiceContext).toHaveBeenCalledWith({
+        apiUrl: "http://api.test",
+        botToken: "tok-secret",
+        content: "new correction terms",
+      });
+    });
+
+    // Empty string rejection tests
+
+    it("voice-context-update rejects undefined content", async () => {
+      const result = await getExecute()("tc", {
+        action: "voice-context-update",
+        // content not provided
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain("must not be empty");
+      expect(updateVoiceContext).not.toHaveBeenCalled();
+    });
+
+    it("voice-context-update rejects null content", async () => {
+      const result = await getExecute()("tc", {
+        action: "voice-context-update",
+        content: null,
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain("must not be empty");
+      expect(updateVoiceContext).not.toHaveBeenCalled();
+    });
+
+    it("voice-context-update rejects empty string content", async () => {
+      const result = await getExecute()("tc", {
+        action: "voice-context-update",
+        content: "",
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain("must not be empty");
+      expect(updateVoiceContext).not.toHaveBeenCalled();
+    });
+
+    it("voice-context-update rejects whitespace-only content", async () => {
+      const result = await getExecute()("tc", {
+        action: "voice-context-update",
+        content: "   \t\n  ",
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain("must not be empty");
+      expect(updateVoiceContext).not.toHaveBeenCalled();
+    });
+
+    it("voice-context-update wraps API errors", async () => {
+      vi.mocked(updateVoiceContext).mockRejectedValue(
+        new Error("Bot API PUT /v1/bot/voice/context failed (400): context exceeds max length"),
+      );
+
+      const result = await getExecute()("tc", {
+        action: "voice-context-update",
+        content: "x".repeat(10001),
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain("voice-context-update failed");
+    });
+
+    // -- voice-context-delete tests --
+
+    it("voice-context-delete succeeds", async () => {
+      vi.mocked(deleteVoiceContext).mockResolvedValue(undefined);
+
+      const result = await getExecute()("tc", { action: "voice-context-delete" });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.deleted).toBe(true);
+      expect(deleteVoiceContext).toHaveBeenCalledWith({
+        apiUrl: "http://api.test",
+        botToken: "tok-secret",
+      });
+    });
+
+    it("voice-context-delete wraps API errors", async () => {
+      vi.mocked(deleteVoiceContext).mockRejectedValue(
+        new Error("Bot API DELETE /v1/bot/voice/context failed (401): invalid token"),
+      );
+
+      const result = await getExecute()("tc", { action: "voice-context-delete" });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain("voice-context-delete failed");
+    });
+
+    // Multi-account tests
+
+    it("voice-context-read uses specified accountId", async () => {
+      vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => {
+        if (accountId === "secondary") {
+          return {
+            accountId: "secondary",
+            enabled: true,
+            configured: true,
+            config: {
+              apiUrl: "http://api-secondary.test",
+              botToken: "tok-secondary",
+              pollIntervalMs: 2000,
+              heartbeatIntervalMs: 30000,
+            },
+          } as any;
+        }
+        return {
+          accountId: "primary",
+          enabled: true,
+          configured: true,
+          config: {
+            apiUrl: "http://api.test",
+            botToken: "tok-secret",
+            pollIntervalMs: 2000,
+            heartbeatIntervalMs: 30000,
+          },
+        } as any;
+      });
+
+      vi.mocked(getVoiceContext).mockResolvedValue({
+        has_context: false,
+        context: "",
+        updated_at: "",
+      });
+
+      await getExecute()("tc", {
+        action: "voice-context-read",
+        accountId: "secondary",
+      });
+
+      expect(getVoiceContext).toHaveBeenCalledWith({
+        apiUrl: "http://api-secondary.test",
+        botToken: "tok-secondary",
+      });
+    });
+
+    it("voice-context-update uses specified accountId", async () => {
+      vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => {
+        if (accountId === "secondary") {
+          return {
+            accountId: "secondary",
+            enabled: true,
+            configured: true,
+            config: {
+              apiUrl: "http://api-secondary.test",
+              botToken: "tok-secondary",
+              pollIntervalMs: 2000,
+              heartbeatIntervalMs: 30000,
+            },
+          } as any;
+        }
+        return {
+          accountId: "primary",
+          enabled: true,
+          configured: true,
+          config: {
+            apiUrl: "http://api.test",
+            botToken: "tok-secret",
+            pollIntervalMs: 2000,
+            heartbeatIntervalMs: 30000,
+          },
+        } as any;
+      });
+
+      vi.mocked(updateVoiceContext).mockResolvedValue(undefined);
+
+      await getExecute()("tc", {
+        action: "voice-context-update",
+        content: "terms",
+        accountId: "secondary",
+      });
+
+      expect(updateVoiceContext).toHaveBeenCalledWith({
+        apiUrl: "http://api-secondary.test",
+        botToken: "tok-secondary",
+        content: "terms",
+      });
+    });
+
+    it("voice-context-delete uses specified accountId", async () => {
+      vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => {
+        if (accountId === "secondary") {
+          return {
+            accountId: "secondary",
+            enabled: true,
+            configured: true,
+            config: {
+              apiUrl: "http://api-secondary.test",
+              botToken: "tok-secondary",
+              pollIntervalMs: 2000,
+              heartbeatIntervalMs: 30000,
+            },
+          } as any;
+        }
+        return {
+          accountId: "primary",
+          enabled: true,
+          configured: true,
+          config: {
+            apiUrl: "http://api.test",
+            botToken: "tok-secret",
+            pollIntervalMs: 2000,
+            heartbeatIntervalMs: 30000,
+          },
+        } as any;
+      });
+
+      vi.mocked(deleteVoiceContext).mockResolvedValue(undefined);
+
+      await getExecute()("tc", {
+        action: "voice-context-delete",
+        accountId: "secondary",
+      });
+
+      expect(deleteVoiceContext).toHaveBeenCalledWith({
+        apiUrl: "http://api-secondary.test",
+        botToken: "tok-secondary",
+      });
+    });
+
+    // Token not leaked on multi-account calls
+    it("multi-account results do not leak secondary botToken", async () => {
+      vi.mocked(resolveDmworkAccount).mockReturnValue({
+        accountId: "secondary",
+        enabled: true,
+        configured: true,
+        config: {
+          apiUrl: "http://api-secondary.test",
+          botToken: "tok-secondary-secret-123",
+          pollIntervalMs: 2000,
+          heartbeatIntervalMs: 30000,
+        },
+      } as any);
+
+      vi.mocked(getVoiceContext).mockResolvedValue({
+        has_context: true,
+        context: "terms",
+        updated_at: "",
+      });
+
+      const result = await getExecute()("tc", {
+        action: "voice-context-read",
+        accountId: "secondary",
+      });
+
+      expect(result.content[0].text).not.toContain("tok-secondary-secret-123");
+    });
+
+    // -- botToken not configured --
+
+    it("returns error when botToken is not configured", async () => {
+      const execute = getExecute();
+      // After tool creation, change mock so execute sees no botToken
+      vi.mocked(resolveDmworkAccount).mockReturnValue({
+        accountId: "no-token",
+        enabled: true,
+        configured: true,
+        config: {
+          apiUrl: "http://api.test",
+          botToken: "",
+          pollIntervalMs: 2000,
+          heartbeatIntervalMs: 30000,
+        },
+      } as any);
+
+      const result = await execute("tc", { action: "voice-context-read" });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain("botToken is not configured");
+    });
+
+    // No alias for voice-context actions
+
+    it("voice-context-* actions do not accept aliases", async () => {
+      // Action name must be exact
+      const result = await getExecute()("tc", { action: "voice-read" });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain("Unknown action");
     });
   });
 });

--- a/openclaw-channel-dmwork/src/agent-tools.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.ts
@@ -123,6 +123,18 @@ export function createDmworkManagementTools(params: {
         // Resolve account
         const accountId =
           requestedAccountId ?? resolveDefaultDmworkAccountId(cfg);
+
+        // Strict validation: reject explicitly requested accountIds that
+        // don't correspond to a real account entry.  Without this check
+        // resolveDmworkAccount() silently falls back to the top-level
+        // channel config, which is a cross-account data isolation risk.
+        if (requestedAccountId) {
+          const knownIds = listDmworkAccountIds(cfg);
+          if (!knownIds.includes(requestedAccountId)) {
+            return makeError(`Account not found: ${requestedAccountId}`);
+          }
+        }
+
         const account = resolveDmworkAccount({ cfg, accountId });
 
         if (!account.config.botToken) {
@@ -287,7 +299,12 @@ async function handleGroupMdUpdate(params: {
 // ---------------------------------------------------------------------------
 
 /**
- * Read the owner's personal voice correction context.
+ * Read the bot owner's personal voice correction context.
+ *
+ * Operates on the owner associated with the resolved bot account.
+ * The `accountId` parameter in the parent execute() selects which bot
+ * (and thus which owner) to operate on.
+ *
  * Returns { has_context, context, updated_at } — normalized by getVoiceContext().
  */
 async function handleVoiceContextRead(params: {
@@ -302,9 +319,16 @@ async function handleVoiceContextRead(params: {
 }
 
 /**
- * Set or update the owner's personal voice correction context.
- * Content validation (empty string rejection) is done in the execute() switch
- * before this handler is called.
+ * Set or replace the bot owner's personal voice correction context.
+ *
+ * Operates on the owner associated with the resolved bot account.
+ * The `accountId` parameter in the parent execute() selects which bot
+ * (and thus which owner) to operate on.
+ *
+ * The `content` param is the full voice-context body (not to be confused
+ * with GROUP.md content used by group-md-update). Content validation
+ * (empty string rejection) is done in the execute() switch before this
+ * handler is called.
  */
 async function handleVoiceContextUpdate(params: {
   apiUrl: string;
@@ -320,7 +344,12 @@ async function handleVoiceContextUpdate(params: {
 }
 
 /**
- * Delete the owner's personal voice correction context.
+ * Delete the bot owner's personal voice correction context.
+ *
+ * Operates on the owner associated with the resolved bot account.
+ * The `accountId` parameter in the parent execute() selects which bot
+ * (and thus which owner) to operate on.
+ *
  * Idempotent — deleting non-existent context is not an error.
  */
 async function handleVoiceContextDelete(params: {

--- a/openclaw-channel-dmwork/src/agent-tools.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.ts
@@ -20,6 +20,9 @@ import {
   getGroupMembers,
   getGroupMd,
   updateGroupMd,
+  getVoiceContext,
+  updateVoiceContext,
+  deleteVoiceContext,
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate } from "./group-md.js";
 
@@ -66,8 +69,9 @@ export function createDmworkManagementTools(params: {
       name: "dmwork_management",
       label: "DMWork Management",
       description:
-        "Manage DMWork groups: list groups the bot belongs to, get group info/members, read or update GROUP.md (group rules/context). " +
-        "Use this tool for any DMWork group management operations.",
+        "Manage DMWork groups and personal voice correction context: list groups, get group info/members, " +
+        "read or update GROUP.md, and manage personal voice correction context (read/update/delete). " +
+        "Use this tool for any DMWork management operations.",
       parameters: {
         type: "object",
         properties: {
@@ -79,6 +83,9 @@ export function createDmworkManagementTools(params: {
               "group-members",
               "group-md-read",
               "group-md-update",
+              "voice-context-read",
+              "voice-context-update",
+              "voice-context-delete",
             ],
             description:
               "The management action to perform.",
@@ -86,12 +93,12 @@ export function createDmworkManagementTools(params: {
           groupId: {
             type: "string",
             description:
-              "The group_no (group ID). Required for all actions except list-groups.",
+              "The group_no (group ID). Required for group-info, group-members, group-md-read, group-md-update.",
           },
           content: {
             type: "string",
             description:
-              "The new GROUP.md content. Required for group-md-update.",
+              "The new content. Required for group-md-update and voice-context-update.",
           },
           accountId: {
             type: "string",
@@ -157,6 +164,31 @@ export function createDmworkManagementTools(params: {
                 content,
                 accountId,
               });
+
+            case "voice-context-read":
+              return await handleVoiceContextRead({ apiUrl, botToken });
+
+            case "voice-context-update": {
+              // Content must NOT be empty. Empty strings have no meaning
+              // for ASR correction.
+              if (
+                content === undefined ||
+                content === null ||
+                content.trim() === ""
+              ) {
+                return makeError(
+                  "content is required for voice-context-update and must not be empty",
+                );
+              }
+              return await handleVoiceContextUpdate({
+                apiUrl,
+                botToken,
+                content,
+              });
+            }
+
+            case "voice-context-delete":
+              return await handleVoiceContextDelete({ apiUrl, botToken });
 
             default:
               return makeError(`Unknown action: ${action}`);
@@ -248,6 +280,58 @@ async function handleGroupMdUpdate(params: {
   });
 
   return makeSuccess({ updated: true, version: result.version });
+}
+
+// ---------------------------------------------------------------------------
+// Voice Context Handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the owner's personal voice correction context.
+ * Returns { has_context, context, updated_at } — normalized by getVoiceContext().
+ */
+async function handleVoiceContextRead(params: {
+  apiUrl: string;
+  botToken: string;
+}): Promise<ToolResult> {
+  const result = await getVoiceContext({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+  });
+  return makeSuccess(result);
+}
+
+/**
+ * Set or update the owner's personal voice correction context.
+ * Content validation (empty string rejection) is done in the execute() switch
+ * before this handler is called.
+ */
+async function handleVoiceContextUpdate(params: {
+  apiUrl: string;
+  botToken: string;
+  content: string;
+}): Promise<ToolResult> {
+  await updateVoiceContext({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+    content: params.content,
+  });
+  return makeSuccess({ updated: true });
+}
+
+/**
+ * Delete the owner's personal voice correction context.
+ * Idempotent — deleting non-existent context is not an error.
+ */
+async function handleVoiceContextDelete(params: {
+  apiUrl: string;
+  botToken: string;
+}): Promise<ToolResult> {
+  await deleteVoiceContext({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+  });
+  return makeSuccess({ deleted: true });
 }
 
 // ---------------------------------------------------------------------------

--- a/openclaw-channel-dmwork/src/api-fetch.test.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.test.ts
@@ -876,6 +876,269 @@ describe("fetchUserInfo", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Voice Context API
+// ---------------------------------------------------------------------------
+import { getVoiceContext, updateVoiceContext, deleteVoiceContext } from "./api-fetch.js";
+
+describe("Voice Context API", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // -- getVoiceContext --
+
+  describe("getVoiceContext", () => {
+    it("sends GET /v1/bot/voice/context with correct auth header", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          status: 200,
+          has_context: true,
+          context: "correction terms",
+          updated_at: "2026-04-09T13:00:00+08:00",
+        }),
+      }) as unknown as typeof fetch;
+
+      const result = await getVoiceContext({
+        apiUrl: "https://api.test/",
+        botToken: "tok-secret",
+      });
+
+      // Verify URL construction (trailing slash stripped)
+      const callUrl = (global.fetch as any).mock.calls[0][0];
+      expect(callUrl).toBe("https://api.test/v1/bot/voice/context");
+
+      // Verify auth header
+      const callInit = (global.fetch as any).mock.calls[0][1];
+      expect(callInit.method).toBe("GET");
+      expect(callInit.headers.Authorization).toBe("Bearer tok-secret");
+
+      // Verify normalized response (status field stripped)
+      expect(result).toEqual({
+        has_context: true,
+        context: "correction terms",
+        updated_at: "2026-04-09T13:00:00+08:00",
+      });
+      // status field must not appear in result
+      expect((result as any).status).toBeUndefined();
+    });
+
+    it("defaults has_context to false when field is missing", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          status: 200,
+          // has_context field intentionally omitted
+          context: "",
+          updated_at: "",
+        }),
+      }) as unknown as typeof fetch;
+
+      const result = await getVoiceContext({
+        apiUrl: "https://api.test",
+        botToken: "tok",
+      });
+
+      expect(result.has_context).toBe(false);
+    });
+
+    it("defaults has_context to false when field is undefined", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          status: 200,
+          has_context: undefined,
+          context: "",
+          updated_at: "",
+        }),
+      }) as unknown as typeof fetch;
+
+      const result = await getVoiceContext({
+        apiUrl: "https://api.test",
+        botToken: "tok",
+      });
+
+      expect(result.has_context).toBe(false);
+    });
+
+    it("returns has_context: false with empty context when not set", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          status: 200,
+          has_context: false,
+          context: "",
+          updated_at: "",
+        }),
+      }) as unknown as typeof fetch;
+
+      const result = await getVoiceContext({
+        apiUrl: "https://api.test",
+        botToken: "tok",
+      });
+
+      expect(result).toEqual({
+        has_context: false,
+        context: "",
+        updated_at: "",
+      });
+    });
+
+    it("throws on non-2xx response with status and body", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        text: vi.fn().mockResolvedValue('{"status":401,"msg":"invalid bot token"}'),
+      }) as unknown as typeof fetch;
+
+      await expect(
+        getVoiceContext({ apiUrl: "https://api.test", botToken: "bad-tok" }),
+      ).rejects.toThrow(/failed \(401\)/);
+    });
+
+    it("includes method and path in error message", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: vi.fn().mockResolvedValue(""),
+      }) as unknown as typeof fetch;
+
+      await expect(
+        getVoiceContext({ apiUrl: "https://api.test", botToken: "tok" }),
+      ).rejects.toThrow("Bot API GET /v1/bot/voice/context failed (500)");
+    });
+  });
+
+  // -- updateVoiceContext --
+
+  describe("updateVoiceContext", () => {
+    it("sends PUT /v1/bot/voice/context with JSON body", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue('{"status":200,"msg":"ok"}'),
+      }) as unknown as typeof fetch;
+
+      await updateVoiceContext({
+        apiUrl: "https://api.test/",
+        botToken: "tok-secret",
+        content: "correction terms",
+      });
+
+      const [callUrl, callInit] = (global.fetch as any).mock.calls[0];
+      expect(callUrl).toBe("https://api.test/v1/bot/voice/context");
+      expect(callInit.method).toBe("PUT");
+      expect(callInit.headers.Authorization).toBe("Bearer tok-secret");
+      expect(callInit.headers["Content-Type"]).toBe("application/json");
+      expect(JSON.parse(callInit.body)).toEqual({ context: "correction terms" });
+    });
+
+    it("throws on 400 (content exceeds max length)", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: vi.fn().mockResolvedValue(
+          '{"status":400,"msg":"context exceeds max length (10000 characters)"}',
+        ),
+      }) as unknown as typeof fetch;
+
+      await expect(
+        updateVoiceContext({
+          apiUrl: "https://api.test",
+          botToken: "tok",
+          content: "x".repeat(10001),
+        }),
+      ).rejects.toThrow(/failed \(400\)/);
+    });
+  });
+
+  // -- deleteVoiceContext --
+
+  describe("deleteVoiceContext", () => {
+    it("sends DELETE /v1/bot/voice/context", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue('{"status":200,"msg":"ok"}'),
+      }) as unknown as typeof fetch;
+
+      await deleteVoiceContext({
+        apiUrl: "https://api.test/",
+        botToken: "tok-secret",
+      });
+
+      const [callUrl, callInit] = (global.fetch as any).mock.calls[0];
+      expect(callUrl).toBe("https://api.test/v1/bot/voice/context");
+      expect(callInit.method).toBe("DELETE");
+      expect(callInit.headers.Authorization).toBe("Bearer tok-secret");
+      // DELETE should not have Content-Type or body
+      expect(callInit.body).toBeUndefined();
+    });
+
+    it("succeeds on deleting non-existent record (idempotent)", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue('{"status":200,"msg":"ok"}'),
+      }) as unknown as typeof fetch;
+
+      // Should not throw
+      await deleteVoiceContext({
+        apiUrl: "https://api.test",
+        botToken: "tok",
+      });
+    });
+  });
+
+  // -- botFetchJson helper --
+
+  describe("botFetchJson (via voice context functions)", () => {
+    it("strips multiple trailing slashes from apiUrl", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          status: 200,
+          has_context: false,
+          context: "",
+          updated_at: "",
+        }),
+      }) as unknown as typeof fetch;
+
+      await getVoiceContext({
+        apiUrl: "https://api.test///",
+        botToken: "tok",
+      });
+
+      const callUrl = (global.fetch as any).mock.calls[0][0];
+      expect(callUrl).toBe("https://api.test/v1/bot/voice/context");
+    });
+
+    it("uses AbortSignal.timeout for request timeout", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          status: 200,
+          has_context: false,
+          context: "",
+          updated_at: "",
+        }),
+      }) as unknown as typeof fetch;
+
+      await getVoiceContext({
+        apiUrl: "https://api.test",
+        botToken: "tok",
+      });
+
+      const callInit = (global.fetch as any).mock.calls[0][1];
+      expect(callInit.signal).toBeDefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // sendMessage — mentionAll serialization
 // ---------------------------------------------------------------------------
 describe("sendMessage — mentionAll serialization", () => {

--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -437,6 +437,117 @@ export async function updateGroupMd(params: {
   return await resp.json();
 }
 
+// ---- Bot JSON Request Helper ----
+
+/**
+ * Generic helper for bot JSON API requests (GET / PUT / DELETE).
+ * Centralizes URL construction, auth headers, timeout, and error handling.
+ *
+ * @throws Error on non-2xx responses with status code and response body.
+ */
+async function botFetchJson<T = void>(params: {
+  apiUrl: string;
+  botToken: string;
+  path: string;
+  method: "GET" | "PUT" | "DELETE";
+  body?: Record<string, unknown>;
+}): Promise<T> {
+  const url = `${params.apiUrl.replace(/\/+$/, "")}${params.path}`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${params.botToken}`,
+  };
+  if (params.body) {
+    Object.assign(headers, DEFAULT_HEADERS);
+  }
+  const resp = await fetch(url, {
+    method: params.method,
+    headers,
+    body: params.body ? JSON.stringify(params.body) : undefined,
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(
+      `Bot API ${params.method} ${params.path} failed (${resp.status}): ${text || resp.statusText}`,
+    );
+  }
+  if (params.method === "GET") {
+    return (await resp.json()) as T;
+  }
+  return undefined as T;
+}
+
+// ---- Voice Context API ----
+
+/**
+ * Query the owner's personal voice correction context.
+ * GET /v1/bot/voice/context
+ *
+ * Returns normalized response with defensive defaults:
+ * - has_context defaults to false if missing from backend response
+ * - context defaults to empty string if missing
+ * - updated_at defaults to empty string if missing
+ */
+export async function getVoiceContext(params: {
+  apiUrl: string;
+  botToken: string;
+}): Promise<{ has_context: boolean; context: string; updated_at: string }> {
+  const raw = await botFetchJson<Record<string, unknown>>({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+    path: "/v1/bot/voice/context",
+    method: "GET",
+  });
+
+  // Defensive normalization — do not blindly pass-through.
+  // If backend omits has_context, treat as false.
+  return {
+    has_context: raw.has_context === true,
+    context: typeof raw.context === "string" ? raw.context : "",
+    updated_at: typeof raw.updated_at === "string" ? raw.updated_at : "",
+  };
+}
+
+/**
+ * Set the owner's personal voice correction context (PUT upsert).
+ * PUT /v1/bot/voice/context
+ *
+ * Content must not be empty — empty strings are rejected at the adapter
+ * validation layer (agent-tools.ts) before this function is called.
+ * Backend also rejects empty context with 400.
+ */
+export async function updateVoiceContext(params: {
+  apiUrl: string;
+  botToken: string;
+  content: string;
+}): Promise<void> {
+  await botFetchJson({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+    path: "/v1/bot/voice/context",
+    method: "PUT",
+    body: { context: params.content },
+  });
+}
+
+/**
+ * Delete the owner's personal voice correction context.
+ * DELETE /v1/bot/voice/context
+ *
+ * Idempotent — deleting a non-existent record returns 200.
+ */
+export async function deleteVoiceContext(params: {
+  apiUrl: string;
+  botToken: string;
+}): Promise<void> {
+  await botFetchJson({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+    path: "/v1/bot/voice/context",
+    method: "DELETE",
+  });
+}
+
 /**
  * 获取频道历史消息（用于注入上下文）
  * @param params.log - Optional logger for consistent logging with OpenClaw log system


### PR DESCRIPTION
## Summary

Extend the `dmwork_management` agent tool with personal voice correction context actions.

### Changes
- Add `voice-context-read` action — read bot owner's voice context
- Add `voice-context-update` action — upsert voice context
- Add `voice-context-delete` action — delete voice context
- New `api-fetch.ts` helpers: `getVoiceContext`, `updateVoiceContext`, `deleteVoiceContext`
- Updated tool description and parameter schema

### Dependencies
- Backend: dmwork-org/dmworkim#916

Closes #160