### PR TITLE
fix: align agent-tools accountId resolution with channel.ts fallback chain

### DIFF
--- a/openclaw-channel-dmwork/src/agent-tools.test.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.test.ts
@@ -318,6 +318,52 @@ describe("createDmworkManagementTools", () => {
       });
     });
 
+    it("multi-account: falls back to first account when no accountId and no default", async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["bot-a", "bot-b"]);
+      vi.mocked(resolveDefaultDmworkAccountId).mockReturnValue(null as any);
+      vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => ({
+        accountId,
+        enabled: true,
+        configured: true,
+        config: {
+          botToken: `tok-${accountId}`,
+          apiUrl: `http://api-${accountId}.test`,
+          pollIntervalMs: 2000,
+          heartbeatIntervalMs: 30000,
+        },
+      }));
+      vi.mocked(fetchBotGroups).mockResolvedValue([]);
+      const execute = getExecute();
+      await execute("tc", { action: "list-groups" });
+      expect(fetchBotGroups).toHaveBeenCalledWith({
+        apiUrl: "http://api-bot-a.test",
+        botToken: "tok-bot-a",
+      });
+    });
+
+    it('multi-account: accountId="default" falls back to first account', async () => {
+      vi.mocked(listDmworkAccountIds).mockReturnValue(["bot-a", "bot-b"]);
+      vi.mocked(resolveDefaultDmworkAccountId).mockReturnValue(null as any);
+      vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => ({
+        accountId,
+        enabled: true,
+        configured: true,
+        config: {
+          botToken: `tok-${accountId}`,
+          apiUrl: `http://api-${accountId}.test`,
+          pollIntervalMs: 2000,
+          heartbeatIntervalMs: 30000,
+        },
+      }));
+      vi.mocked(fetchBotGroups).mockResolvedValue([]);
+      const execute = getExecute();
+      await execute("tc", { action: "list-groups", accountId: "default" });
+      expect(fetchBotGroups).toHaveBeenCalledWith({
+        apiUrl: "http://api-bot-a.test",
+        botToken: "tok-bot-a",
+      });
+    });
+
     it("resolves correct account in multi-account setup", async () => {
       vi.mocked(listDmworkAccountIds).mockReturnValue(["primary", "secondary"]);
       vi.mocked(resolveDmworkAccount).mockImplementation(({ accountId }: any) => {

--- a/openclaw-channel-dmwork/src/agent-tools.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.ts
@@ -40,6 +40,10 @@ import { broadcastGroupMdUpdate } from "./group-md.js";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 
+// Matches DEFAULT_ACCOUNT_ID from openclaw/plugin-sdk — the semantic alias
+// used by the framework when no explicit account is specified.
+const DEFAULT_ACCOUNT_ID = "default";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -178,17 +182,14 @@ export function createDmworkManagementTools(params: {
           | string
           | undefined;
         const content = (args.content ?? args.message) as string | undefined;
-        const requestedAccountId = args.accountId as string | undefined;
+        const rawAccountId = args.accountId as string | undefined;
 
-        // Resolve account — multi-bot setups require explicit accountId
-        const defaultAccountId = resolveDefaultDmworkAccountId(cfg);
-        const accountId = requestedAccountId ?? defaultAccountId;
-
-        if (!accountId) {
-          return makeError(
-            "accountId is required. Check your agent.md for your assigned accountId."
-          );
-        }
+        // Treat DEFAULT_ACCOUNT_ID ("default") as a semantic alias — not a
+        // real account key — so normalise it to "unspecified".
+        const requestedAccountId =
+          rawAccountId && rawAccountId !== DEFAULT_ACCOUNT_ID
+            ? rawAccountId
+            : undefined;
 
         // Strict validation: reject explicitly requested accountIds that
         // don't correspond to a real account entry.
@@ -198,6 +199,14 @@ export function createDmworkManagementTools(params: {
             return makeError(`Account not found: ${requestedAccountId}`);
           }
         }
+
+        // Four-level fallback (consistent with channel.ts):
+        //   1. explicitly requested id  2. configured default  3. first account  4. DEFAULT_ACCOUNT_ID
+        const accountId =
+          requestedAccountId ??
+          resolveDefaultDmworkAccountId(cfg) ??
+          listDmworkAccountIds(cfg)[0] ??
+          DEFAULT_ACCOUNT_ID;
 
         const account = resolveDmworkAccount({ cfg, accountId });
 


### PR DESCRIPTION
## Problem

`dmwork_management` tool fails to resolve `accountId` in multi-account setups (#172):

1. Passing `accountId="default"` → `Account not found` (strict validation rejects the semantic alias)
2. Omitting `accountId` → `accountId is required` (`resolveDefaultDmworkAccountId` returns `null` for multi-account, no fallback)

## Root Cause

`agent-tools.ts` execute method has a simpler accountId resolution than `channel.ts`:

| | `channel.ts:361` | `agent-tools.ts` (before) |
|---|---|---|
| Fallback chain | `resolveDefault → listIds()[0] → DEFAULT_ACCOUNT_ID` | `resolveDefault` only |
| `"default"` handling | Resolved through `resolveDmworkAccount` internal fallback | Treated as literal account key, rejected by strict validation |

## Fix

- Normalize `DEFAULT_ACCOUNT_ID` (`"default"`) as a semantic alias — treat it as "use the default account" rather than a literal account key
- Add four-level fallback chain matching `channel.ts:361`: `requestedAccountId → resolveDefault → firstAccount → DEFAULT_ACCOUNT_ID`
- Strict validation only applies to non-`"default"` explicitly requested IDs

## Changes

- `openclaw-channel-dmwork/src/agent-tools.ts` — Fix accountId resolution logic (~15 lines)
- `openclaw-channel-dmwork/src/agent-tools.test.ts` — Add 2 test cases for multi-account fallback scenarios

## Testing

All 52 tests pass (50 existing + 2 new):
- `multi-account: falls back to first account when no accountId and no default`
- `multi-account: accountId="default" falls back to first account`

Fixes #172