### PR TITLE
feat: CLI installer for npx one-command install/update/doctor

### DIFF
--- a/openclaw-channel-dmwork/.gitignore
+++ b/openclaw-channel-dmwork/.gitignore
@@ -4,5 +4,6 @@ dist/
 *.js.map
 *.d.ts
 !vitest.config.ts
+!bin/**
 .claude/
 CLAUDE.md

--- a/openclaw-channel-dmwork/README.md
+++ b/openclaw-channel-dmwork/README.md
@@ -7,42 +7,89 @@ Repository: https://github.com/yujiawei/dmwork-adapters
 ## Prerequisites
 
 - Node.js >= 18
-- OpenClaw installed and configured
+- OpenClaw installed and configured (`npm i -g openclaw`)
 - A bot created via BotFather in DMWork (send `/newbot` to BotFather)
 
-## Install as OpenClaw Extension
+## Install
+
+One-command install via npx (BotFather will provide the exact command):
 
 ```bash
-git clone https://github.com/yujiawei/dmwork-adapters.git
-cp -r dmwork-adapters/openclaw-channel-dmwork ~/.openclaw/extensions/dmwork
-cd ~/.openclaw/extensions/dmwork && npm install
+npx -y openclaw-channel-dmwork install \
+  --bot-token bf_your_token_here \
+  --api-url http://your-server:8090 \
+  --account-id my_bot
 ```
 
-## Configure
+This will:
+1. Install the plugin via `openclaw plugins install`
+2. Configure the bot account in `channels.dmwork.accounts.<account-id>`
+3. Restart the OpenClaw gateway
 
-Add to your `~/.openclaw/config.yaml`:
+### Interactive install
 
-```yaml
-channels:
-  dmwork:
-    botToken: "bf_your_token_here"   # Bot token from BotFather
-    apiUrl: "http://your-server:8090" # DMWork server API URL
-    # wsUrl: "ws://your-server:5200" # Optional — auto-detected from register if omitted
+Run without arguments to be prompted for each value:
+
+```bash
+npx -y openclaw-channel-dmwork install
 ```
 
-Configuration fields:
+## CLI Commands
+
+```bash
+# Update the plugin to the latest version
+npx -y openclaw-channel-dmwork update
+
+# Diagnose plugin health
+npx -y openclaw-channel-dmwork doctor
+
+# Uninstall (keeps bot config by default)
+npx -y openclaw-channel-dmwork uninstall
+
+# Remove a single bot account
+npx -y openclaw-channel-dmwork remove-account --account-id my_bot
+```
+
+### OpenClaw internal commands
+
+After installation, these commands are available inside OpenClaw:
+
+```
+/dmwork_doctor              # Check plugin status and connectivity
+/dmwork_doctor my_bot       # Check a specific account
+```
+
+## Configuration
+
+Bot accounts are stored in `~/.openclaw/openclaw.json` under `channels.dmwork.accounts`:
+
+```json
+{
+  "channels": {
+    "dmwork": {
+      "apiUrl": "http://your-server:8090",
+      "accounts": {
+        "my_bot": {
+          "botToken": "bf_your_token_here",
+          "apiUrl": "http://your-server:8090"
+        },
+        "another_bot": {
+          "botToken": "bf_another_token",
+          "apiUrl": "https://im.example.com/api"
+        }
+      }
+    }
+  }
+}
+```
+
+Configuration fields per account:
 
 - `botToken` (required): Bot token from BotFather (`bf_` prefix)
-- `apiUrl` (required): DMWork server API URL, e.g. `http://192.168.1.100:8090`
-- `wsUrl` (optional): DMWORK WebSocket URL. Auto-detected from register if omitted.
-
-## Run
-
-```bash
-openclaw gateway restart
-```
-
-The plugin is loaded automatically by OpenClaw when the gateway starts.
+- `apiUrl` (required): DMWork server API URL
+- `wsUrl` (optional): DMWORK WebSocket URL. Auto-detected if omitted.
+- `requireMention` (optional): Only respond when @mentioned in groups
+- `historyLimit` (optional): Group chat history message limit (default: 20)
 
 ## What it does
 
@@ -60,6 +107,7 @@ The `index.ts` exports a standard OpenClaw plugin object. When loaded by OpenCla
 - `register(api)` is called automatically
 - `api.runtime` is injected for logging and lifecycle management
 - `api.registerChannel()` registers the DMWork channel plugin
+- `api.registerCommand()` registers `/dmwork_doctor`
 - Configuration is read from `channels.dmwork` in OpenClaw's config
 
 The plugin uses the `ChannelPlugin` SDK interface with support for:

--- a/openclaw-channel-dmwork/README.md
+++ b/openclaw-channel-dmwork/README.md
@@ -43,7 +43,7 @@ npx -y openclaw-channel-dmwork update
 # Diagnose plugin health
 npx -y openclaw-channel-dmwork doctor
 
-# Uninstall (keeps bot config by default)
+# Uninstall (removes plugin and all bot configs)
 npx -y openclaw-channel-dmwork uninstall
 
 # Remove a single bot account

--- a/openclaw-channel-dmwork/bin/dmwork.js
+++ b/openclaw-channel-dmwork/bin/dmwork.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/cli/index.js";

--- a/openclaw-channel-dmwork/cli/config-preserve.test.ts
+++ b/openclaw-channel-dmwork/cli/config-preserve.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  copyFileSync: vi.fn(),
+}));
+
+const mockExecFileSync = vi.mocked(execFileSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockCopyFileSync = vi.mocked(copyFileSync);
+
+async function loadModule() {
+  vi.resetModules();
+  return await import("./openclaw-cli.js");
+}
+
+const SAMPLE_CONFIG = {
+  channels: {
+    dmwork: {
+      apiUrl: "http://localhost:8090",
+      accounts: {
+        my_bot: { botToken: "bf_real_secret_token", apiUrl: "http://localhost:8090" },
+        other_bot: { botToken: "bf_other_secret", apiUrl: "http://other:8090" },
+      },
+    },
+  },
+};
+
+describe("saveChannelConfigFromFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should read channels.dmwork with real secrets from file", async () => {
+    const { saveChannelConfigFromFile } = await loadModule();
+    mockExecFileSync.mockReturnValue("/home/user/.openclaw/openclaw.json");
+    mockReadFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
+
+    const saved = saveChannelConfigFromFile();
+
+    expect(saved).not.toBeNull();
+    expect((saved as any).accounts.my_bot.botToken).toBe("bf_real_secret_token");
+    expect((saved as any).accounts.other_bot.botToken).toBe("bf_other_secret");
+  });
+
+  it("should return null when channels.dmwork does not exist", async () => {
+    const { saveChannelConfigFromFile } = await loadModule();
+    mockExecFileSync.mockReturnValue("/home/user/.openclaw/openclaw.json");
+    mockReadFileSync.mockReturnValue(JSON.stringify({ channels: {} }));
+
+    expect(saveChannelConfigFromFile()).toBeNull();
+  });
+
+  it("should return null when file read fails", async () => {
+    const { saveChannelConfigFromFile } = await loadModule();
+    mockExecFileSync.mockReturnValue("/home/user/.openclaw/openclaw.json");
+    mockReadFileSync.mockImplementation(() => { throw new Error("ENOENT"); });
+
+    expect(saveChannelConfigFromFile()).toBeNull();
+  });
+});
+
+describe("restoreChannelConfigToFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should write channels.dmwork back to file with backup", async () => {
+    const { restoreChannelConfigToFile } = await loadModule();
+    mockExecFileSync.mockReturnValue("/home/user/.openclaw/openclaw.json");
+    mockReadFileSync.mockReturnValue(JSON.stringify({ channels: {}, plugins: {} }));
+
+    const dmworkConfig = SAMPLE_CONFIG.channels.dmwork;
+    restoreChannelConfigToFile(dmworkConfig as any);
+
+    // Should create backup
+    expect(mockCopyFileSync).toHaveBeenCalledWith(
+      "/home/user/.openclaw/openclaw.json",
+      "/home/user/.openclaw/openclaw.json.bak",
+    );
+
+    // Should write merged config
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const writtenContent = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(writtenContent.channels.dmwork.accounts.my_bot.botToken).toBe("bf_real_secret_token");
+    // Should preserve other config sections
+    expect(writtenContent.plugins).toEqual({});
+  });
+});
+
+describe("config preserve on install --force failure", () => {
+  it("should restore config even when pluginsInstall throws", async () => {
+    const mod = await loadModule();
+
+    // getConfigFilePath returns path
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") {
+        return "/home/user/.openclaw/openclaw.json";
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "install") {
+        throw new Error("network error during install");
+      }
+      return "";
+    });
+
+    // saveChannelConfigFromFile reads file
+    mockReadFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
+
+    const saved = mod.saveChannelConfigFromFile();
+    expect(saved).not.toBeNull();
+
+    // Simulate install --force with try/finally
+    let installFailed = false;
+    try {
+      mod.pluginsInstall("test-plugin", true);
+    } catch {
+      installFailed = true;
+    } finally {
+      if (saved) {
+        // Reset read mock for restore
+        mockReadFileSync.mockReturnValue(JSON.stringify({ channels: {} }));
+        mod.restoreChannelConfigToFile(saved);
+      }
+    }
+
+    expect(installFailed).toBe(true);
+    // Config should have been written back
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    const restored = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(restored.channels.dmwork.accounts.my_bot.botToken).toBe("bf_real_secret_token");
+  });
+});
+
+describe("config preserve on uninstall failure", () => {
+  it("should restore config even when pluginsUninstall throws", async () => {
+    const mod = await loadModule();
+
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") {
+        return "/home/user/.openclaw/openclaw.json";
+      }
+      if (argsArr[0] === "plugins" && argsArr[1] === "uninstall") {
+        throw new Error("uninstall partially failed");
+      }
+      return "";
+    });
+
+    mockReadFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
+
+    const saved = mod.saveChannelConfigFromFile();
+    expect(saved).not.toBeNull();
+
+    let uninstallFailed = false;
+    try {
+      mod.pluginsUninstall("test-plugin", true);
+    } catch {
+      uninstallFailed = true;
+    } finally {
+      if (saved) {
+        mockReadFileSync.mockReturnValue(JSON.stringify({ channels: {} }));
+        mod.restoreChannelConfigToFile(saved);
+      }
+    }
+
+    expect(uninstallFailed).toBe(true);
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    const restored = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(restored.channels.dmwork.accounts.my_bot.botToken).toBe("bf_real_secret_token");
+  });
+});

--- a/openclaw-channel-dmwork/cli/doctor.test.ts
+++ b/openclaw-channel-dmwork/cli/doctor.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  type ConfigReader,
+  runDoctorChecks,
+  formatDoctorResult,
+} from "./doctor.js";
+
+/** Stub config reader that returns values from a plain object. */
+function stubReader(data: Record<string, any>): ConfigReader {
+  return {
+    get(path: string): string | null {
+      const parts = path.split(".");
+      let cur: any = data;
+      for (const p of parts) {
+        if (cur == null || typeof cur !== "object") return null;
+        cur = cur[p];
+      }
+      return cur == null ? null : String(cur);
+    },
+    getJson(path: string): any {
+      const parts = path.split(".");
+      let cur: any = data;
+      for (const p of parts) {
+        if (cur == null || typeof cur !== "object") return null;
+        cur = cur[p];
+      }
+      return cur ?? null;
+    },
+  };
+}
+
+describe("doctor checks (in-process mode)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should PASS when accounts are configured with valid token", async () => {
+    const reader = stubReader({
+      channels: {
+        dmwork: {
+          apiUrl: "http://localhost:8090",
+          accounts: {
+            my_bot: {
+              botToken: "bf_test123",
+              apiUrl: "http://localhost:8090",
+            },
+          },
+        },
+      },
+      session: { dmScope: "per-account-channel-peer" },
+    });
+
+    // Mock fetch for API probe
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const result = await runDoctorChecks({
+      reader,
+      inProcess: true,
+    });
+
+    globalThis.fetch = origFetch;
+
+    const accountCheck = result.checks.find((c) => c.name === "Accounts configured");
+    expect(accountCheck?.status).toBe("PASS");
+
+    const tokenCheck = result.checks.find((c) => c.name === "my_bot: botToken");
+    expect(tokenCheck?.status).toBe("PASS");
+
+    const scopeCheck = result.checks.find((c) => c.name === "session.dmScope");
+    expect(scopeCheck?.status).toBe("PASS");
+  });
+
+  it("should WARN when botToken does not start with bf_ in-process", async () => {
+    const reader = stubReader({
+      channels: {
+        dmwork: {
+          accounts: {
+            bad_bot: { botToken: "invalid_token", apiUrl: "http://localhost" },
+          },
+        },
+      },
+      session: { dmScope: "per-account-channel-peer" },
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const result = await runDoctorChecks({ reader, inProcess: true });
+
+    globalThis.fetch = vi.fn() as any;
+
+    const tokenCheck = result.checks.find((c) => c.name === "bad_bot: botToken format");
+    expect(tokenCheck?.status).toBe("WARN");
+  });
+
+  it("should fallback to legacy flat config when no accounts", async () => {
+    const reader = stubReader({
+      channels: {
+        dmwork: {
+          botToken: "bf_legacy",
+          apiUrl: "http://localhost:8090",
+        },
+      },
+      session: {},
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const result = await runDoctorChecks({ reader, inProcess: true });
+
+    globalThis.fetch = vi.fn() as any;
+
+    const accountCheck = result.checks.find((c) => c.name === "Accounts configured");
+    expect(accountCheck?.status).toBe("PASS");
+    expect(accountCheck?.detail).toContain("Legacy");
+  });
+
+  it("should FAIL when no accounts and no legacy botToken", async () => {
+    const reader = stubReader({
+      channels: { dmwork: {} },
+      session: {},
+    });
+
+    const result = await runDoctorChecks({ reader, inProcess: true });
+
+    const accountCheck = result.checks.find((c) => c.name === "Accounts configured");
+    expect(accountCheck?.status).toBe("FAIL");
+    expect(result.errors).toBeGreaterThan(0);
+  });
+
+  it("should WARN when dmScope is not the recommended value", async () => {
+    const reader = stubReader({
+      channels: {
+        dmwork: {
+          accounts: { bot1: { botToken: "bf_test", apiUrl: "http://localhost" } },
+        },
+      },
+      session: { dmScope: "per-channel" },
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const result = await runDoctorChecks({ reader, inProcess: true });
+
+    globalThis.fetch = vi.fn() as any;
+
+    const scopeCheck = result.checks.find((c) => c.name === "session.dmScope");
+    expect(scopeCheck?.status).toBe("WARN");
+    expect(scopeCheck?.detail).toContain("per-channel");
+  });
+
+  it("should only check specified account when accountId is given", async () => {
+    const reader = stubReader({
+      channels: {
+        dmwork: {
+          accounts: {
+            bot_a: { botToken: "bf_aaa", apiUrl: "http://localhost" },
+            bot_b: { botToken: "bf_bbb", apiUrl: "http://localhost" },
+          },
+        },
+      },
+      session: { dmScope: "per-account-channel-peer" },
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const result = await runDoctorChecks({
+      reader,
+      accountId: "bot_a",
+      inProcess: true,
+    });
+
+    globalThis.fetch = vi.fn() as any;
+
+    const tokenChecks = result.checks.filter((c) => c.name.includes("botToken"));
+    expect(tokenChecks).toHaveLength(1);
+    expect(tokenChecks[0].name).toContain("bot_a");
+  });
+});
+
+describe("formatDoctorResult", () => {
+  it("should format checks into readable text", () => {
+    const text = formatDoctorResult({
+      checks: [
+        { name: "Plugin installed", status: "PASS", detail: "v0.5.19" },
+        { name: "Gateway running", status: "FAIL", detail: "Not running" },
+      ],
+      errors: 1,
+      warnings: 0,
+    });
+
+    expect(text).toContain("[PASS] Plugin installed");
+    expect(text).toContain("[FAIL] Gateway running");
+    expect(text).toContain("1 error(s)");
+  });
+});

--- a/openclaw-channel-dmwork/cli/doctor.test.ts
+++ b/openclaw-channel-dmwork/cli/doctor.test.ts
@@ -187,10 +187,13 @@ describe("formatDoctorResult", () => {
       ],
       errors: 1,
       warnings: 0,
+      fixed: 0,
     });
 
-    expect(text).toContain("[PASS] Plugin installed");
-    expect(text).toContain("[FAIL] Gateway running");
+    expect(text).toContain("[PASS]");
+    expect(text).toContain("Plugin installed");
+    expect(text).toContain("[FAIL]");
+    expect(text).toContain("Gateway running");
     expect(text).toContain("1 error(s)");
   });
 });

--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -1,0 +1,278 @@
+/**
+ * doctor command: diagnose DMWork plugin health.
+ *
+ * Exports a pure check function reusable from both CLI mode
+ * (using openclaw config get) and in-process mode (using ctx.config).
+ */
+
+import {
+  configGet,
+  configGetJson,
+  gatewayStatus,
+  pluginsInspect,
+} from "./openclaw-cli.js";
+import { PLUGIN_ID, RECOMMENDED_DM_SCOPE } from "./utils.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CheckStatus = "PASS" | "FAIL" | "WARN";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail: string;
+}
+
+export interface DoctorResult {
+  checks: CheckResult[];
+  errors: number;
+  warnings: number;
+}
+
+export interface DoctorOptions {
+  accountId?: string;
+  json?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Config reader abstraction (CLI vs in-process)
+// ---------------------------------------------------------------------------
+
+export interface ConfigReader {
+  get(path: string): string | null;
+  getJson(path: string): any;
+}
+
+/** CLI mode: reads via openclaw config get */
+export const cliConfigReader: ConfigReader = {
+  get: configGet,
+  getJson: configGetJson,
+};
+
+/** In-process mode: reads from a config object */
+export function inProcessConfigReader(config: any): ConfigReader {
+  return {
+    get(path: string): string | null {
+      const parts = path.split(".");
+      let cur = config;
+      for (const p of parts) {
+        if (cur == null || typeof cur !== "object") return null;
+        cur = cur[p];
+      }
+      if (cur == null) return null;
+      return String(cur);
+    },
+    getJson(path: string): any {
+      const parts = path.split(".");
+      let cur = config;
+      for (const p of parts) {
+        if (cur == null || typeof cur !== "object") return null;
+        cur = cur[p];
+      }
+      return cur ?? null;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Doctor checks
+// ---------------------------------------------------------------------------
+
+export async function runDoctorChecks(params: {
+  reader?: ConfigReader;
+  accountId?: string;
+  inProcess?: boolean;
+}): Promise<DoctorResult> {
+  const reader = params.reader ?? cliConfigReader;
+  const checks: CheckResult[] = [];
+
+  // 1. Plugin installed (skip in-process — if we're running, it's installed)
+  if (!params.inProcess) {
+    const inspect = pluginsInspect(PLUGIN_ID);
+    if (inspect?.plugin) {
+      checks.push({
+        name: "Plugin installed",
+        status: "PASS",
+        detail: `v${inspect.plugin.version}`,
+      });
+    } else {
+      checks.push({
+        name: "Plugin installed",
+        status: "FAIL",
+        detail: "Not installed",
+      });
+      return summarize(checks);
+    }
+  }
+
+  // 2. Plugin enabled (skip in-process)
+  if (!params.inProcess) {
+    const enabled = reader.get(
+      `plugins.entries.openclaw-channel-dmwork.enabled`,
+    );
+    checks.push({
+      name: "Plugin enabled",
+      status: enabled === "true" ? "PASS" : "FAIL",
+      detail: enabled === "true" ? "Yes" : "No",
+    });
+  }
+
+  // 3. Accounts configured (with legacy fallback)
+  const accounts = reader.getJson("channels.dmwork.accounts");
+  const accountIds = accounts ? Object.keys(accounts) : [];
+  const legacyToken = reader.get("channels.dmwork.botToken");
+
+  if (accountIds.length > 0) {
+    checks.push({
+      name: "Accounts configured",
+      status: "PASS",
+      detail: `${accountIds.join(", ")} (${accountIds.length} total)`,
+    });
+  } else if (legacyToken) {
+    checks.push({
+      name: "Accounts configured",
+      status: "PASS",
+      detail: "Legacy flat config (top-level botToken)",
+    });
+  } else {
+    checks.push({
+      name: "Accounts configured",
+      status: "FAIL",
+      detail: "No accounts or botToken configured",
+    });
+    return summarize(checks);
+  }
+
+  // 4 & 5. Per-account checks: botToken + API reachability
+  const targetAccounts = params.accountId
+    ? [params.accountId]
+    : accountIds.length > 0
+      ? accountIds
+      : ["__legacy__"];
+
+  for (const acctId of targetAccounts) {
+    const isLegacy = acctId === "__legacy__";
+    const label = isLegacy ? "default" : acctId;
+
+    // botToken check
+    const tokenPath = isLegacy
+      ? "channels.dmwork.botToken"
+      : `channels.dmwork.accounts.${acctId}.botToken`;
+    const tokenVal = reader.get(tokenPath);
+
+    if (tokenVal) {
+      // In-process mode can do bf_ format check
+      if (params.inProcess && !tokenVal.startsWith("bf_")) {
+        checks.push({
+          name: `${label}: botToken format`,
+          status: "WARN",
+          detail: "Does not start with bf_",
+        });
+      } else {
+        checks.push({
+          name: `${label}: botToken`,
+          status: "PASS",
+          detail: "Configured",
+        });
+      }
+    } else {
+      checks.push({
+        name: `${label}: botToken`,
+        status: "FAIL",
+        detail: "Not configured",
+      });
+      continue;
+    }
+
+    // API reachability
+    const apiUrlPath = isLegacy
+      ? "channels.dmwork.apiUrl"
+      : `channels.dmwork.accounts.${acctId}.apiUrl`;
+    let apiUrl = reader.get(apiUrlPath);
+    // Fallback to top-level apiUrl
+    if (!apiUrl) apiUrl = reader.get("channels.dmwork.apiUrl");
+    if (!apiUrl) apiUrl = "http://localhost:8090";
+
+    try {
+      const probeUrl = `${apiUrl.replace(/\/+$/, "")}/v1/bot/skill.md`;
+      const resp = await fetch(probeUrl, { signal: AbortSignal.timeout(5000) });
+      checks.push({
+        name: `${label}: API reachable`,
+        status: resp.ok ? "PASS" : "FAIL",
+        detail: resp.ok ? apiUrl : `HTTP ${resp.status}`,
+      });
+    } catch (err) {
+      checks.push({
+        name: `${label}: API reachable`,
+        status: "FAIL",
+        detail: `${apiUrl} - ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  // 6. Gateway running (skip in-process)
+  if (!params.inProcess) {
+    const gw = gatewayStatus();
+    checks.push({
+      name: "Gateway running",
+      status: gw.running ? "PASS" : "FAIL",
+      detail: gw.running ? "Yes" : "Not running",
+    });
+  }
+
+  // 7. session.dmScope
+  const dmScope = reader.get("session.dmScope");
+  if (!dmScope) {
+    checks.push({
+      name: "session.dmScope",
+      status: "WARN",
+      detail: `Not set (recommended: ${RECOMMENDED_DM_SCOPE})`,
+    });
+  } else if (dmScope === RECOMMENDED_DM_SCOPE) {
+    checks.push({
+      name: "session.dmScope",
+      status: "PASS",
+      detail: dmScope,
+    });
+  } else {
+    checks.push({
+      name: "session.dmScope",
+      status: "WARN",
+      detail: `${dmScope} (recommended: ${RECOMMENDED_DM_SCOPE})`,
+    });
+  }
+
+  return summarize(checks);
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function summarize(checks: CheckResult[]): DoctorResult {
+  return {
+    checks,
+    errors: checks.filter((c) => c.status === "FAIL").length,
+    warnings: checks.filter((c) => c.status === "WARN").length,
+  };
+}
+
+export function formatDoctorResult(result: DoctorResult): string {
+  const lines = ["DMWork Plugin Doctor"];
+  for (const c of result.checks) {
+    const tag =
+      c.status === "PASS"
+        ? "[PASS]"
+        : c.status === "WARN"
+          ? "[WARN]"
+          : "[FAIL]";
+    lines.push(`  ${tag} ${c.name} (${c.detail})`);
+  }
+  lines.push("");
+  lines.push(
+    `${result.errors} error(s), ${result.warnings} warning(s).`,
+  );
+  return lines.join("\n");
+}

--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -1,15 +1,23 @@
 /**
- * doctor command: diagnose DMWork plugin health.
+ * doctor command: diagnose and optionally fix DMWork plugin health.
  *
  * Exports a pure check function reusable from both CLI mode
  * (using openclaw config get) and in-process mode (using ctx.config).
  */
 
+import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import {
   configGet,
   configGetJson,
+  configSet,
+  gatewayRestart,
   gatewayStatus,
   pluginsInspect,
+  pluginsInstall,
+  removeChannelConfigFromFile,
+  removeOrphanedBindingsFromFile,
+  readConfigFromFile,
 } from "./openclaw-cli.js";
 import { PLUGIN_ID, RECOMMENDED_DM_SCOPE } from "./utils.js";
 
@@ -17,7 +25,7 @@ import { PLUGIN_ID, RECOMMENDED_DM_SCOPE } from "./utils.js";
 // Types
 // ---------------------------------------------------------------------------
 
-export type CheckStatus = "PASS" | "FAIL" | "WARN";
+export type CheckStatus = "PASS" | "FAIL" | "WARN" | "FIXED";
 
 export interface CheckResult {
   name: string;
@@ -29,11 +37,7 @@ export interface DoctorResult {
   checks: CheckResult[];
   errors: number;
   warnings: number;
-}
-
-export interface DoctorOptions {
-  accountId?: string;
-  json?: boolean;
+  fixed: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -77,18 +81,79 @@ export function inProcessConfigReader(config: any): ConfigReader {
 }
 
 // ---------------------------------------------------------------------------
-// Doctor checks
+// Doctor checks (with optional fix)
 // ---------------------------------------------------------------------------
 
 export async function runDoctorChecks(params: {
   reader?: ConfigReader;
   accountId?: string;
   inProcess?: boolean;
+  fix?: boolean;
 }): Promise<DoctorResult> {
-  const reader = params.reader ?? cliConfigReader;
+  const fix = params.fix ?? false;
   const checks: CheckResult[] = [];
 
-  // 1. Plugin installed (skip in-process — if we're running, it's installed)
+  // =========================================================================
+  // Phase 1: Fatal config issues (OpenClaw CLI may not work)
+  // =========================================================================
+  if (!params.inProcess && fix) {
+    const cfg = readConfigFromFile();
+    if (cfg) {
+      const hasDmworkChannel = Boolean(cfg.channels?.dmwork);
+      // Check if plugin actually exists on disk, not just config records
+      const installPath = cfg.plugins?.installs?.["openclaw-channel-dmwork"]?.installPath;
+      const pluginOnDisk = installPath
+        ? existsSync(installPath.replace(/^~/, process.env.HOME ?? ""))
+        : false;
+
+      // channels.dmwork exists but plugin not on disk → residual config
+      if (hasDmworkChannel && !pluginOnDisk) {
+        removeChannelConfigFromFile();
+        checks.push({
+          name: "Residual channels.dmwork",
+          status: "FIXED",
+          detail: "Removed orphaned channel config (plugin not installed)",
+        });
+      }
+
+      // Orphaned dmwork bindings
+      const bindings = cfg.bindings as Array<{ agentId: string; match?: { channel?: string; accountId?: string } }> | undefined;
+      const dmworkBindings = bindings?.filter((b) => b.match?.channel === "dmwork") ?? [];
+      const configuredAccounts = cfg.channels?.dmwork?.accounts
+        ? Object.keys(cfg.channels.dmwork.accounts)
+        : [];
+
+      if (dmworkBindings.length > 0 && !hasDmworkChannel) {
+        // All dmwork bindings are orphaned — no channel config at all
+        removeOrphanedBindingsFromFile("dmwork");
+        checks.push({
+          name: "Orphaned bindings",
+          status: "FIXED",
+          detail: `Removed ${dmworkBindings.length} orphaned dmwork binding(s)`,
+        });
+      } else if (dmworkBindings.length > 0 && configuredAccounts.length > 0) {
+        // Check for bindings referencing non-existent accounts
+        const orphaned = dmworkBindings.filter(
+          (b) => b.match?.accountId && !configuredAccounts.includes(b.match.accountId),
+        );
+        if (orphaned.length > 0) {
+          removeOrphanedBindingsFromFile("dmwork", configuredAccounts);
+          checks.push({
+            name: "Orphaned bindings",
+            status: "FIXED",
+            detail: `Removed ${orphaned.length} binding(s) for non-existent account(s)`,
+          });
+        }
+      }
+    }
+  }
+
+  // =========================================================================
+  // Phase 2: Standard checks (with fix support)
+  // =========================================================================
+  const reader = params.reader ?? cliConfigReader;
+
+  // 1. Plugin installed
   if (!params.inProcess) {
     const inspect = pluginsInspect(PLUGIN_ID);
     if (inspect?.plugin) {
@@ -97,6 +162,23 @@ export async function runDoctorChecks(params: {
         status: "PASS",
         detail: `v${inspect.plugin.version}`,
       });
+    } else if (fix) {
+      try {
+        pluginsInstall(PLUGIN_ID, true);
+        const after = pluginsInspect(PLUGIN_ID);
+        checks.push({
+          name: "Plugin installed",
+          status: "FIXED",
+          detail: `Installed v${after?.plugin?.version ?? "unknown"}`,
+        });
+      } catch {
+        checks.push({
+          name: "Plugin installed",
+          status: "FAIL",
+          detail: "Not installed (auto-install failed)",
+        });
+        return summarize(checks);
+      }
     } else {
       checks.push({
         name: "Plugin installed",
@@ -107,19 +189,50 @@ export async function runDoctorChecks(params: {
     }
   }
 
-  // 2. Plugin enabled (skip in-process)
+  // 2. Plugin enabled
   if (!params.inProcess) {
     const enabled = reader.get(
-      `plugins.entries.openclaw-channel-dmwork.enabled`,
+      "plugins.entries.openclaw-channel-dmwork.enabled",
     );
-    checks.push({
-      name: "Plugin enabled",
-      status: enabled === "true" ? "PASS" : "FAIL",
-      detail: enabled === "true" ? "Yes" : "No",
-    });
+    if (enabled === "true") {
+      checks.push({ name: "Plugin enabled", status: "PASS", detail: "Yes" });
+    } else if (fix) {
+      try {
+        configSet("plugins.entries.openclaw-channel-dmwork.enabled", "true");
+        checks.push({ name: "Plugin enabled", status: "FIXED", detail: "Enabled" });
+      } catch {
+        checks.push({ name: "Plugin enabled", status: "FAIL", detail: "No (auto-fix failed)" });
+      }
+    } else {
+      checks.push({ name: "Plugin enabled", status: "FAIL", detail: "No" });
+    }
   }
 
-  // 3. Accounts configured (with legacy fallback)
+  // 3. node_modules check
+  if (!params.inProcess) {
+    const inspect = pluginsInspect(PLUGIN_ID);
+    const installPath = inspect?.install?.installPath;
+    if (installPath) {
+      const nmPath = installPath.replace(/^~/, process.env.HOME ?? "") + "/node_modules";
+      if (existsSync(nmPath)) {
+        checks.push({ name: "Dependencies", status: "PASS", detail: "node_modules exists" });
+      } else if (fix) {
+        try {
+          execFileSync("npm", ["install", "--production", "--ignore-scripts"], {
+            cwd: installPath.replace(/^~/, process.env.HOME ?? ""),
+            stdio: ["pipe", "pipe", "pipe"],
+          });
+          checks.push({ name: "Dependencies", status: "FIXED", detail: "npm install completed" });
+        } catch {
+          checks.push({ name: "Dependencies", status: "FAIL", detail: "node_modules missing (npm install failed)" });
+        }
+      } else {
+        checks.push({ name: "Dependencies", status: "FAIL", detail: "node_modules missing" });
+      }
+    }
+  }
+
+  // 4. Accounts configured (with legacy fallback)
   const accounts = reader.getJson("channels.dmwork.accounts");
   const accountIds = accounts ? Object.keys(accounts) : [];
   const legacyToken = reader.get("channels.dmwork.botToken");
@@ -140,30 +253,30 @@ export async function runDoctorChecks(params: {
     checks.push({
       name: "Accounts configured",
       status: "FAIL",
-      detail: "No accounts or botToken configured",
+      detail: "No accounts configured (run install to add a bot)",
     });
-    return summarize(checks);
+    // Don't return early — continue checking other items
   }
 
-  // 4 & 5. Per-account checks: botToken + API reachability
+  // 5 & 6. Per-account checks: botToken + API reachability
   const targetAccounts = params.accountId
     ? [params.accountId]
     : accountIds.length > 0
       ? accountIds
-      : ["__legacy__"];
+      : legacyToken
+        ? ["__legacy__"]
+        : [];
 
   for (const acctId of targetAccounts) {
     const isLegacy = acctId === "__legacy__";
     const label = isLegacy ? "default" : acctId;
 
-    // botToken check
     const tokenPath = isLegacy
       ? "channels.dmwork.botToken"
       : `channels.dmwork.accounts.${acctId}.botToken`;
     const tokenVal = reader.get(tokenPath);
 
     if (tokenVal) {
-      // In-process mode can do bf_ format check
       if (params.inProcess && !tokenVal.startsWith("bf_")) {
         checks.push({
           name: `${label}: botToken format`,
@@ -186,12 +299,10 @@ export async function runDoctorChecks(params: {
       continue;
     }
 
-    // API reachability
     const apiUrlPath = isLegacy
       ? "channels.dmwork.apiUrl"
       : `channels.dmwork.accounts.${acctId}.apiUrl`;
     let apiUrl = reader.get(apiUrlPath);
-    // Fallback to top-level apiUrl
     if (!apiUrl) apiUrl = reader.get("channels.dmwork.apiUrl");
     if (!apiUrl) apiUrl = "http://localhost:8090";
 
@@ -212,36 +323,37 @@ export async function runDoctorChecks(params: {
     }
   }
 
-  // 6. Gateway running (skip in-process)
+  // 7. Gateway running
   if (!params.inProcess) {
     const gw = gatewayStatus();
-    checks.push({
-      name: "Gateway running",
-      status: gw.running ? "PASS" : "FAIL",
-      detail: gw.running ? "Yes" : "Not running",
-    });
+    if (gw.running) {
+      checks.push({ name: "Gateway running", status: "PASS", detail: "Yes" });
+    } else if (fix) {
+      if (gatewayRestart()) {
+        checks.push({ name: "Gateway running", status: "FIXED", detail: "Restarted" });
+      } else {
+        checks.push({ name: "Gateway running", status: "FAIL", detail: "Not running (restart failed)" });
+      }
+    } else {
+      checks.push({ name: "Gateway running", status: "FAIL", detail: "Not running" });
+    }
   }
 
-  // 7. session.dmScope
+  // 8. session.dmScope
   const dmScope = reader.get("session.dmScope");
-  if (!dmScope) {
-    checks.push({
-      name: "session.dmScope",
-      status: "WARN",
-      detail: `Not set (recommended: ${RECOMMENDED_DM_SCOPE})`,
-    });
-  } else if (dmScope === RECOMMENDED_DM_SCOPE) {
-    checks.push({
-      name: "session.dmScope",
-      status: "PASS",
-      detail: dmScope,
-    });
+  if (dmScope === RECOMMENDED_DM_SCOPE) {
+    checks.push({ name: "session.dmScope", status: "PASS", detail: dmScope });
+  } else if (!dmScope && fix) {
+    try {
+      configSet("session.dmScope", RECOMMENDED_DM_SCOPE);
+      checks.push({ name: "session.dmScope", status: "FIXED", detail: `Set to ${RECOMMENDED_DM_SCOPE}` });
+    } catch {
+      checks.push({ name: "session.dmScope", status: "WARN", detail: `Not set (recommended: ${RECOMMENDED_DM_SCOPE})` });
+    }
+  } else if (!dmScope) {
+    checks.push({ name: "session.dmScope", status: "WARN", detail: `Not set (recommended: ${RECOMMENDED_DM_SCOPE})` });
   } else {
-    checks.push({
-      name: "session.dmScope",
-      status: "WARN",
-      detail: `${dmScope} (recommended: ${RECOMMENDED_DM_SCOPE})`,
-    });
+    checks.push({ name: "session.dmScope", status: "WARN", detail: `${dmScope} (recommended: ${RECOMMENDED_DM_SCOPE})` });
   }
 
   return summarize(checks);
@@ -256,6 +368,7 @@ function summarize(checks: CheckResult[]): DoctorResult {
     checks,
     errors: checks.filter((c) => c.status === "FAIL").length,
     warnings: checks.filter((c) => c.status === "WARN").length,
+    fixed: checks.filter((c) => c.status === "FIXED").length,
   };
 }
 
@@ -264,15 +377,17 @@ export function formatDoctorResult(result: DoctorResult): string {
   for (const c of result.checks) {
     const tag =
       c.status === "PASS"
-        ? "[PASS]"
+        ? "[PASS] "
         : c.status === "WARN"
-          ? "[WARN]"
-          : "[FAIL]";
+          ? "[WARN] "
+          : c.status === "FIXED"
+            ? "[FIXED]"
+            : "[FAIL] ";
     lines.push(`  ${tag} ${c.name} (${c.detail})`);
   }
   lines.push("");
-  lines.push(
-    `${result.errors} error(s), ${result.warnings} warning(s).`,
-  );
+  const parts = [`${result.errors} error(s)`, `${result.warnings} warning(s)`];
+  if (result.fixed > 0) parts.push(`${result.fixed} fixed`);
+  lines.push(parts.join(", ") + ".");
   return lines.join("\n");
 }

--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -1,0 +1,97 @@
+/**
+ * CLI entry point: register 5 subcommands with commander.
+ */
+
+import { Command } from "commander";
+import { runInstall } from "./install.js";
+import { runUpdate } from "./update.js";
+import {
+  cliConfigReader,
+  formatDoctorResult,
+  runDoctorChecks,
+} from "./doctor.js";
+import { runUninstall } from "./uninstall.js";
+import { runRemoveAccount } from "./remove-account.js";
+import { ensureOpenClawCompat } from "./utils.js";
+
+const program = new Command();
+
+program
+  .name("openclaw-channel-dmwork")
+  .description("DMWork channel plugin CLI for OpenClaw")
+  .version("0.5.19");
+
+// --- install ---
+program
+  .command("install")
+  .description("Install the DMWork plugin and configure a bot account")
+  .option("--bot-token <token>", "Bot token (starts with bf_)")
+  .option("--api-url <url>", "API server URL")
+  .option("--account-id <id>", "Account ID (required in non-interactive mode)")
+  .option("--skip-config", "Skip bot configuration", false)
+  .option("--force", "Force reinstall", false)
+  .action(async (opts) => {
+    await runInstall({
+      botToken: opts.botToken,
+      apiUrl: opts.apiUrl,
+      accountId: opts.accountId,
+      skipConfig: opts.skipConfig,
+      force: opts.force,
+    });
+  });
+
+// --- update ---
+program
+  .command("update")
+  .description("Update the DMWork plugin to the latest version")
+  .option("--json", "Output JSON", false)
+  .action(async (opts) => {
+    await runUpdate({ json: opts.json });
+  });
+
+// --- doctor ---
+program
+  .command("doctor")
+  .description("Diagnose DMWork plugin health")
+  .option("--account-id <id>", "Check a specific account only")
+  .option("--json", "Output JSON", false)
+  .action(async (opts) => {
+    ensureOpenClawCompat();
+    const result = await runDoctorChecks({
+      reader: cliConfigReader,
+      accountId: opts.accountId,
+    });
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatDoctorResult(result));
+    }
+  });
+
+// --- uninstall ---
+program
+  .command("uninstall")
+  .description("Uninstall the DMWork plugin")
+  .option("--remove-config", "Also remove channels.dmwork config", false)
+  .option("--yes", "Skip confirmation", false)
+  .action(async (opts) => {
+    await runUninstall({
+      removeConfig: opts.removeConfig,
+      yes: opts.yes,
+    });
+  });
+
+// --- remove-account ---
+program
+  .command("remove-account")
+  .description("Remove a single bot account config")
+  .requiredOption("--account-id <id>", "Account ID to remove")
+  .option("--yes", "Skip confirmation", false)
+  .action(async (opts) => {
+    await runRemoveAccount({
+      accountId: opts.accountId,
+      yes: opts.yes,
+    });
+  });
+
+program.parse();

--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -12,7 +12,9 @@ import {
 } from "./doctor.js";
 import { runUninstall } from "./uninstall.js";
 import { runRemoveAccount } from "./remove-account.js";
-import { ensureOpenClawCompat } from "./utils.js";
+import { ensureOpenClawCompat, PLUGIN_ID } from "./utils.js";
+import { getOpenClawVersion, pluginsInspect } from "./openclaw-cli.js";
+import { createRequire } from "node:module";
 
 const program = new Command();
 
@@ -20,6 +22,34 @@ program
   .name("openclaw-channel-dmwork")
   .description("DMWork channel plugin CLI for OpenClaw")
   .version("0.5.19");
+
+// --- info ---
+program
+  .command("info")
+  .description("Show CLI and plugin version info")
+  .action(() => {
+    const require = createRequire(import.meta.url);
+    const cliPkg = require("../package.json");
+    const openclawVersion = getOpenClawVersion() ?? "not found";
+    const inspect = pluginsInspect(PLUGIN_ID);
+    const installedVersion = inspect?.plugin?.version ?? "not installed";
+
+    // ANSI: \x1b[1m = bold, \x1b[32m = green, \x1b[4m = underline, \x1b[0m = reset
+    const b = "\x1b[1m";   // bold
+    const g = "\x1b[32m";  // green
+    const u = "\x1b[4m";   // underline
+    const r = "\x1b[0m";   // reset
+
+    console.log(`${b}openclaw-channel-dmwork-cli:${r} ${g}${cliPkg.version}${r}`);
+    console.log(`${b}openclaw:${r} ${g}${openclawVersion}${r}`);
+    console.log(`${b}openclaw-channel-dmwork:${r} ${g}${installedVersion}${r}`);
+    console.log(`${b}plugin package:${r} ${g}${PLUGIN_ID}${r}`);
+    console.log();
+    console.log(`${b}环境信息：${r}`);
+    console.log(`${b}OS:${r} ${g}${process.platform} ${process.arch}${r}`);
+    console.log(`${b}Node.js:${r} ${g}${process.version}${r}`);
+    console.log(`${b}Shell:${r} ${g}${process.env.SHELL ?? "unknown"}${r}`);
+  });
 
 // --- install ---
 program

--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -87,12 +87,14 @@ program
   .command("doctor")
   .description("Diagnose DMWork plugin health")
   .option("--account-id <id>", "Check a specific account only")
+  .option("--fix", "Attempt to automatically fix issues", false)
   .option("--json", "Output JSON", false)
   .action(async (opts) => {
     ensureOpenClawCompat();
     const result = await runDoctorChecks({
       reader: cliConfigReader,
       accountId: opts.accountId,
+      fix: opts.fix,
     });
     if (opts.json) {
       console.log(JSON.stringify(result, null, 2));

--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -2,7 +2,7 @@
  * CLI entry point: register 5 subcommands with commander.
  */
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { runInstall } from "./install.js";
 import { runUpdate } from "./update.js";
 import {
@@ -60,6 +60,7 @@ program
   .option("--account-id <id>", "Account ID (required in non-interactive mode)")
   .option("--skip-config", "Skip bot configuration", false)
   .option("--force", "Force reinstall", false)
+  .addOption(new Option("--dev").hideHelp().default(false))
   .action(async (opts) => {
     await runInstall({
       botToken: opts.botToken,
@@ -67,6 +68,7 @@ program
       accountId: opts.accountId,
       skipConfig: opts.skipConfig,
       force: opts.force,
+      dev: opts.dev,
     });
   });
 
@@ -75,8 +77,9 @@ program
   .command("update")
   .description("Update the DMWork plugin to the latest version")
   .option("--json", "Output JSON", false)
+  .addOption(new Option("--dev").hideHelp().default(false))
   .action(async (opts) => {
-    await runUpdate({ json: opts.json });
+    await runUpdate({ json: opts.json, dev: opts.dev });
   });
 
 // --- doctor ---
@@ -101,14 +104,10 @@ program
 // --- uninstall ---
 program
   .command("uninstall")
-  .description("Uninstall the DMWork plugin")
-  .option("--remove-config", "Also remove channels.dmwork config", false)
+  .description("Uninstall the DMWork plugin and remove all bot configs")
   .option("--yes", "Skip confirmation", false)
   .action(async (opts) => {
-    await runUninstall({
-      removeConfig: opts.removeConfig,
-      yes: opts.yes,
-    });
+    await runUninstall({ yes: opts.yes });
   });
 
 // --- remove-account ---

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -10,6 +10,8 @@ import {
   gatewayRestart,
   pluginsInspect,
   pluginsInstall,
+  saveChannelConfigFromFile,
+  restoreChannelConfigToFile,
 } from "./openclaw-cli.js";
 import {
   PLUGIN_ID,
@@ -40,8 +42,20 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       `DMWork plugin is already installed (v${inspect.plugin.version}). Skipping install.`,
     );
   } else {
+    // --force triggers uninstall+reinstall internally, which deletes channels.dmwork.
+    // Save config by reading file directly (preserves secrets), restore after install.
+    const savedConfig = opts.force
+      ? saveChannelConfigFromFile()
+      : null;
+
     console.log("Installing DMWork plugin...");
     pluginsInstall(PLUGIN_ID, opts.force);
+
+    if (savedConfig) {
+      restoreChannelConfigToFile(savedConfig);
+      console.log("Restored channels.dmwork config.");
+    }
+
     console.log("Plugin installed successfully.");
   }
 

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -136,8 +136,11 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
         );
         process.exit(1);
       } else {
-        // No credentials provided at all — keep existing
+        // No credentials provided at all — keep existing, but still ensure binding/agent
         console.log(`Account "${accountId}" already configured. Keeping existing config.`);
+        const apiUrl = configGet(`channels.dmwork.accounts.${accountId}.apiUrl`)
+          ?? configGet("channels.dmwork.apiUrl") ?? "";
+        await ensureBindingAndAgent(accountId, apiUrl);
         ensureDmScope();
         return;
       }
@@ -148,6 +151,9 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
       );
       if (keep) {
         console.log("Keeping existing config.");
+        const apiUrl = configGet(`channels.dmwork.accounts.${accountId}.apiUrl`)
+          ?? configGet("channels.dmwork.apiUrl") ?? "";
+        await ensureBindingAndAgent(accountId, apiUrl);
         ensureDmScope();
         return;
       }
@@ -181,11 +187,53 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
   console.log(`  API: ${apiUrl}`);
 
   // Create binding + agent
-  const agentId = accountId.replace(/_bot$/, "");
-  ensureBinding(accountId, agentId);
-  ensureAgentMd(agentId, accountId, apiUrl);
+  await ensureBindingAndAgent(accountId, apiUrl);
 
   ensureDmScope();
+}
+
+// ---------------------------------------------------------------------------
+// Binding + Agent (with conflict detection)
+// ---------------------------------------------------------------------------
+
+async function ensureBindingAndAgent(accountId: string, apiUrl: string): Promise<void> {
+  let agentId = accountId.replace(/_bot$/, "");
+
+  // Check if agent already exists on disk
+  const agentMdPath = join(homedir(), ".openclaw", "agents", agentId, "agent", "agent.md");
+  if (existsSync(agentMdPath)) {
+    // Check if this agent is already bound to this accountId — that's fine
+    const bindings: Array<{ agentId: string; match?: { channel?: string; accountId?: string } }> =
+      configGetJson("bindings") ?? [];
+    const alreadyBound = bindings.some(
+      (b) => b.match?.channel === "dmwork" && b.match?.accountId === accountId && b.agentId === agentId,
+    );
+    if (alreadyBound) {
+      console.log(`Binding ${accountId} -> agent "${agentId}" already exists.`);
+      return;
+    }
+
+    // Agent exists but not bound to this accountId — potential conflict
+    if (isInteractive()) {
+      const reuse = await confirm(
+        `Agent "${agentId}" already exists. Use this agent for ${accountId}?`,
+        true,
+      );
+      if (!reuse) {
+        agentId = await prompt(`Enter a different agent ID for ${accountId}:`);
+        if (!agentId || !validateAccountId(agentId)) {
+          console.log("Invalid or empty agent ID. Skipping binding/agent setup.");
+          return;
+        }
+      }
+    } else {
+      // Non-interactive: reuse existing agent silently
+      console.log(`Using existing agent "${agentId}" for ${accountId}.`);
+    }
+  }
+
+  ensureBinding(accountId, agentId);
+  ensureAgentMd(agentId, accountId, apiUrl);
 }
 
 // ---------------------------------------------------------------------------

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -48,12 +48,15 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       ? saveChannelConfigFromFile()
       : null;
 
-    console.log("Installing DMWork plugin...");
-    pluginsInstall(PLUGIN_ID, opts.force);
-
-    if (savedConfig) {
-      restoreChannelConfigToFile(savedConfig);
-      console.log("Restored channels.dmwork config.");
+    try {
+      console.log("Installing DMWork plugin...");
+      pluginsInstall(PLUGIN_ID, opts.force);
+    } finally {
+      // Always restore config, even if install fails partway through
+      if (savedConfig) {
+        restoreChannelConfigToFile(savedConfig);
+        console.log("Restored channels.dmwork config.");
+      }
     }
 
     console.log("Plugin installed successfully.");

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -43,7 +43,7 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
   } else {
     const spec = opts.dev ? `${PLUGIN_ID}@dev` : PLUGIN_ID;
     console.log(`Installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
-    pluginsInstall(spec, opts.force);
+    pluginsInstall(spec, false, opts.force);
     console.log("Plugin installed successfully.");
   }
 

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -1,0 +1,193 @@
+/**
+ * install command: install plugin via official CLI + interactive config setup.
+ */
+
+import {
+  configGet,
+  configGetJson,
+  configSet,
+  configUnset,
+  gatewayRestart,
+  pluginsInspect,
+  pluginsInstall,
+} from "./openclaw-cli.js";
+import {
+  PLUGIN_ID,
+  RECOMMENDED_DM_SCOPE,
+  confirm,
+  ensureOpenClawCompat,
+  isInteractive,
+  prompt,
+  validateAccountId,
+} from "./utils.js";
+
+export interface InstallOptions {
+  botToken?: string;
+  apiUrl?: string;
+  accountId?: string;
+  skipConfig?: boolean;
+  force?: boolean;
+}
+
+export async function runInstall(opts: InstallOptions): Promise<void> {
+  // 1. Pre-check
+  ensureOpenClawCompat();
+
+  // 2. Plugin install (delegate to official CLI)
+  const inspect = pluginsInspect(PLUGIN_ID);
+  if (inspect?.plugin && !opts.force) {
+    console.log(
+      `DMWork plugin is already installed (v${inspect.plugin.version}). Skipping install.`,
+    );
+  } else {
+    console.log("Installing DMWork plugin...");
+    pluginsInstall(PLUGIN_ID, opts.force);
+    console.log("Plugin installed successfully.");
+  }
+
+  // 3. Legacy config migration
+  await migrateLegacyConfig();
+
+  // 4. DMWork config (unless --skip-config)
+  if (!opts.skipConfig) {
+    await configureDmworkAccount(opts);
+  }
+
+  // 5. Gateway restart
+  console.log("Restarting gateway...");
+  if (!gatewayRestart()) {
+    console.log(
+      "Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.",
+    );
+  }
+
+  // 6. Success
+  console.log("\nDMWork plugin setup complete!");
+}
+
+// ---------------------------------------------------------------------------
+// Legacy config migration
+// ---------------------------------------------------------------------------
+
+async function migrateLegacyConfig(): Promise<void> {
+  const legacyToken = configGet("channels.dmwork.botToken");
+  const accounts = configGetJson("channels.dmwork.accounts");
+
+  // Has top-level botToken but no accounts map → legacy flat config
+  if (legacyToken && (!accounts || Object.keys(accounts).length === 0)) {
+    console.log("Detected legacy flat config. Migrating to accounts model...");
+
+    // Copy token to accounts.default
+    configSet("channels.dmwork.accounts.default.botToken", legacyToken);
+
+    // Copy apiUrl if present
+    const legacyApiUrl = configGet("channels.dmwork.apiUrl");
+    if (legacyApiUrl) {
+      configSet("channels.dmwork.accounts.default.apiUrl", legacyApiUrl);
+    }
+
+    // Remove top-level botToken (keep apiUrl as shared default)
+    configUnset("channels.dmwork.botToken");
+
+    console.log("Migrated legacy config to accounts.default.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Account configuration
+// ---------------------------------------------------------------------------
+
+async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
+  // Collect accountId
+  let accountId = opts.accountId;
+  if (!accountId) {
+    accountId = await prompt("Enter bot account ID (e.g. my_bot):");
+    if (!accountId) {
+      console.log("No account ID provided. Skipping config.");
+      return;
+    }
+  }
+
+  if (!validateAccountId(accountId)) {
+    console.error(
+      `Error: Invalid account ID "${accountId}". Only letters, digits, and underscores are allowed.`,
+    );
+    process.exit(1);
+  }
+
+  // Check if account already exists
+  const existingToken = configGet(
+    `channels.dmwork.accounts.${accountId}.botToken`,
+  );
+  if (existingToken) {
+    if (!isInteractive()) {
+      // Non-interactive: require both botToken and apiUrl to overwrite
+      if (opts.botToken && opts.apiUrl) {
+        console.log(`Overwriting existing account "${accountId}".`);
+      } else if (opts.botToken || opts.apiUrl) {
+        console.error(
+          `Error: Account "${accountId}" already exists. Provide both --bot-token and --api-url to overwrite.`,
+        );
+        process.exit(1);
+      } else {
+        // No credentials provided at all — keep existing
+        console.log(`Account "${accountId}" already configured. Keeping existing config.`);
+        ensureDmScope();
+        return;
+      }
+    } else {
+      const keep = await confirm(
+        `Bot account "${accountId}" is already configured. Keep current config?`,
+        true,
+      );
+      if (keep) {
+        console.log("Keeping existing config.");
+        ensureDmScope();
+        return;
+      }
+    }
+  }
+
+  // Collect botToken
+  let botToken = opts.botToken;
+  if (!botToken) {
+    botToken = await prompt("Enter bot token (bf_...):");
+  }
+  if (!botToken?.startsWith("bf_")) {
+    console.error("Error: Bot token must start with 'bf_'.");
+    process.exit(1);
+  }
+
+  // Collect apiUrl
+  let apiUrl = opts.apiUrl;
+  if (!apiUrl) {
+    apiUrl = await prompt("Enter API server URL:");
+  }
+  if (!apiUrl) {
+    console.error("Error: API URL is required.");
+    process.exit(1);
+  }
+
+  // Write account config
+  configSet(`channels.dmwork.accounts.${accountId}.botToken`, botToken);
+  configSet(`channels.dmwork.accounts.${accountId}.apiUrl`, apiUrl);
+  console.log(`Configured bot account: ${accountId}`);
+  console.log(`  API: ${apiUrl}`);
+
+  ensureDmScope();
+}
+
+// ---------------------------------------------------------------------------
+// session.dmScope
+// ---------------------------------------------------------------------------
+
+function ensureDmScope(): void {
+  const current = configGet("session.dmScope");
+  if (!current) {
+    configSet("session.dmScope", RECOMMENDED_DM_SCOPE);
+  } else if (current !== RECOMMENDED_DM_SCOPE) {
+    console.log(
+      `Warning: session.dmScope is "${current}" (recommended: ${RECOMMENDED_DM_SCOPE})`,
+    );
+  }
+}

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -1,15 +1,14 @@
 /**
  * install command: install plugin via official CLI + interactive config setup.
+ *
+ * Only manages channels.dmwork account config. Agent creation (binding,
+ * workspace, agent.md) is left to the user via `openclaw agents add`.
  */
 
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import {
   configGet,
   configGetJson,
   configSet,
-  configSetJson,
   configUnset,
   gatewayRestart,
   pluginsInspect,
@@ -127,7 +126,6 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
   );
   if (existingToken) {
     if (!isInteractive()) {
-      // Non-interactive: require both botToken and apiUrl to overwrite
       if (opts.botToken && opts.apiUrl) {
         console.log(`Overwriting existing account "${accountId}".`);
       } else if (opts.botToken || opts.apiUrl) {
@@ -136,12 +134,9 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
         );
         process.exit(1);
       } else {
-        // No credentials provided at all — keep existing, but still ensure binding/agent
         console.log(`Account "${accountId}" already configured. Keeping existing config.`);
-        const apiUrl = configGet(`channels.dmwork.accounts.${accountId}.apiUrl`)
-          ?? configGet("channels.dmwork.apiUrl") ?? "";
-        await ensureBindingAndAgent(accountId, apiUrl);
         ensureDmScope();
+        printAgentHint(accountId);
         return;
       }
     } else {
@@ -151,10 +146,8 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
       );
       if (keep) {
         console.log("Keeping existing config.");
-        const apiUrl = configGet(`channels.dmwork.accounts.${accountId}.apiUrl`)
-          ?? configGet("channels.dmwork.apiUrl") ?? "";
-        await ensureBindingAndAgent(accountId, apiUrl);
         ensureDmScope();
+        printAgentHint(accountId);
         return;
       }
     }
@@ -186,130 +179,8 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
   console.log(`Configured bot account: ${accountId}`);
   console.log(`  API: ${apiUrl}`);
 
-  // Create binding + agent
-  await ensureBindingAndAgent(accountId, apiUrl);
-
   ensureDmScope();
-}
-
-// ---------------------------------------------------------------------------
-// Binding + Agent (with conflict detection)
-// ---------------------------------------------------------------------------
-
-async function ensureBindingAndAgent(accountId: string, apiUrl: string): Promise<void> {
-  let agentId = accountId.replace(/_bot$/, "");
-
-  // Check if agent already exists on disk
-  const agentMdPath = join(homedir(), ".openclaw", "agents", agentId, "agent", "agent.md");
-  if (existsSync(agentMdPath)) {
-    // Check if this agent is already bound to this accountId — that's fine
-    const bindings: Array<{ agentId: string; match?: { channel?: string; accountId?: string } }> =
-      configGetJson("bindings") ?? [];
-    const alreadyBound = bindings.some(
-      (b) => b.match?.channel === "dmwork" && b.match?.accountId === accountId && b.agentId === agentId,
-    );
-    if (alreadyBound) {
-      console.log(`Binding ${accountId} -> agent "${agentId}" already exists.`);
-      return;
-    }
-
-    // Agent exists but not bound to this accountId — potential conflict
-    if (isInteractive()) {
-      const reuse = await confirm(
-        `Agent "${agentId}" already exists. Use this agent for ${accountId}?`,
-        true,
-      );
-      if (!reuse) {
-        agentId = await prompt(`Enter a different agent ID for ${accountId}:`);
-        if (!agentId || !validateAccountId(agentId)) {
-          console.log("Invalid or empty agent ID. Skipping binding/agent setup.");
-          return;
-        }
-      }
-    } else {
-      // Non-interactive: reuse existing agent silently
-      console.log(`Using existing agent "${agentId}" for ${accountId}.`);
-    }
-  }
-
-  ensureBinding(accountId, agentId);
-  ensureAgentMd(agentId, accountId, apiUrl);
-}
-
-// ---------------------------------------------------------------------------
-// Binding
-// ---------------------------------------------------------------------------
-
-function ensureBinding(accountId: string, agentId: string): void {
-  try {
-    const bindings: Array<{ agentId: string; match?: { channel?: string; accountId?: string } }> =
-      configGetJson("bindings") ?? [];
-
-    // Check if binding already exists for this accountId
-    const exists = bindings.some(
-      (b) => b.match?.channel === "dmwork" && b.match?.accountId === accountId,
-    );
-    if (exists) {
-      console.log(`Binding for ${accountId} already exists.`);
-      return;
-    }
-
-    // Append binding at the end using numeric index
-    const index = bindings.length;
-    configSetJson(`bindings[${index}]`, {
-      agentId,
-      match: { channel: "dmwork", accountId },
-    });
-    console.log(`Created binding: ${accountId} -> agent "${agentId}"`);
-  } catch {
-    console.log(
-      `Warning: Could not create binding. Add manually: {"agentId":"${agentId}","match":{"channel":"dmwork","accountId":"${accountId}"}}`,
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Agent.md
-// ---------------------------------------------------------------------------
-
-function ensureAgentMd(agentId: string, accountId: string, apiUrl: string): void {
-  const agentDir = join(homedir(), ".openclaw", "agents", agentId, "agent");
-  const agentMdPath = join(agentDir, "agent.md");
-
-  if (existsSync(agentMdPath)) {
-    console.log(`Agent "${agentId}" already exists. Keeping existing agent.md.`);
-    return;
-  }
-
-  try {
-    mkdirSync(agentDir, { recursive: true });
-    writeFileSync(
-      agentMdPath,
-      `I am ${accountId}, a DMWork bot.
-
-## Credentials
-
-- Account ID: ${accountId}
-- API server: ${apiUrl}
-- accountId must be passed when using dmwork_management tool
-
-## Capabilities
-
-My full API capabilities are documented at ${apiUrl}/v1/bot/skill.md — read it when I need to perform an action I'm unsure about.
-
-## Rules
-
-- Respond in the user's language
-- Be helpful and concise
-`,
-      "utf-8",
-    );
-    console.log(`Created agent: ~/.openclaw/agents/${agentId}/agent/agent.md`);
-  } catch {
-    console.log(
-      `Warning: Could not create agent.md at ${agentMdPath}`,
-    );
-  }
+  printAgentHint(accountId);
 }
 
 // ---------------------------------------------------------------------------
@@ -325,4 +196,16 @@ function ensureDmScope(): void {
       `Warning: session.dmScope is "${current}" (recommended: ${RECOMMENDED_DM_SCOPE})`,
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Agent hint
+// ---------------------------------------------------------------------------
+
+function printAgentHint(accountId: string): void {
+  const agentName = accountId.replace(/_bot$/, "");
+  console.log(`
+To create an independent agent for this bot (optional):
+  openclaw agents add ${agentName}
+  openclaw agents bind ${agentName} dmwork ${accountId}`);
 }

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -10,8 +10,6 @@ import {
   gatewayRestart,
   pluginsInspect,
   pluginsInstall,
-  saveChannelConfigFromFile,
-  restoreChannelConfigToFile,
 } from "./openclaw-cli.js";
 import {
   PLUGIN_ID,
@@ -29,6 +27,7 @@ export interface InstallOptions {
   accountId?: string;
   skipConfig?: boolean;
   force?: boolean;
+  dev?: boolean;
 }
 
 export async function runInstall(opts: InstallOptions): Promise<void> {
@@ -42,23 +41,9 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       `DMWork plugin is already installed (v${inspect.plugin.version}). Skipping install.`,
     );
   } else {
-    // --force triggers uninstall+reinstall internally, which deletes channels.dmwork.
-    // Save config by reading file directly (preserves secrets), restore after install.
-    const savedConfig = opts.force
-      ? saveChannelConfigFromFile()
-      : null;
-
-    try {
-      console.log("Installing DMWork plugin...");
-      pluginsInstall(PLUGIN_ID, opts.force);
-    } finally {
-      // Always restore config, even if install fails partway through
-      if (savedConfig) {
-        restoreChannelConfigToFile(savedConfig);
-        console.log("Restored channels.dmwork config.");
-      }
-    }
-
+    const spec = opts.dev ? `${PLUGIN_ID}@dev` : PLUGIN_ID;
+    console.log(`Installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
+    pluginsInstall(spec, opts.force);
     console.log("Plugin installed successfully.");
   }
 

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -2,10 +2,14 @@
  * install command: install plugin via official CLI + interactive config setup.
  */
 
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
   configGet,
   configGetJson,
   configSet,
+  configSetJson,
   configUnset,
   gatewayRestart,
   pluginsInspect,
@@ -176,7 +180,88 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
   console.log(`Configured bot account: ${accountId}`);
   console.log(`  API: ${apiUrl}`);
 
+  // Create binding + agent
+  const agentId = accountId.replace(/_bot$/, "");
+  ensureBinding(accountId, agentId);
+  ensureAgentMd(agentId, accountId, apiUrl);
+
   ensureDmScope();
+}
+
+// ---------------------------------------------------------------------------
+// Binding
+// ---------------------------------------------------------------------------
+
+function ensureBinding(accountId: string, agentId: string): void {
+  try {
+    const bindings: Array<{ agentId: string; match?: { channel?: string; accountId?: string } }> =
+      configGetJson("bindings") ?? [];
+
+    // Check if binding already exists for this accountId
+    const exists = bindings.some(
+      (b) => b.match?.channel === "dmwork" && b.match?.accountId === accountId,
+    );
+    if (exists) {
+      console.log(`Binding for ${accountId} already exists.`);
+      return;
+    }
+
+    // Append binding at the end using numeric index
+    const index = bindings.length;
+    configSetJson(`bindings[${index}]`, {
+      agentId,
+      match: { channel: "dmwork", accountId },
+    });
+    console.log(`Created binding: ${accountId} -> agent "${agentId}"`);
+  } catch {
+    console.log(
+      `Warning: Could not create binding. Add manually: {"agentId":"${agentId}","match":{"channel":"dmwork","accountId":"${accountId}"}}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Agent.md
+// ---------------------------------------------------------------------------
+
+function ensureAgentMd(agentId: string, accountId: string, apiUrl: string): void {
+  const agentDir = join(homedir(), ".openclaw", "agents", agentId, "agent");
+  const agentMdPath = join(agentDir, "agent.md");
+
+  if (existsSync(agentMdPath)) {
+    console.log(`Agent "${agentId}" already exists. Keeping existing agent.md.`);
+    return;
+  }
+
+  try {
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      agentMdPath,
+      `I am ${accountId}, a DMWork bot.
+
+## Credentials
+
+- Account ID: ${accountId}
+- API server: ${apiUrl}
+- accountId must be passed when using dmwork_management tool
+
+## Capabilities
+
+My full API capabilities are documented at ${apiUrl}/v1/bot/skill.md — read it when I need to perform an action I'm unsure about.
+
+## Rules
+
+- Respond in the user's language
+- Be helpful and concise
+`,
+      "utf-8",
+    );
+    console.log(`Created agent: ~/.openclaw/agents/${agentId}/agent/agent.md`);
+  } catch {
+    console.log(
+      `Warning: Could not create agent.md at ${agentMdPath}`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+
+// Mock child_process at module level
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+// Re-import after mock is set up — dynamic import to get fresh module
+async function loadModule() {
+  // Clear module cache to pick up the mock
+  vi.resetModules();
+  return await import("./openclaw-cli.js");
+}
+
+describe("gatewayStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should parse real openclaw gateway status --json structure as running", async () => {
+    const { gatewayStatus } = await loadModule();
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({
+        service: { runtime: { status: "running", pid: 12345 } },
+        health: { healthy: true },
+        rpc: { ok: true },
+      }),
+    );
+
+    expect(gatewayStatus()).toEqual({ running: true });
+  });
+
+  it("should detect stopped gateway", async () => {
+    const { gatewayStatus } = await loadModule();
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({
+        service: { runtime: { status: "stopped" } },
+        health: { healthy: false },
+      }),
+    );
+
+    expect(gatewayStatus()).toEqual({ running: false });
+  });
+
+  it("should handle command failure gracefully", async () => {
+    const { gatewayStatus } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("command failed");
+    });
+
+    expect(gatewayStatus()).toEqual({ running: false });
+  });
+});
+
+describe("pluginsInspect", () => {
+  it("should parse JSON with preceding log noise", async () => {
+    const { pluginsInspect } = await loadModule();
+    mockExecFileSync.mockReturnValue(
+      '[dmwork] registering before_prompt_build hook\n' +
+        JSON.stringify({
+          plugin: { id: "test", version: "1.0.0", enabled: true },
+          install: { source: "npm", version: "1.0.0", installPath: "/tmp" },
+        }),
+    );
+
+    const result = pluginsInspect("test");
+    expect(result?.plugin?.version).toBe("1.0.0");
+    expect(result?.plugin?.enabled).toBe(true);
+  });
+
+  it("should return null when plugin not found", async () => {
+    const { pluginsInspect } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    expect(pluginsInspect("nonexistent")).toBeNull();
+  });
+});
+
+describe("getOpenClawVersion", () => {
+  it("should extract version from openclaw --version output", async () => {
+    const { getOpenClawVersion } = await loadModule();
+    mockExecFileSync.mockReturnValue("OpenClaw 2026.4.11 (769908e)\n");
+
+    expect(getOpenClawVersion()).toBe("2026.4.11");
+  });
+
+  it("should return null when openclaw is not installed", async () => {
+    const { getOpenClawVersion } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    expect(getOpenClawVersion()).toBeNull();
+  });
+});
+
+describe("configGet / configSet", () => {
+  it("should pass correct args to execFileSync", async () => {
+    const { configGet } = await loadModule();
+    mockExecFileSync.mockReturnValue("some_value\n");
+
+    const result = configGet("channels.dmwork.accounts.my_bot.botToken");
+    expect(result).toBe("some_value");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "openclaw",
+      ["config", "get", "channels.dmwork.accounts.my_bot.botToken"],
+      expect.any(Object),
+    );
+  });
+
+  it("should return null on empty output", async () => {
+    const { configGet } = await loadModule();
+    mockExecFileSync.mockReturnValue("\n");
+
+    expect(configGet("nonexistent.path")).toBeNull();
+  });
+});

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -1,0 +1,170 @@
+/**
+ * openclaw CLI wrapper.
+ * All openclaw invocations go through this module using execFileSync with
+ * argument arrays to avoid shell-quoting issues.
+ */
+
+import { execFileSync } from "node:child_process";
+
+const OPENCLAW = "openclaw";
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+export function getConfigFilePath(): string {
+  return execFileSync(OPENCLAW, ["config", "file"], { encoding: "utf-8" }).trim();
+}
+
+export function configGet(path: string): string | null {
+  try {
+    const val = execFileSync(OPENCLAW, ["config", "get", path], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return val === "" ? null : val;
+  } catch {
+    return null;
+  }
+}
+
+export function configGetJson(path: string): any {
+  try {
+    const out = execFileSync(OPENCLAW, ["config", "get", path, "--json"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const jsonStart = out.indexOf("{");
+    const arrStart = out.indexOf("[");
+    const start = jsonStart >= 0 && arrStart >= 0
+      ? Math.min(jsonStart, arrStart)
+      : Math.max(jsonStart, arrStart);
+    if (start < 0) return null;
+    return JSON.parse(out.slice(start));
+  } catch {
+    return null;
+  }
+}
+
+export function configSet(path: string, value: string): void {
+  execFileSync(OPENCLAW, ["config", "set", path, value], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+export function configSetBatch(
+  operations: Array<{ path: string; value: unknown }>,
+): void {
+  const batchJson = JSON.stringify(
+    operations.map((op) => ({ path: op.path, value: op.value })),
+  );
+  execFileSync(OPENCLAW, ["config", "set", "--batch-json", batchJson], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+export function configUnset(path: string): void {
+  execFileSync(OPENCLAW, ["config", "unset", path], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Plugin helpers
+// ---------------------------------------------------------------------------
+
+export function pluginsInstall(spec: string, force?: boolean): void {
+  const args = ["plugins", "install", spec];
+  if (force) args.push("--force");
+  execFileSync(OPENCLAW, args, { stdio: "inherit" });
+}
+
+export function pluginsUpdate(id: string, quiet?: boolean): void {
+  execFileSync(OPENCLAW, ["plugins", "update", id], {
+    stdio: quiet ? ["pipe", "pipe", "pipe"] : "inherit",
+  });
+}
+
+export function pluginsUninstall(id: string, yes?: boolean): void {
+  const args = ["plugins", "uninstall", id];
+  if (yes) args.push("--force");
+  execFileSync(OPENCLAW, args, { stdio: "inherit" });
+}
+
+export interface PluginInspectResult {
+  plugin?: {
+    id: string;
+    version: string;
+    enabled: boolean;
+  };
+  install?: {
+    source: string;
+    version: string;
+    installPath: string;
+  };
+}
+
+export function pluginsInspect(id: string): PluginInspectResult | null {
+  try {
+    const out = execFileSync(OPENCLAW, ["plugins", "inspect", id, "--json"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    // stdout may contain plugin log noise before JSON — find the JSON object
+    const jsonStart = out.indexOf("{");
+    if (jsonStart < 0) return null;
+    return JSON.parse(out.slice(jsonStart));
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gateway helpers
+// ---------------------------------------------------------------------------
+
+export function gatewayStatus(): { running: boolean } {
+  try {
+    const out = execFileSync(OPENCLAW, ["gateway", "status", "--json"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const jsonStart = out.indexOf("{");
+    if (jsonStart < 0) return { running: false };
+    const data = JSON.parse(out.slice(jsonStart));
+    // Real structure: { service.runtime.status: "running", health.healthy: true }
+    const runtimeRunning = data.service?.runtime?.status === "running";
+    const healthy = data.health?.healthy === true;
+    return { running: runtimeRunning || healthy };
+  } catch {
+    return { running: false };
+  }
+}
+
+export function gatewayRestart(quiet?: boolean): boolean {
+  try {
+    execFileSync(OPENCLAW, ["gateway", "restart"], {
+      stdio: quiet ? ["pipe", "pipe", "pipe"] : "inherit",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Version
+// ---------------------------------------------------------------------------
+
+export function getOpenClawVersion(): string | null {
+  try {
+    const out = execFileSync(OPENCLAW, ["--version"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const match = out.match(/(\d{4}\.\d+\.\d+)/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -88,10 +88,12 @@ export function configUnset(path: string): void {
 // Plugin helpers
 // ---------------------------------------------------------------------------
 
-export function pluginsInstall(spec: string, force?: boolean): void {
+export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): void {
   const args = ["plugins", "install", spec];
   if (force) args.push("--force");
-  execFileSync(OPENCLAW, args, { stdio: "inherit" });
+  execFileSync(OPENCLAW, args, {
+    stdio: quiet ? ["pipe", "pipe", "pipe"] : "inherit",
+  });
 }
 
 export function pluginsUpdate(id: string, quiet?: boolean): void {

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -5,8 +5,17 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
 
 const OPENCLAW = "openclaw";
+
+/** Expand ~ to home directory */
+function expandHome(p: string): string {
+  if (p.startsWith("~/")) return resolve(homedir(), p.slice(2));
+  return p;
+}
 
 // ---------------------------------------------------------------------------
 // Config helpers
@@ -59,6 +68,12 @@ export function configSetBatch(
     operations.map((op) => ({ path: op.path, value: op.value })),
   );
   execFileSync(OPENCLAW, ["config", "set", "--batch-json", batchJson], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+export function configSetJson(path: string, value: unknown): void {
+  execFileSync(OPENCLAW, ["config", "set", path, JSON.stringify(value), "--strict-json"], {
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
@@ -167,4 +182,48 @@ export function getOpenClawVersion(): string | null {
   } catch {
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Direct JSON file access (for config backup/restore around uninstall)
+//
+// openclaw plugins uninstall deletes channels.dmwork from the config file.
+// We cannot use `openclaw config get` to back up because it redacts secrets,
+// and we cannot use `openclaw config set` to restore because after uninstall
+// the channel id is unknown and validation rejects it.
+// So we read/write the JSON file directly for this specific operation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Save the channels.dmwork section from openclaw.json by reading the file
+ * directly (preserving secrets that `openclaw config get` would redact).
+ */
+export function saveChannelConfigFromFile(): Record<string, unknown> | null {
+  try {
+    const configPath = expandHome(getConfigFilePath());
+    const raw = readFileSync(configPath, "utf-8");
+    const cfg = JSON.parse(raw);
+    return cfg?.channels?.dmwork ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Restore the channels.dmwork section into openclaw.json by writing the file
+ * directly (bypassing validation that would reject unknown channel ids).
+ * Creates a .bak backup before writing.
+ */
+export function restoreChannelConfigToFile(
+  dmworkConfig: Record<string, unknown>,
+): void {
+  const configPath = expandHome(getConfigFilePath());
+  // Backup
+  copyFileSync(configPath, configPath + ".bak");
+  // Read, merge, write
+  const raw = readFileSync(configPath, "utf-8");
+  const cfg = JSON.parse(raw);
+  if (!cfg.channels) cfg.channels = {};
+  cfg.channels.dmwork = dmworkConfig;
+  writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
 }

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -227,3 +227,36 @@ export function restoreChannelConfigToFile(
   cfg.channels.dmwork = dmworkConfig;
   writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
 }
+
+/**
+ * Remove channels.dmwork directly from the JSON file.
+ * Used before uninstall to avoid config validation errors
+ * (openclaw config unset also fails when the channel id is unknown).
+ */
+/**
+ * Get the openclaw config file path without calling the CLI.
+ * Falls back to the standard default when CLI is unavailable
+ * (e.g. during uninstall when config validation fails).
+ */
+function getConfigFilePathSafe(): string {
+  try {
+    return expandHome(getConfigFilePath());
+  } catch {
+    return resolve(homedir(), ".openclaw", "openclaw.json");
+  }
+}
+
+export function removeChannelConfigFromFile(): void {
+  try {
+    const configPath = getConfigFilePathSafe();
+    copyFileSync(configPath, configPath + ".bak");
+    const raw = readFileSync(configPath, "utf-8");
+    const cfg = JSON.parse(raw);
+    if (cfg.channels?.dmwork) {
+      delete cfg.channels.dmwork;
+      writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+    }
+  } catch {
+    // best effort
+  }
+}

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -262,3 +262,43 @@ export function removeChannelConfigFromFile(): void {
     // best effort
   }
 }
+
+/**
+ * Read the full config object directly from file (for doctor phase-1 checks).
+ */
+export function readConfigFromFile(): Record<string, any> | null {
+  try {
+    const configPath = getConfigFilePathSafe();
+    const raw = readFileSync(configPath, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove orphaned dmwork bindings from the config file.
+ * If validAccountIds is provided, only removes bindings referencing accounts
+ * not in that list. Otherwise removes all dmwork bindings.
+ */
+export function removeOrphanedBindingsFromFile(
+  channel: string,
+  validAccountIds?: string[],
+): void {
+  try {
+    const configPath = getConfigFilePathSafe();
+    copyFileSync(configPath, configPath + ".bak");
+    const raw = readFileSync(configPath, "utf-8");
+    const cfg = JSON.parse(raw);
+    if (!Array.isArray(cfg.bindings)) return;
+    cfg.bindings = cfg.bindings.filter((b: any) => {
+      if (b.match?.channel !== channel) return true; // keep non-dmwork
+      if (!validAccountIds) return false; // remove all dmwork bindings
+      // Keep only if accountId is in valid list (or no accountId specified)
+      return !b.match.accountId || validAccountIds.includes(b.match.accountId);
+    });
+    writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+  } catch {
+    // best effort
+  }
+}

--- a/openclaw-channel-dmwork/cli/remove-account.ts
+++ b/openclaw-channel-dmwork/cli/remove-account.ts
@@ -7,6 +7,8 @@ import {
   configGetJson,
   configUnset,
   gatewayRestart,
+  saveChannelConfigFromFile,
+  restoreChannelConfigToFile,
   pluginsUninstall,
 } from "./openclaw-cli.js";
 import {
@@ -70,7 +72,18 @@ export async function runRemoveAccount(
       );
     }
     if (shouldUninstall) {
-      pluginsUninstall(PLUGIN_ID, true);
+      // Use same backup/restore pattern as uninstall command:
+      // openclaw plugins uninstall deletes channels.dmwork, so save first
+      const savedConfig = saveChannelConfigFromFile();
+      try {
+        pluginsUninstall(PLUGIN_ID, true);
+      } finally {
+        // Restore channels.dmwork (accounts section is now empty but
+        // top-level apiUrl etc. may still be useful for future reinstall)
+        if (savedConfig) {
+          restoreChannelConfigToFile(savedConfig);
+        }
+      }
       console.log("Plugin uninstalled.");
     }
   }

--- a/openclaw-channel-dmwork/cli/remove-account.ts
+++ b/openclaw-channel-dmwork/cli/remove-account.ts
@@ -1,0 +1,84 @@
+/**
+ * remove-account command: delete a single bot account config without touching the plugin.
+ */
+
+import {
+  configGet,
+  configGetJson,
+  configUnset,
+  gatewayRestart,
+  pluginsUninstall,
+} from "./openclaw-cli.js";
+import {
+  PLUGIN_ID,
+  confirm,
+  ensureOpenClawCompat,
+  validateAccountId,
+} from "./utils.js";
+
+export interface RemoveAccountOptions {
+  accountId: string;
+  yes?: boolean;
+}
+
+export async function runRemoveAccount(
+  opts: RemoveAccountOptions,
+): Promise<void> {
+  ensureOpenClawCompat();
+
+  if (!validateAccountId(opts.accountId)) {
+    console.error(
+      `Error: Invalid account ID "${opts.accountId}". Only letters, digits, and underscores are allowed.`,
+    );
+    process.exit(1);
+  }
+
+  // Check if account exists
+  const token = configGet(
+    `channels.dmwork.accounts.${opts.accountId}.botToken`,
+  );
+  if (!token) {
+    console.error(`Error: Account "${opts.accountId}" does not exist.`);
+    process.exit(1);
+  }
+
+  if (!opts.yes) {
+    const ok = await confirm(
+      `Delete bot account "${opts.accountId}"?`,
+    );
+    if (!ok) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  // Delete account
+  configUnset(`channels.dmwork.accounts.${opts.accountId}`);
+  console.log(`Removed account: ${opts.accountId}`);
+
+  // Check remaining accounts
+  const remaining = configGetJson("channels.dmwork.accounts");
+  const remainingCount = remaining ? Object.keys(remaining).length : 0;
+
+  if (remainingCount === 0) {
+    let shouldUninstall = false;
+    if (opts.yes) {
+      shouldUninstall = true;
+    } else {
+      shouldUninstall = await confirm(
+        "No active bot accounts remaining. Uninstall the plugin?",
+      );
+    }
+    if (shouldUninstall) {
+      pluginsUninstall(PLUGIN_ID, true);
+      console.log("Plugin uninstalled.");
+    }
+  }
+
+  console.log("Restarting gateway...");
+  if (!gatewayRestart()) {
+    console.log(
+      "Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.",
+    );
+  }
+}

--- a/openclaw-channel-dmwork/cli/remove-account.ts
+++ b/openclaw-channel-dmwork/cli/remove-account.ts
@@ -7,8 +7,6 @@ import {
   configGetJson,
   configUnset,
   gatewayRestart,
-  saveChannelConfigFromFile,
-  restoreChannelConfigToFile,
   pluginsUninstall,
 } from "./openclaw-cli.js";
 import {
@@ -72,18 +70,10 @@ export async function runRemoveAccount(
       );
     }
     if (shouldUninstall) {
-      // Use same backup/restore pattern as uninstall command:
-      // openclaw plugins uninstall deletes channels.dmwork, so save first
-      const savedConfig = saveChannelConfigFromFile();
-      try {
-        pluginsUninstall(PLUGIN_ID, true);
-      } finally {
-        // Restore channels.dmwork (accounts section is now empty but
-        // top-level apiUrl etc. may still be useful for future reinstall)
-        if (savedConfig) {
-          restoreChannelConfigToFile(savedConfig);
-        }
-      }
+      // Clean up channels.dmwork before uninstall to avoid "unknown channel id"
+      // residue that would block future installs
+      configUnset("channels.dmwork");
+      pluginsUninstall(PLUGIN_ID, true);
       console.log("Plugin uninstalled.");
     }
   }

--- a/openclaw-channel-dmwork/cli/uninstall.ts
+++ b/openclaw-channel-dmwork/cli/uninstall.ts
@@ -1,11 +1,18 @@
 /**
- * uninstall command: delegate to openclaw plugins uninstall + optional config cleanup.
+ * uninstall command: delegate to openclaw plugins uninstall + config preservation.
+ *
+ * IMPORTANT: openclaw plugins uninstall deletes channels.dmwork along with the
+ * plugin. We save the config by reading the JSON file directly before uninstall,
+ * then write it back afterwards. We cannot use openclaw config get/set because:
+ * - get redacts secrets (botToken becomes __OPENCLAW_REDACTED__)
+ * - set rejects channels.dmwork after uninstall ("unknown channel id")
  */
 
 import {
-  configUnset,
   gatewayRestart,
   pluginsUninstall,
+  saveChannelConfigFromFile,
+  restoreChannelConfigToFile,
 } from "./openclaw-cli.js";
 import { PLUGIN_ID, confirm, ensureOpenClawCompat } from "./utils.js";
 
@@ -27,14 +34,20 @@ export async function runUninstall(opts: UninstallOptions): Promise<void> {
     }
   }
 
+  // Save channels.dmwork config BEFORE uninstall (reading file directly to preserve secrets)
+  const savedConfig = opts.removeConfig
+    ? null
+    : saveChannelConfigFromFile();
+
   console.log("Uninstalling DMWork plugin...");
   pluginsUninstall(PLUGIN_ID, opts.yes);
 
+  // Restore or confirm removal
   if (opts.removeConfig) {
-    console.log("Removing channels.dmwork config...");
-    configUnset("channels.dmwork");
-  } else {
-    console.log("Keeping channels.dmwork config (use --remove-config to delete).");
+    console.log("Removed channels.dmwork config.");
+  } else if (savedConfig) {
+    restoreChannelConfigToFile(savedConfig);
+    console.log("Restored channels.dmwork config.");
   }
 
   console.log("Restarting gateway...");

--- a/openclaw-channel-dmwork/cli/uninstall.ts
+++ b/openclaw-channel-dmwork/cli/uninstall.ts
@@ -1,0 +1,48 @@
+/**
+ * uninstall command: delegate to openclaw plugins uninstall + optional config cleanup.
+ */
+
+import {
+  configUnset,
+  gatewayRestart,
+  pluginsUninstall,
+} from "./openclaw-cli.js";
+import { PLUGIN_ID, confirm, ensureOpenClawCompat } from "./utils.js";
+
+export interface UninstallOptions {
+  removeConfig?: boolean;
+  yes?: boolean;
+}
+
+export async function runUninstall(opts: UninstallOptions): Promise<void> {
+  ensureOpenClawCompat();
+
+  if (!opts.yes) {
+    const ok = await confirm(
+      "Uninstall DMWork plugin? All bots will stop working.",
+    );
+    if (!ok) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  console.log("Uninstalling DMWork plugin...");
+  pluginsUninstall(PLUGIN_ID, opts.yes);
+
+  if (opts.removeConfig) {
+    console.log("Removing channels.dmwork config...");
+    configUnset("channels.dmwork");
+  } else {
+    console.log("Keeping channels.dmwork config (use --remove-config to delete).");
+  }
+
+  console.log("Restarting gateway...");
+  if (!gatewayRestart()) {
+    console.log(
+      "Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.",
+    );
+  }
+
+  console.log("DMWork plugin uninstalled.");
+}

--- a/openclaw-channel-dmwork/cli/uninstall.ts
+++ b/openclaw-channel-dmwork/cli/uninstall.ts
@@ -39,15 +39,19 @@ export async function runUninstall(opts: UninstallOptions): Promise<void> {
     ? null
     : saveChannelConfigFromFile();
 
-  console.log("Uninstalling DMWork plugin...");
-  pluginsUninstall(PLUGIN_ID, opts.yes);
+  try {
+    console.log("Uninstalling DMWork plugin...");
+    pluginsUninstall(PLUGIN_ID, opts.yes);
+  } finally {
+    // Always restore config, even if uninstall fails partway through
+    if (!opts.removeConfig && savedConfig) {
+      restoreChannelConfigToFile(savedConfig);
+      console.log("Restored channels.dmwork config.");
+    }
+  }
 
-  // Restore or confirm removal
   if (opts.removeConfig) {
     console.log("Removed channels.dmwork config.");
-  } else if (savedConfig) {
-    restoreChannelConfigToFile(savedConfig);
-    console.log("Restored channels.dmwork config.");
   }
 
   console.log("Restarting gateway...");

--- a/openclaw-channel-dmwork/cli/uninstall.ts
+++ b/openclaw-channel-dmwork/cli/uninstall.ts
@@ -1,23 +1,17 @@
 /**
- * uninstall command: delegate to openclaw plugins uninstall + config preservation.
- *
- * IMPORTANT: openclaw plugins uninstall deletes channels.dmwork along with the
- * plugin. We save the config by reading the JSON file directly before uninstall,
- * then write it back afterwards. We cannot use openclaw config get/set because:
- * - get redacts secrets (botToken becomes __OPENCLAW_REDACTED__)
- * - set rejects channels.dmwork after uninstall ("unknown channel id")
+ * uninstall command: delegate to openclaw plugins uninstall.
+ * Removes plugin + all channels.dmwork config (openclaw CLI does this automatically).
  */
 
 import {
   gatewayRestart,
+  pluginsInspect,
   pluginsUninstall,
-  saveChannelConfigFromFile,
-  restoreChannelConfigToFile,
+  removeChannelConfigFromFile,
 } from "./openclaw-cli.js";
 import { PLUGIN_ID, confirm, ensureOpenClawCompat } from "./utils.js";
 
 export interface UninstallOptions {
-  removeConfig?: boolean;
   yes?: boolean;
 }
 
@@ -26,7 +20,7 @@ export async function runUninstall(opts: UninstallOptions): Promise<void> {
 
   if (!opts.yes) {
     const ok = await confirm(
-      "Uninstall DMWork plugin? All bots will stop working.",
+      "Uninstall DMWork plugin? All bot configs will be removed.",
     );
     if (!ok) {
       console.log("Cancelled.");
@@ -34,24 +28,16 @@ export async function runUninstall(opts: UninstallOptions): Promise<void> {
     }
   }
 
-  // Save channels.dmwork config BEFORE uninstall (reading file directly to preserve secrets)
-  const savedConfig = opts.removeConfig
-    ? null
-    : saveChannelConfigFromFile();
+  // Remove channels.dmwork directly from file before uninstall to avoid
+  // config validation errors ("unknown channel id: dmwork")
+  removeChannelConfigFromFile();
 
-  try {
-    console.log("Uninstalling DMWork plugin...");
+  console.log("Uninstalling DMWork plugin...");
+  const inspect = pluginsInspect(PLUGIN_ID);
+  if (inspect?.plugin) {
     pluginsUninstall(PLUGIN_ID, opts.yes);
-  } finally {
-    // Always restore config, even if uninstall fails partway through
-    if (!opts.removeConfig && savedConfig) {
-      restoreChannelConfigToFile(savedConfig);
-      console.log("Restored channels.dmwork config.");
-    }
-  }
-
-  if (opts.removeConfig) {
-    console.log("Removed channels.dmwork config.");
+  } else {
+    console.log("Plugin not installed. Skipping.");
   }
 
   console.log("Restarting gateway...");

--- a/openclaw-channel-dmwork/cli/update.ts
+++ b/openclaw-channel-dmwork/cli/update.ts
@@ -1,18 +1,35 @@
 /**
- * update command: delegate to openclaw plugins update + gateway restart.
+ * update command:
+ * - Without --dev: always target latest (stable) version
+ * - With --dev: always target @dev tag version
+ * - Skip if the target version is already installed
  */
 
 import {
   gatewayRestart,
   pluginsInspect,
   pluginsInstall,
-  pluginsUpdate,
 } from "./openclaw-cli.js";
 import { PLUGIN_ID, ensureOpenClawCompat } from "./utils.js";
+import { execFileSync } from "node:child_process";
 
 export interface UpdateOptions {
   json?: boolean;
   dev?: boolean;
+}
+
+/**
+ * Query npm registry for the latest version under a given tag.
+ */
+function getLatestNpmVersion(tag: string): string | null {
+  try {
+    return execFileSync("npm", ["view", `${PLUGIN_ID}@${tag}`, "version"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
 }
 
 export async function runUpdate(opts: UpdateOptions): Promise<void> {
@@ -28,45 +45,50 @@ export async function runUpdate(opts: UpdateOptions): Promise<void> {
     process.exit(1);
   }
 
-  const previousVersion = inspect.plugin.version;
+  const currentVersion = inspect.plugin.version;
+  const tag = opts.dev ? "dev" : "latest";
+  const targetVersion = getLatestNpmVersion(tag);
+
+  if (!targetVersion) {
+    if (opts.json) {
+      console.log(JSON.stringify({ success: false, error: "registry_unavailable" }));
+    } else {
+      console.error(`Error: Cannot reach npm registry to check ${tag} version.`);
+    }
+    process.exit(1);
+  }
+
+  // Skip if already on the target version
+  if (currentVersion === targetVersion) {
+    if (opts.json) {
+      console.log(JSON.stringify({ success: true, previousVersion: currentVersion, currentVersion: targetVersion }));
+    } else {
+      console.log(`Already up to date (v${currentVersion}).`);
+    }
+    return;
+  }
+
+  const quiet = Boolean(opts.json);
+
+  if (!quiet) {
+    console.log(`Updating DMWork plugin: v${currentVersion} -> v${targetVersion}${opts.dev ? " (dev)" : ""}...`);
+  }
+
+  // Use --force to replace existing installation when switching versions
+  pluginsInstall(`${PLUGIN_ID}@${tag}`, quiet, true);
+
+  if (!quiet) {
+    console.log("Restarting gateway...");
+  }
+  if (!gatewayRestart(quiet)) {
+    if (!quiet) {
+      console.log("Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.");
+    }
+  }
 
   if (opts.json) {
-    if (opts.dev) {
-      pluginsInstall(`${PLUGIN_ID}@dev`, true);
-    } else {
-      pluginsUpdate(PLUGIN_ID, true);
-    }
-    gatewayRestart(true);
-    const updated = pluginsInspect(PLUGIN_ID);
-    console.log(
-      JSON.stringify({
-        success: true,
-        previousVersion,
-        currentVersion: updated?.plugin?.version ?? previousVersion,
-      }),
-    );
+    console.log(JSON.stringify({ success: true, previousVersion: currentVersion, currentVersion: targetVersion }));
   } else {
-    if (opts.dev) {
-      console.log("Updating DMWork plugin (dev)...");
-      pluginsInstall(`${PLUGIN_ID}@dev`, true);
-    } else {
-      console.log("Updating DMWork plugin...");
-      pluginsUpdate(PLUGIN_ID);
-    }
-
-    console.log("Restarting gateway...");
-    if (!gatewayRestart()) {
-      console.log(
-        "Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.",
-      );
-    }
-
-    const updated = pluginsInspect(PLUGIN_ID);
-    const newVersion = updated?.plugin?.version ?? "unknown";
-    if (newVersion === previousVersion) {
-      console.log(`Already up to date (v${previousVersion}).`);
-    } else {
-      console.log(`Updated: v${previousVersion} -> v${newVersion}`);
-    }
+    console.log(`Updated: v${currentVersion} -> v${targetVersion}`);
   }
 }

--- a/openclaw-channel-dmwork/cli/update.ts
+++ b/openclaw-channel-dmwork/cli/update.ts
@@ -1,0 +1,62 @@
+/**
+ * update command: delegate to openclaw plugins update + gateway restart.
+ */
+
+import {
+  gatewayRestart,
+  pluginsInspect,
+  pluginsUpdate,
+} from "./openclaw-cli.js";
+import { PLUGIN_ID, ensureOpenClawCompat } from "./utils.js";
+
+export interface UpdateOptions {
+  json?: boolean;
+}
+
+export async function runUpdate(opts: UpdateOptions): Promise<void> {
+  ensureOpenClawCompat();
+
+  const inspect = pluginsInspect(PLUGIN_ID);
+  if (!inspect?.plugin) {
+    if (opts.json) {
+      console.log(JSON.stringify({ success: false, error: "not_installed" }));
+    } else {
+      console.error("DMWork plugin is not installed. Use 'install' first.");
+    }
+    process.exit(1);
+  }
+
+  const previousVersion = inspect.plugin.version;
+
+  if (opts.json) {
+    // JSON mode: suppress text output, capture everything
+    pluginsUpdate(PLUGIN_ID, true);
+    gatewayRestart(true);
+    const updated = pluginsInspect(PLUGIN_ID);
+    console.log(
+      JSON.stringify({
+        success: true,
+        previousVersion,
+        currentVersion: updated?.plugin?.version ?? previousVersion,
+      }),
+    );
+  } else {
+    console.log("Updating DMWork plugin...");
+    pluginsUpdate(PLUGIN_ID);
+
+    console.log("Restarting gateway...");
+    if (!gatewayRestart()) {
+      console.log(
+        "Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.",
+      );
+    }
+
+    const updated = pluginsInspect(PLUGIN_ID);
+    const newVersion = updated?.plugin?.version ?? "unknown";
+    if (newVersion === previousVersion) {
+      console.log(`Already up to date (v${previousVersion}).`);
+    } else {
+      console.log(`Updated: v${previousVersion} -> v${newVersion}`);
+    }
+  }
+}

--- a/openclaw-channel-dmwork/cli/update.ts
+++ b/openclaw-channel-dmwork/cli/update.ts
@@ -5,12 +5,14 @@
 import {
   gatewayRestart,
   pluginsInspect,
+  pluginsInstall,
   pluginsUpdate,
 } from "./openclaw-cli.js";
 import { PLUGIN_ID, ensureOpenClawCompat } from "./utils.js";
 
 export interface UpdateOptions {
   json?: boolean;
+  dev?: boolean;
 }
 
 export async function runUpdate(opts: UpdateOptions): Promise<void> {
@@ -29,8 +31,11 @@ export async function runUpdate(opts: UpdateOptions): Promise<void> {
   const previousVersion = inspect.plugin.version;
 
   if (opts.json) {
-    // JSON mode: suppress text output, capture everything
-    pluginsUpdate(PLUGIN_ID, true);
+    if (opts.dev) {
+      pluginsInstall(`${PLUGIN_ID}@dev`, true);
+    } else {
+      pluginsUpdate(PLUGIN_ID, true);
+    }
     gatewayRestart(true);
     const updated = pluginsInspect(PLUGIN_ID);
     console.log(
@@ -41,8 +46,13 @@ export async function runUpdate(opts: UpdateOptions): Promise<void> {
       }),
     );
   } else {
-    console.log("Updating DMWork plugin...");
-    pluginsUpdate(PLUGIN_ID);
+    if (opts.dev) {
+      console.log("Updating DMWork plugin (dev)...");
+      pluginsInstall(`${PLUGIN_ID}@dev`, true);
+    } else {
+      console.log("Updating DMWork plugin...");
+      pluginsUpdate(PLUGIN_ID);
+    }
 
     console.log("Restarting gateway...");
     if (!gatewayRestart()) {

--- a/openclaw-channel-dmwork/cli/utils.test.ts
+++ b/openclaw-channel-dmwork/cli/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { validateAccountId } from "./utils.js";
+
+describe("validateAccountId", () => {
+  it("should accept valid IDs", () => {
+    expect(validateAccountId("my_bot")).toBe(true);
+    expect(validateAccountId("Bot123")).toBe(true);
+    expect(validateAccountId("a")).toBe(true);
+    expect(validateAccountId("test_bot_2")).toBe(true);
+  });
+
+  it("should reject invalid IDs", () => {
+    expect(validateAccountId("")).toBe(false);
+    expect(validateAccountId("my-bot")).toBe(false);
+    expect(validateAccountId("my bot")).toBe(false);
+    expect(validateAccountId("bot.name")).toBe(false);
+    expect(validateAccountId("bot/name")).toBe(false);
+    expect(validateAccountId("bot@name")).toBe(false);
+  });
+});

--- a/openclaw-channel-dmwork/cli/utils.ts
+++ b/openclaw-channel-dmwork/cli/utils.ts
@@ -1,0 +1,116 @@
+/**
+ * CLI utilities: version checking, accountId validation, readline prompts.
+ */
+
+import { createInterface } from "node:readline";
+import { getOpenClawVersion } from "./openclaw-cli.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const PLUGIN_ID = "openclaw-channel-dmwork";
+export const MIN_OPENCLAW_VERSION = "2026.2.0";
+export const RECOMMENDED_DM_SCOPE = "per-account-channel-peer";
+
+// ---------------------------------------------------------------------------
+// Version helpers
+// ---------------------------------------------------------------------------
+
+/** Compare two semver-like version strings. Returns -1, 0, or 1. */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va < vb) return -1;
+    if (va > vb) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Check that openclaw is available and meets the minimum version.
+ * Exits the process on failure.
+ */
+export function ensureOpenClawCompat(): void {
+  const version = getOpenClawVersion();
+  if (!version) {
+    console.error(
+      "Error: openclaw not found. Install it first: npm i -g openclaw",
+    );
+    process.exit(1);
+  }
+  if (compareVersions(version, MIN_OPENCLAW_VERSION) < 0) {
+    console.error(
+      `Error: OpenClaw ${version} is too old. Minimum required: ${MIN_OPENCLAW_VERSION}`,
+    );
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// accountId validation
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_ID_RE = /^[A-Za-z0-9_]+$/;
+
+export function validateAccountId(id: string): boolean {
+  return ACCOUNT_ID_RE.test(id);
+}
+
+// ---------------------------------------------------------------------------
+// Interactive detection
+// ---------------------------------------------------------------------------
+
+/** Returns true if stdin is a TTY (interactive terminal). */
+export function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY);
+}
+
+// ---------------------------------------------------------------------------
+// readline prompts (fail in non-TTY)
+// ---------------------------------------------------------------------------
+
+function createRL() {
+  return createInterface({ input: process.stdin, output: process.stdout });
+}
+
+/** Ask a yes/no question. Returns true for yes. In non-TTY, returns defaultYes. */
+export async function confirm(
+  question: string,
+  defaultYes = false,
+): Promise<boolean> {
+  if (!isInteractive()) return defaultYes;
+  const suffix = defaultYes ? "(Y/n)" : "(y/N)";
+  const rl = createRL();
+  return new Promise<boolean>((resolve) => {
+    rl.question(`${question} ${suffix} `, (answer) => {
+      rl.close();
+      const trimmed = answer.trim().toLowerCase();
+      if (trimmed === "") resolve(defaultYes);
+      else resolve(trimmed === "y" || trimmed === "yes");
+    });
+  });
+}
+
+/**
+ * Prompt for a text value. In non-TTY, exits with error.
+ * Use requireParam() instead when possible.
+ */
+export async function prompt(question: string): Promise<string> {
+  if (!isInteractive()) {
+    console.error(
+      `Error: Missing required input in non-interactive mode. Pass the value via command-line arguments.`,
+    );
+    process.exit(1);
+  }
+  const rl = createRL();
+  return new Promise<string>((resolve) => {
+    rl.question(`${question} `, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}

--- a/openclaw-channel-dmwork/index.ts
+++ b/openclaw-channel-dmwork/index.ts
@@ -9,6 +9,11 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { dmworkPlugin } from "./src/channel.js";
 import { setDmworkRuntime } from "./src/runtime.js";
 import { getGroupMdForPrompt } from "./src/group-md.js";
+import {
+  inProcessConfigReader,
+  runDoctorChecks,
+  formatDoctorResult,
+} from "./cli/doctor.js";
 
 const plugin: {
   id: string;
@@ -22,6 +27,21 @@ const plugin: {
   register(api) {
     setDmworkRuntime(api.runtime);
     api.registerChannel({ plugin: dmworkPlugin });
+
+    api.registerCommand({
+      name: "dmwork_doctor",
+      description: "Check DMWork plugin status and connectivity",
+      acceptsArgs: true,
+      async handler(ctx) {
+        const reader = inProcessConfigReader(ctx.config);
+        const result = await runDoctorChecks({
+          reader,
+          accountId: ctx.args?.trim() || undefined,
+          inProcess: true,
+        });
+        return { text: formatDoctorResult(result) };
+      },
+    });
 
     console.log('[dmwork] registering before_prompt_build hook');
     api.on('before_prompt_build', (_event, ctx) => {

--- a/openclaw-channel-dmwork/index.ts
+++ b/openclaw-channel-dmwork/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { execFileSync } from "node:child_process";
 import { dmworkPlugin } from "./src/channel.js";
 import { setDmworkRuntime } from "./src/runtime.js";
 import { getGroupMdForPrompt } from "./src/group-md.js";
@@ -14,6 +15,19 @@ import {
   runDoctorChecks,
   formatDoctorResult,
 } from "./cli/doctor.js";
+import {
+  getOpenClawVersion,
+  pluginsInspect,
+  configGet,
+  configGetJson,
+  configSet,
+  configUnset,
+  gatewayRestart,
+  pluginsInstall,
+  pluginsUninstall,
+  removeChannelConfigFromFile,
+} from "./cli/openclaw-cli.js";
+import { PLUGIN_ID, RECOMMENDED_DM_SCOPE, validateAccountId } from "./cli/utils.js";
 
 const plugin: {
   id: string;
@@ -40,6 +54,151 @@ const plugin: {
           inProcess: true,
         });
         return { text: formatDoctorResult(result) };
+      },
+    });
+
+    // /dmwork_info
+    api.registerCommand({
+      name: "dmwork_info",
+      description: "Show DMWork plugin version info",
+      acceptsArgs: false,
+      async handler() {
+        const openclawVersion = getOpenClawVersion() ?? "not found";
+        const inspect = pluginsInspect(PLUGIN_ID);
+        const installedVersion = inspect?.plugin?.version ?? "not installed";
+        return {
+          text: [
+            `openclaw-channel-dmwork: ${installedVersion}`,
+            `openclaw: ${openclawVersion}`,
+            `plugin package: ${PLUGIN_ID}`,
+          ].join("\n"),
+        };
+      },
+    });
+
+    // /dmwork_install
+    api.registerCommand({
+      name: "dmwork_install",
+      description: "Install or reinstall the DMWork plugin",
+      acceptsArgs: true,
+      async handler(ctx) {
+        const args = ctx.args?.trim() ?? "";
+        // Parse: --force or empty
+        const force = args.includes("--force");
+        try {
+          const inspect = pluginsInspect(PLUGIN_ID);
+          if (inspect?.plugin && !force) {
+            return { text: `DMWork plugin already installed (v${inspect.plugin.version}). Use --force to reinstall.` };
+          }
+          pluginsInstall(PLUGIN_ID, true, force);
+          gatewayRestart(true);
+          const after = pluginsInspect(PLUGIN_ID);
+          return { text: `DMWork plugin installed (v${after?.plugin?.version ?? "unknown"}). Gateway restarted.` };
+        } catch (e) {
+          return { text: `Install failed: ${e instanceof Error ? e.message : String(e)}`, isError: true };
+        }
+      },
+    });
+
+    // /dmwork_update
+    api.registerCommand({
+      name: "dmwork_update",
+      description: "Update DMWork plugin to latest version",
+      acceptsArgs: false,
+      async handler() {
+        try {
+          const inspect = pluginsInspect(PLUGIN_ID);
+          if (!inspect?.plugin) {
+            return { text: "DMWork plugin is not installed. Use /dmwork_install first.", isError: true };
+          }
+          const currentVersion = inspect.plugin.version;
+          const targetVersion = execFileSync("npm", ["view", `${PLUGIN_ID}@latest`, "version"], {
+            encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"],
+          }).trim();
+          if (currentVersion === targetVersion) {
+            return { text: `Already up to date (v${currentVersion}).` };
+          }
+          pluginsInstall(`${PLUGIN_ID}@latest`, true, true);
+          gatewayRestart(true);
+          return { text: `Updated: v${currentVersion} -> v${targetVersion}. Gateway restarted.` };
+        } catch (e) {
+          return { text: `Update failed: ${e instanceof Error ? e.message : String(e)}`, isError: true };
+        }
+      },
+    });
+
+    // /dmwork_uninstall
+    api.registerCommand({
+      name: "dmwork_uninstall",
+      description: "Uninstall DMWork plugin and remove all bot configs",
+      acceptsArgs: false,
+      async handler() {
+        try {
+          removeChannelConfigFromFile();
+          pluginsUninstall(PLUGIN_ID, true);
+          gatewayRestart(true);
+          return { text: "DMWork plugin uninstalled. All bot configs removed." };
+        } catch (e) {
+          return { text: `Uninstall failed: ${e instanceof Error ? e.message : String(e)}`, isError: true };
+        }
+      },
+    });
+
+    // /dmwork_add_account <account_id> <bot_token> <api_url>
+    api.registerCommand({
+      name: "dmwork_add_account",
+      description: "Add a DMWork bot account. Args: <account_id> <bot_token> <api_url>",
+      acceptsArgs: true,
+      async handler(ctx) {
+        const parts = ctx.args?.trim().split(/\s+/) ?? [];
+        if (parts.length < 3) {
+          return { text: "Usage: /dmwork_add_account <account_id> <bot_token> <api_url>", isError: true };
+        }
+        const [accountId, botToken, apiUrl] = parts;
+        if (!validateAccountId(accountId)) {
+          return { text: `Invalid account ID "${accountId}". Only letters, digits, and underscores allowed.`, isError: true };
+        }
+        if (!botToken.startsWith("bf_")) {
+          return { text: "Bot token must start with 'bf_'.", isError: true };
+        }
+        try {
+          configSet(`channels.dmwork.accounts.${accountId}.botToken`, botToken);
+          configSet(`channels.dmwork.accounts.${accountId}.apiUrl`, apiUrl);
+          const dmScope = configGet("session.dmScope");
+          if (!dmScope) {
+            configSet("session.dmScope", RECOMMENDED_DM_SCOPE);
+          }
+          gatewayRestart(true);
+          return { text: `Added bot account: ${accountId} (API: ${apiUrl}). Gateway restarted.` };
+        } catch (e) {
+          return { text: `Failed: ${e instanceof Error ? e.message : String(e)}`, isError: true };
+        }
+      },
+    });
+
+    // /dmwork_remove_account <account_id>
+    api.registerCommand({
+      name: "dmwork_remove_account",
+      description: "Remove a DMWork bot account. Args: <account_id>",
+      acceptsArgs: true,
+      async handler(ctx) {
+        const accountId = ctx.args?.trim();
+        if (!accountId) {
+          return { text: "Usage: /dmwork_remove_account <account_id>", isError: true };
+        }
+        try {
+          const token = configGet(`channels.dmwork.accounts.${accountId}.botToken`);
+          if (!token) {
+            return { text: `Account "${accountId}" does not exist.`, isError: true };
+          }
+          configUnset(`channels.dmwork.accounts.${accountId}`);
+          gatewayRestart(true);
+          const remaining = configGetJson("channels.dmwork.accounts");
+          const count = remaining ? Object.keys(remaining).length : 0;
+          return { text: `Removed account: ${accountId}. ${count} account(s) remaining. Gateway restarted.` };
+        } catch (e) {
+          return { text: `Failed: ${e instanceof Error ? e.message : String(e)}`, isError: true };
+        }
       },
     });
 

--- a/openclaw-channel-dmwork/index.ts
+++ b/openclaw-channel-dmwork/index.ts
@@ -147,7 +147,7 @@ const plugin: {
     // /dmwork_add_account <account_id> <bot_token> <api_url>
     api.registerCommand({
       name: "dmwork_add_account",
-      description: "Add a DMWork bot account. Args: <account_id> <bot_token> <api_url>",
+      description: "Add or update a DMWork bot account. Args: <account_id> <bot_token> <api_url>",
       acceptsArgs: true,
       async handler(ctx) {
         const parts = ctx.args?.trim().split(/\s+/) ?? [];
@@ -162,6 +162,7 @@ const plugin: {
           return { text: "Bot token must start with 'bf_'.", isError: true };
         }
         try {
+          const existed = Boolean(configGet(`channels.dmwork.accounts.${accountId}.botToken`));
           configSet(`channels.dmwork.accounts.${accountId}.botToken`, botToken);
           configSet(`channels.dmwork.accounts.${accountId}.apiUrl`, apiUrl);
           const dmScope = configGet("session.dmScope");
@@ -169,7 +170,7 @@ const plugin: {
             configSet("session.dmScope", RECOMMENDED_DM_SCOPE);
           }
           gatewayRestart(true);
-          return { text: `Added bot account: ${accountId} (API: ${apiUrl}). Gateway restarted.` };
+          return { text: `${existed ? "Updated" : "Added"} bot account: ${accountId} (API: ${apiUrl}). Gateway restarted.` };
         } catch (e) {
           return { text: `Failed: ${e instanceof Error ? e.message : String(e)}`, isError: true };
         }
@@ -185,6 +186,9 @@ const plugin: {
         const accountId = ctx.args?.trim();
         if (!accountId) {
           return { text: "Usage: /dmwork_remove_account <account_id>", isError: true };
+        }
+        if (!validateAccountId(accountId)) {
+          return { text: `Invalid account ID "${accountId}". Only letters, digits, and underscores allowed.`, isError: true };
         }
         try {
           const token = configGet(`channels.dmwork.accounts.${accountId}.botToken`);

--- a/openclaw-channel-dmwork/package-lock.json
+++ b/openclaw-channel-dmwork/package-lock.json
@@ -15,11 +15,15 @@
       ],
       "dependencies": {
         "axios": "^1.7.0",
+        "commander": "^12.1.0",
         "cos-nodejs-sdk-v5": "^2.15.4",
         "crypto-js": "^4.2.0",
         "curve25519-js": "^0.0.4",
         "md5-typescript": "^1.0.5",
         "ws": "^8.16.0"
+      },
+      "bin": {
+        "openclaw-channel-dmwork": "bin/dmwork.js"
       },
       "devDependencies": {
         "@types/crypto-js": "^4.2.0",
@@ -954,15 +958,6 @@
         "scripts/actions/documentation"
       ]
     },
-    "node_modules/@buape/carbon/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@buape/carbon/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
@@ -1251,15 +1246,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/voice/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
@@ -7035,14 +7021,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -9174,6 +9158,17 @@
       },
       "optionalDependencies": {
         "@reflink/reflink": "^0.1.16"
+      }
+    },
+    "node_modules/ipull/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/ipull/node_modules/lifecycle-utils": {

--- a/openclaw-channel-dmwork/package.json
+++ b/openclaw-channel-dmwork/package.json
@@ -3,13 +3,18 @@
   "version": "0.5.19",
   "description": "DMWork channel plugin for OpenClaw via WuKongIM WebSocket",
   "main": "dist/index.js",
+  "bin": {
+    "openclaw-channel-dmwork": "bin/dmwork.js"
+  },
   "types": "dist/index.d.ts",
   "type": "module",
   "files": [
+    "bin",
     "dist",
     "openclaw.plugin.json"
   ],
   "scripts": {
+    "prebuild": "rm -rf dist",
     "build": "tsc",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
@@ -17,6 +22,7 @@
   },
   "dependencies": {
     "axios": "^1.7.0",
+    "commander": "^12.1.0",
     "cos-nodejs-sdk-v5": "^2.15.4",
     "crypto-js": "^4.2.0",
     "curve25519-js": "^0.0.4",

--- a/openclaw-channel-dmwork/tsconfig.json
+++ b/openclaw-channel-dmwork/tsconfig.json
@@ -10,6 +10,6 @@
     "declaration": true,
     "sourceMap": true
   },
-  "include": ["index.ts", "src/**/*.ts"],
+  "include": ["index.ts", "src/**/*.ts", "cli/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- 新增 CLI 安装器，支持 `npx -y openclaw-channel-dmwork install/update/doctor/uninstall/remove-account/info` 一键操作
- 所有插件生命周期委托 `openclaw plugins` 官方 CLI，我们只做 dmwork 专属配置引导
- 配置以 accounts 多账号模型为中心，install 追加 bot 不覆盖已有配置
- doctor --fix 自动修复残留配置、插件未安装/未启用、Gateway 未运行等问题
- update 先比对版本再决定是否安装，支持隐藏 --dev 参数切换 dev/latest
- 注册 7 个 OpenClaw 内部命令（/dmwork_doctor、/dmwork_info、/dmwork_install 等）
- 更新 README 为 npx 安装方式和 accounts 配置模型

## Test plan

- [ ] `npm run build` 编译通过
- [ ] `npm test` 476 个测试全部通过
- [ ] `node bin/dmwork.js info` 显示版本信息
- [ ] `node bin/dmwork.js install --bot-token bf_xxx --api-url https://... --account-id test` 安装配置
- [ ] `node bin/dmwork.js doctor` 诊断检查
- [ ] `node bin/dmwork.js doctor --fix` 自动修复
- [ ] `node bin/dmwork.js update` 更新插件
- [ ] `node bin/dmwork.js remove-account --account-id test --yes` 删除账号
- [ ] `node bin/dmwork.js uninstall --yes` 卸载插件

🤖 Generated with [Claude Code](https://claude.com/claude-code)