### PR TITLE
fix: 支持子区(CommunityTopic) channelType=5 全链路

### DIFF
--- a/openclaw-channel-dmwork/src/actions.ts
+++ b/openclaw-channel-dmwork/src/actions.ts
@@ -40,9 +40,17 @@ export function parseTarget(
   currentChannelId?: string,
   knownGroupIds?: Set<string>,
 ): { channelId: string; channelType: ChannelType } {
+  const THREAD_SEP = "____";
+
   // Explicit prefixes always win
-  if (target.startsWith("group:"))
-    return { channelId: target.slice(6), channelType: ChannelType.Group };
+  if (target.startsWith("group:")) {
+    const channelId = target.slice(6);
+    // groupNo____shortId → CommunityTopic
+    if (channelId.includes(THREAD_SEP)) {
+      return { channelId, channelType: ChannelType.CommunityTopic };
+    }
+    return { channelId, channelType: ChannelType.Group };
+  }
   if (target.startsWith("user:"))
     return { channelId: target.slice(5), channelType: ChannelType.DM };
 
@@ -50,7 +58,12 @@ export function parseTarget(
   let bareId = target;
   if (bareId.startsWith("dmwork:")) bareId = bareId.slice(7);
 
-  // Bare ID: check knownGroupIds
+  // Thread channel ID (groupNo____shortId)
+  if (bareId.includes(THREAD_SEP)) {
+    return { channelId: bareId, channelType: ChannelType.CommunityTopic };
+  }
+
+  // Bare ID: check knownGroupIds, also check parent group for thread context
   const isGroup = knownGroupIds?.has(bareId) ?? false;
   return { channelId: bareId, channelType: isGroup ? ChannelType.Group : ChannelType.DM };
 }
@@ -171,7 +184,7 @@ async function handleSend(params: {
     let mentionEntities: MentionEntity[] = [];
     let finalMessage = message;
 
-    if (channelType === ChannelType.Group) {
+    if (channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic) {
       // v2 path: convert @[uid:name] → @name + entities
       if (uidToNameMap) {
         const structuredMentions = parseStructuredMentions(finalMessage);
@@ -263,9 +276,11 @@ async function handleRead(params: {
   // ====== Permission check ======
   // Strip dmwork: prefix from currentChannelId for comparison
   const bareCurrentChannelId = currentChannelId?.replace(/^dmwork:/, "");
-  // Infer the current channel type: if the bare ID is a known group, it's Group; otherwise DM
+  // Infer the current channel type
   const knownGroups = getKnownGroupIds();
-  const currentChannelType = knownGroups.has(bareCurrentChannelId ?? "") ? ChannelType.Group : ChannelType.DM;
+  const currentChannelType = bareCurrentChannelId?.includes("____")
+    ? ChannelType.CommunityTopic
+    : knownGroups.has(bareCurrentChannelId ?? "") ? ChannelType.Group : ChannelType.DM;
   // Must match both channelId AND channelType to be considered the same channel
   const isSameChannel = !!(bareCurrentChannelId && channelId === bareCurrentChannelId && channelType === currentChannelType);
 

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -303,7 +303,9 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       let accountId = ctx.accountId ?? DEFAULT_ACCOUNT_ID;
       const currentChannelId = ctx.toolContext?.currentChannelId;
       if (currentChannelId) {
-        const rawGroupNo = currentChannelId.replace(/^dmwork:/, '');
+        const rawId = currentChannelId.replace(/^dmwork:/, '');
+        // 子区 channelID (groupNo____shortId) → 提取父群 groupNo
+        const rawGroupNo = rawId.includes("____") ? rawId.split("____")[0] : rawId;
         // Only correct if current accountId is NOT registered for this group
         // (i.e., framework passed a clearly wrong accountId).
         // For shared groups (multiple bots), don't override — respect framework's choice.

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -239,8 +239,9 @@ export function resolveOutboundAccountId(ctxTo: string, fallbackAccountId: strin
     if (atIdx >= 0) targetForParse = "group:" + groupPart.slice(0, atIdx);
   }
   const { channelId, channelType } = parseTarget(targetForParse, undefined, getKnownGroupIds());
-  if (channelType === ChannelType.Group) {
-    const correctAccountId = resolveAccountForGroup(channelId);
+  if (channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic) {
+    const groupId = channelType === ChannelType.CommunityTopic ? channelId.split("____")[0] : channelId;
+    const correctAccountId = resolveAccountForGroup(groupId);
     if (correctAccountId) return correctAccountId;
   }
   return fallbackAccountId;
@@ -414,7 +415,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       let mentionEntities: MentionEntity[] = [];
       let finalContent = content;
 
-      if (channelType === ChannelType.Group) {
+      if (channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic) {
         const accountMemberMap = getOrCreateMemberMap(accountId);
         const uidToNameMap = getOrCreateUidToNameMap(accountId);
 
@@ -854,8 +855,11 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
           // Track cache activity for cleanup
           if (msg.channel_id) {
             touchCache(account.accountId, msg.channel_id);
-            if (msg.channel_type === ChannelType.Group) {
-              registerGroupToAccount(msg.channel_id, account.accountId);
+            if (msg.channel_type === ChannelType.Group || msg.channel_type === ChannelType.CommunityTopic) {
+              const groupId = msg.channel_type === ChannelType.CommunityTopic
+                ? msg.channel_id.split("____")[0]
+                : msg.channel_id;
+              registerGroupToAccount(groupId, account.accountId);
             }
           }
 

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -997,7 +997,7 @@ export async function handleInboundMessage(params: {
   const isGroup =
     typeof message.channel_id === "string" &&
     message.channel_id.length > 0 &&
-    message.channel_type === ChannelType.Group;
+    (message.channel_type === ChannelType.Group || message.channel_type === ChannelType.CommunityTopic);
 
   // --- GROUP.md: register group→account mapping and handle structured events ---
   if (isGroup && message.channel_id) {
@@ -1191,7 +1191,7 @@ export async function handleInboundMessage(params: {
           apiUrl: account.config.apiUrl,
           botToken: account.config.botToken,
           channelId: message.channel_id!,
-          channelType: ChannelType.Group,
+          channelType: message.channel_type ?? ChannelType.Group,
           limit: fetchLimit,
           log,
         });
@@ -1399,7 +1399,7 @@ export async function handleInboundMessage(params: {
   statusSink?.({ lastInboundAt: Date.now(), lastError: null });
 
   const replyChannelId = isGroup ? message.channel_id! : message.from_uid;
-  const replyChannelType = isGroup ? ChannelType.Group : ChannelType.DM;
+  const replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;
 
   // 已读回执 + 正在输入 — fire-and-forget
   log?.info?.(`dmwork: sending readReceipt+typing to channel=${replyChannelId} type=${replyChannelType} apiUrl=${account.config.apiUrl}`);

--- a/openclaw-channel-dmwork/src/permission.ts
+++ b/openclaw-channel-dmwork/src/permission.ts
@@ -61,5 +61,24 @@ export async function checkPermission(params: {
     return { allowed: true };
   }
 
+  if (channelType === ChannelType.CommunityTopic) {
+    // Thread/子区: channelId 格式为 groupNo____shortId，校验父群成员身份
+    const groupNo = channelId.split("____")[0];
+    if (!groupNo) {
+      return { allowed: false, reason: "无效的子区频道ID" };
+    }
+    const members = await getGroupMembersFromCache({
+      apiUrl: params.apiUrl,
+      botToken: params.botToken,
+      groupNo,
+      log: params.log,
+    });
+    const memberUids = members.map((m) => m.uid).filter(Boolean);
+    if (!memberUids.includes(requesterSenderId)) {
+      return { allowed: false, reason: "你不在该群中，无权访问子区" };
+    }
+    return { allowed: true };
+  }
+
   return { allowed: false, reason: `不支持的频道类型: ${channelType}` };
 }

--- a/openclaw-channel-dmwork/src/types.ts
+++ b/openclaw-channel-dmwork/src/types.ts
@@ -112,6 +112,7 @@ export interface SendMessageResult {
 export enum ChannelType {
   DM = 1,
   Group = 2,
+  CommunityTopic = 5, // Thread/子区
 }
 
 /** Message content types */


### PR DESCRIPTION
## Summary

修复 adapter 不识别子区消息（channelType=5），导致 Bot 在子区内无法正常收发消息。

## 问题

- Bot 在子区收到消息后回复到私聊而不是子区
- `parseTarget` 不识别 `groupNo____shortId` 格式，子区消息被当作 Group 或 DM
- 多 bot 场景下子区的 account 纠偏用完整 channelID 查映射表，查不到父群
- `handleRead` 的 same-channel 判断在子区上下文失效

## 改动

| 文件 | 改动 |
|------|------|
| `types.ts` | ChannelType 新增 `CommunityTopic = 5` |
| `permission.ts` | 子区权限检查：从 channelID 解析父群 groupNo 校验成员身份 |
| `inbound.ts` | `isGroup` 包含 CommunityTopic，回复保持原始 channelType |
| `channel.ts` | 消息路由、account 纠偏、resolveOutboundAccountId 支持子区 |
| `actions.ts` | `parseTarget` 识别 `____` 分隔符返回 CommunityTopic；handleSend/handleRead 支持子区 |

## Test plan

- [x] TypeScript 编译通过
- [x] 452 个 vitest 用例全部通过
- [x] 本地测试：子区内发消息 Bot 在子区内回复（不再跳到私聊）
- [ ] 补充 parseTarget/same-channel/account 纠偏的子区单测（P2，后续补充）

🤖 Generated with [Claude Code](https://claude.ai/code)