### PR TITLE
fix: openclaw.extensions point to dist/index.js instead of index.ts

### DIFF
--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -37,7 +37,7 @@
     "id": "openclaw-channel-dmwork",
     "type": "channel",
     "extensions": [
-      "index.ts"
+      "dist/index.js"
     ]
   },
   "bundledDependencies": [


### PR DESCRIPTION
## Problem

The published npm package only contains compiled `dist/` files (`files: ["dist", "openclaw.plugin.json"]`), but `openclaw.extensions` was still pointing to `index.ts` (source file).

This causes the following error when installing via `openclaw plugins install`:
```
extension entry escapes package directory
```

## Fix

Change `openclaw.extensions` from `index.ts` to `dist/index.js` to match the actual published package structure.

## Test plan
- [ ] `npm pack` and verify `openclaw.extensions` resolves correctly inside the tarball
- [ ] `openclaw plugins install openclaw-channel-dmwork` succeeds without errors