### PR TITLE
release: bump openclaw-channel-dmwork to 0.5.18

### DIFF
--- a/openclaw-channel-dmwork/package-lock.json
+++ b/openclaw-channel-dmwork/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-channel-dmwork",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-channel-dmwork",
-      "version": "0.5.17",
+      "version": "0.5.18",
       "bundleDependencies": [
         "cos-nodejs-sdk-v5",
         "crypto-js",

--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-channel-dmwork",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "description": "DMWork channel plugin for OpenClaw via WuKongIM WebSocket",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump for npm release.