### PR TITLE
feat: Thread GROUP.md support for sub-channels

### DIFF
--- a/openclaw-channel-dmwork/src/agent-tools.test.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.test.ts
@@ -15,10 +15,13 @@ vi.mock("./api-fetch.js", () => ({
   getVoiceContext: vi.fn(),
   updateVoiceContext: vi.fn(),
   deleteVoiceContext: vi.fn(),
+  getThreadMd: vi.fn(),
+  updateThreadMd: vi.fn(),
 }));
 
 vi.mock("./group-md.js", () => ({
   broadcastGroupMdUpdate: vi.fn(),
+  broadcastThreadMdUpdate: vi.fn(),
 }));
 
 import { createDmworkManagementTools } from "./agent-tools.js";
@@ -36,8 +39,10 @@ import {
   getVoiceContext,
   updateVoiceContext,
   deleteVoiceContext,
+  getThreadMd,
+  updateThreadMd,
 } from "./api-fetch.js";
-import { broadcastGroupMdUpdate } from "./group-md.js";
+import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 
 // Minimal config stub — mocked account functions don't inspect it
 const mockCfg = { channels: { dmwork: { botToken: "tok-secret" } } } as any;
@@ -833,6 +838,136 @@ describe("createDmworkManagementTools", () => {
       const result = await getExecute()("tc", { action: "voice-read" });
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.error).toContain("Unknown action");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // thread-md-read
+  // -----------------------------------------------------------------------
+  describe("execute — thread-md-read", () => {
+    it("returns THREAD.md content on success", async () => {
+      vi.mocked(getThreadMd).mockResolvedValue({
+        content: "# Sprint 42",
+        version: 2,
+        updated_at: "2026-04-13",
+        updated_by: "user1",
+      });
+      const result = await getExecute()("tc", {
+        action: "thread-md-read",
+        groupId: "g1",
+        shortId: "thr1",
+      });
+      const data = parseText(result);
+      expect(data.content).toBe("# Sprint 42");
+      expect(data.version).toBe(2);
+    });
+
+    it("returns error when groupId is missing", async () => {
+      const result = await getExecute()("tc", {
+        action: "thread-md-read",
+        shortId: "thr1",
+      });
+      const data = parseText(result);
+      expect(data.error).toContain("groupId");
+    });
+
+    it("returns error when shortId is missing", async () => {
+      const result = await getExecute()("tc", {
+        action: "thread-md-read",
+        groupId: "g1",
+      });
+      const data = parseText(result);
+      expect(data.error).toContain("shortId");
+    });
+
+    it("returns empty content on 404 instead of throwing", async () => {
+      vi.mocked(getThreadMd).mockRejectedValue(new Error("getThreadMd failed (404): not found"));
+      const result = await getExecute()("tc", {
+        action: "thread-md-read",
+        groupId: "g1",
+        shortId: "thr1",
+      });
+      const data = parseText(result);
+      expect(data.content).toBe("");
+      expect(data.version).toBe(0);
+    });
+
+    it("returns error on non-404 API failure", async () => {
+      vi.mocked(getThreadMd).mockRejectedValue(new Error("getThreadMd failed (500): internal"));
+      const result = await getExecute()("tc", {
+        action: "thread-md-read",
+        groupId: "g1",
+        shortId: "thr1",
+      });
+      const data = parseText(result);
+      expect(data.error).toContain("Failed to read thread THREAD.md");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // thread-md-update
+  // -----------------------------------------------------------------------
+  describe("execute — thread-md-update", () => {
+    it("updates and calls broadcastThreadMdUpdate", async () => {
+      vi.mocked(updateThreadMd).mockResolvedValue({ version: 3 });
+      const result = await getExecute()("tc", {
+        action: "thread-md-update",
+        groupId: "g1",
+        shortId: "thr1",
+        content: "# Updated thread",
+      });
+      const data = parseText(result);
+      expect(data.updated).toBe(true);
+      expect(data.version).toBe(3);
+      expect(broadcastThreadMdUpdate).toHaveBeenCalledWith({
+        accountId: "default",
+        groupNo: "g1",
+        shortId: "thr1",
+        content: "# Updated thread",
+        version: 3,
+      });
+    });
+
+    it("returns error when groupId is missing", async () => {
+      const result = await getExecute()("tc", {
+        action: "thread-md-update",
+        shortId: "thr1",
+        content: "# New",
+      });
+      const data = parseText(result);
+      expect(data.error).toContain("groupId");
+    });
+
+    it("returns error when shortId is missing", async () => {
+      const result = await getExecute()("tc", {
+        action: "thread-md-update",
+        groupId: "g1",
+        content: "# New",
+      });
+      const data = parseText(result);
+      expect(data.error).toContain("shortId");
+    });
+
+    it("returns error when content is missing", async () => {
+      const result = await getExecute()("tc", {
+        action: "thread-md-update",
+        groupId: "g1",
+        shortId: "thr1",
+      });
+      const data = parseText(result);
+      expect(data.error).toContain("content");
+    });
+
+    it("returns error on API failure", async () => {
+      vi.mocked(updateThreadMd).mockRejectedValue(new Error("updateThreadMd failed (403): forbidden"));
+      const result = await getExecute()("tc", {
+        action: "thread-md-update",
+        groupId: "g1",
+        shortId: "thr1",
+        content: "# Fail",
+      });
+      const data = parseText(result);
+      expect(data.error).toContain("thread-md-update failed");
     });
   });
 });

--- a/openclaw-channel-dmwork/src/agent-tools.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.ts
@@ -35,8 +35,10 @@ import {
   getVoiceContext,
   updateVoiceContext,
   deleteVoiceContext,
+  getThreadMd,
+  updateThreadMd,
 } from "./api-fetch.js";
-import { broadcastGroupMdUpdate } from "./group-md.js";
+import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 
@@ -82,7 +84,7 @@ export function createDmworkManagementTools(params: {
       label: "DMWork Management",
       description:
         "Manage DMWork groups and personal voice correction context: list groups, get group info/members, " +
-        "read or update GROUP.md, and manage personal voice correction context (read/update/delete). " +
+        "read or update GROUP.md (group-level and thread-level), and manage personal voice correction context. " +
         "Use this tool for any DMWork management operations.",
       parameters: {
         type: "object",
@@ -107,6 +109,8 @@ export function createDmworkManagementTools(params: {
               "list-thread-members",
               "join-thread",
               "leave-thread",
+              "thread-md-read",
+              "thread-md-update",
               "voice-context-read",
               "voice-context-update",
               "voice-context-delete",
@@ -158,7 +162,7 @@ export function createDmworkManagementTools(params: {
           shortId: {
             type: "string",
             description:
-              "Thread short ID. Required for get-thread, delete-thread, list-thread-members, join-thread, leave-thread.",
+              "Thread short ID. Required for get-thread, delete-thread, list-thread-members, join-thread, leave-thread, thread-md-read, thread-md-update.",
           },
           accountId: {
             type: "string",
@@ -385,6 +389,33 @@ export function createDmworkManagementTools(params: {
               return makeSuccess({ left: true, groupId, shortId });
             }
 
+            case "thread-md-read": {
+              if (!groupId)
+                return makeError("groupId is required for thread-md-read");
+              const shortId = args.shortId as string | undefined;
+              if (!shortId)
+                return makeError("shortId is required for thread-md-read");
+              return await handleThreadMdRead({ apiUrl, botToken, groupId, shortId });
+            }
+
+            case "thread-md-update": {
+              if (!groupId)
+                return makeError("groupId is required for thread-md-update");
+              const shortId = args.shortId as string | undefined;
+              if (!shortId)
+                return makeError("shortId is required for thread-md-update");
+              if (!content)
+                return makeError("content is required for thread-md-update");
+              return await handleThreadMdUpdate({
+                apiUrl,
+                botToken,
+                groupId,
+                shortId,
+                content,
+                accountId,
+              });
+            }
+
             case "voice-context-read":
               return await handleVoiceContextRead({ apiUrl, botToken });
 
@@ -493,6 +524,60 @@ async function handleGroupMdUpdate(params: {
   broadcastGroupMdUpdate({
     accountId: params.accountId,
     groupNo: params.groupId,
+    content: params.content,
+    version: result.version,
+  });
+
+  return makeSuccess({ updated: true, version: result.version });
+}
+
+// ---------------------------------------------------------------------------
+// Thread MD Handlers
+// ---------------------------------------------------------------------------
+
+async function handleThreadMdRead(params: {
+  apiUrl: string;
+  botToken: string;
+  groupId: string;
+  shortId: string;
+}): Promise<ToolResult> {
+  try {
+    const md = await getThreadMd({
+      apiUrl: params.apiUrl,
+      botToken: params.botToken,
+      groupNo: params.groupId,
+      shortId: params.shortId,
+    });
+    return makeSuccess(md);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("(404)")) {
+      return makeSuccess({ content: "", version: 0, updated_at: null, updated_by: "" });
+    }
+    return makeError(`Failed to read thread THREAD.md: ${msg}`);
+  }
+}
+
+async function handleThreadMdUpdate(params: {
+  apiUrl: string;
+  botToken: string;
+  groupId: string;
+  shortId: string;
+  content: string;
+  accountId: string;
+}): Promise<ToolResult> {
+  const result = await updateThreadMd({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+    groupNo: params.groupId,
+    shortId: params.shortId,
+    content: params.content,
+  });
+
+  broadcastThreadMdUpdate({
+    accountId: params.accountId,
+    groupNo: params.groupId,
+    shortId: params.shortId,
     content: params.content,
     version: result.version,
   });

--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -412,6 +412,69 @@ export async function getGroupMd(params: {
   return await resp.json();
 }
 
+/**
+ * Get thread THREAD.md content (throws on non-2xx — used by agent-tools).
+ * GET /v1/bot/groups/{groupNo}/threads/{shortId}/md
+ *
+ * See also: group-md.ts `fetchThreadMdFromApi()` which returns null on error
+ * and is used for background cache refresh where failures are non-fatal.
+ */
+export async function getThreadMd(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  log?: { info?: (msg: string) => void; error?: (msg: string) => void };
+}): Promise<{ content: string; version: number; updated_at: string | null; updated_by: string }> {
+  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/md`;
+  const resp = await fetch(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${params.botToken}` },
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`getThreadMd failed (${resp.status}): ${text || resp.statusText}`);
+  }
+  return await resp.json();
+}
+
+/**
+ * Update thread THREAD.md content (requires bot_admin permission).
+ * PUT /v1/bot/groups/{groupNo}/threads/{shortId}/md
+ *
+ * Content size limit: 10,240 bytes (server-side GetGroupMdMaxSize()).
+ */
+export async function updateThreadMd(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  content: string;
+  log?: { info?: (msg: string) => void; error?: (msg: string) => void };
+}): Promise<{ version: number }> {
+  const contentSize = new TextEncoder().encode(params.content).byteLength;
+  if (contentSize > 10240) {
+    throw new Error(`updateThreadMd: content size (${contentSize} bytes) exceeds maximum 10,240 bytes`);
+  }
+
+  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/md`;
+  const resp = await fetch(url, {
+    method: "PUT",
+    headers: {
+      ...DEFAULT_HEADERS,
+      Authorization: `Bearer ${params.botToken}`,
+    },
+    body: JSON.stringify({ content: params.content }),
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`updateThreadMd failed (${resp.status}): ${text || resp.statusText}`);
+  }
+  return await resp.json();
+}
+
 // Update GROUP.md content for a group (requires bot_admin permission)
 export async function updateGroupMd(params: {
   apiUrl: string;

--- a/openclaw-channel-dmwork/src/group-md.test.ts
+++ b/openclaw-channel-dmwork/src/group-md.test.ts
@@ -20,6 +20,7 @@ import {
   readThreadMdFromDisk,
   deleteThreadMdFromDisk,
   broadcastThreadMdUpdate,
+  broadcastGroupMdUpdate,
   ensureThreadMd,
   handleThreadMdEvent,
   DMWORK_GROUP_RE,
@@ -570,6 +571,56 @@ describe("broadcastThreadMdUpdate", () => {
 
     const content = readThreadMdFromDisk("acct1", "grp1", "thr1");
     expect(content).toBe("# Broadcast test");
+  });
+
+  it("should not throw when writeThreadMdToDisk fails", () => {
+    // Make HOME point to a read-only path that will cause mkdirSync to fail
+    process.env.HOME = "/dev/null/impossible";
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      broadcastThreadMdUpdate({
+        accountId: "acct1",
+        groupNo: "grp1",
+        shortId: "thr1",
+        content: "# fail",
+        version: 1,
+      }),
+    ).not.toThrow();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("broadcastThreadMdUpdate failed"),
+    );
+    spy.mockRestore();
+  });
+});
+
+describe("broadcastGroupMdUpdate", () => {
+  it("should write group md to disk", () => {
+    broadcastGroupMdUpdate({
+      accountId: "acct1",
+      groupNo: "grp1",
+      content: "# Group test",
+      version: 3,
+    });
+
+    const content = readGroupMdFromDisk("acct1", "grp1");
+    expect(content).toBe("# Group test");
+  });
+
+  it("should not throw when writeGroupMdToDisk fails", () => {
+    process.env.HOME = "/dev/null/impossible";
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() =>
+      broadcastGroupMdUpdate({
+        accountId: "acct1",
+        groupNo: "grp1",
+        content: "# fail",
+        version: 1,
+      }),
+    ).not.toThrow();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("broadcastGroupMdUpdate failed"),
+    );
+    spy.mockRestore();
   });
 });
 

--- a/openclaw-channel-dmwork/src/group-md.test.ts
+++ b/openclaw-channel-dmwork/src/group-md.test.ts
@@ -13,9 +13,19 @@ import {
   clearGroupMdChecked,
   getKnownGroupIds,
   getOrCreateGroupMdCache,
+  extractParentGroupNo,
+  extractThreadShortId,
+  isThreadChannelId,
+  writeThreadMdToDisk,
+  readThreadMdFromDisk,
+  deleteThreadMdFromDisk,
+  broadcastThreadMdUpdate,
+  ensureThreadMd,
+  handleThreadMdEvent,
   DMWORK_GROUP_RE,
   _testGetGroupAccountMap,
   _testGetCheckedGroups,
+  _testGetCheckedThreads,
   _testReset,
   type GroupMdMeta,
 } from "./group-md.js";
@@ -379,5 +389,511 @@ describe("getKnownGroupIds", () => {
     const ids = getKnownGroupIds();
     expect(ids.has("grp_a1")).toBe(true);
     expect(ids.has("grp_a2")).toBe(true);
+  });
+});
+
+// =========================================================================
+// Channel ID helper tests
+// =========================================================================
+
+describe("extractParentGroupNo", () => {
+  it("should return groupNo for plain group channelId", () => {
+    expect(extractParentGroupNo("abc123")).toBe("abc123");
+  });
+
+  it("should extract parent groupNo from thread channelId", () => {
+    expect(extractParentGroupNo("abc123____def456")).toBe("abc123");
+  });
+
+  it("should handle real-world hex group + numeric shortId", () => {
+    expect(extractParentGroupNo("04f51b141553442ca63d7d10b1274be5____2039626171074744320")).toBe("04f51b141553442ca63d7d10b1274be5");
+  });
+
+  it("should return the full string when no ____ separator", () => {
+    expect(extractParentGroupNo("no_separator_here")).toBe("no_separator_here");
+  });
+
+  it("should handle empty string", () => {
+    expect(extractParentGroupNo("")).toBe("");
+  });
+});
+
+describe("extractThreadShortId", () => {
+  it("should return null for plain group channelId", () => {
+    expect(extractThreadShortId("abc123")).toBeNull();
+  });
+
+  it("should extract shortId from thread channelId", () => {
+    expect(extractThreadShortId("abc123____def456")).toBe("def456");
+  });
+
+  it("should handle real-world hex group + numeric shortId", () => {
+    expect(extractThreadShortId("04f51b141553442ca63d7d10b1274be5____2039626171074744320")).toBe("2039626171074744320");
+  });
+
+  it("should return null for single underscore separators", () => {
+    expect(extractThreadShortId("abc_123")).toBeNull();
+    expect(extractThreadShortId("abc__123")).toBeNull();
+    expect(extractThreadShortId("abc___123")).toBeNull();
+  });
+
+  it("should return null when shortId portion is empty", () => {
+    expect(extractThreadShortId("abc123____")).toBeNull();
+  });
+});
+
+describe("isThreadChannelId", () => {
+  it("should return false for plain group channelId", () => {
+    expect(isThreadChannelId("abc123")).toBe(false);
+  });
+
+  it("should return true for thread channelId", () => {
+    expect(isThreadChannelId("abc123____def456")).toBe(true);
+  });
+
+  it("should return false for fewer than 4 underscores", () => {
+    expect(isThreadChannelId("abc___def")).toBe(false);
+    expect(isThreadChannelId("abc__def")).toBe(false);
+  });
+
+  it("should return true when ____ appears anywhere", () => {
+    expect(isThreadChannelId("____suffix")).toBe(true);
+    expect(isThreadChannelId("prefix____")).toBe(true);
+  });
+});
+
+// =========================================================================
+// Thread disk cache tests
+// =========================================================================
+
+describe("writeThreadMdToDisk / readThreadMdFromDisk", () => {
+  const accountId = "jeff";
+  const groupNo = "grp_abc";
+  const shortId = "thread_123";
+
+  it("should write and read THREAD.md content", () => {
+    const content = "# Thread Rules\nStay on topic.";
+    const meta: GroupMdMeta = {
+      version: 3,
+      updated_at: "2026-04-13T15:30:00Z",
+      updated_by: "user123",
+      fetched_at: "2026-04-13T15:31:00Z",
+      account_id: accountId,
+    };
+
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content, meta });
+
+    const readContent = readThreadMdFromDisk(accountId, groupNo, shortId);
+    expect(readContent).toBe(content);
+  });
+
+  it("should return null for non-existent thread file", () => {
+    expect(readThreadMdFromDisk(accountId, groupNo, "nonexistent")).toBeNull();
+  });
+
+  it("should overwrite existing thread files", () => {
+    const meta: GroupMdMeta = {
+      version: 1,
+      updated_at: null,
+      updated_by: "u1",
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content: "v1", meta });
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBe("v1");
+
+    writeThreadMdToDisk({
+      accountId, groupNo, shortId,
+      content: "v2",
+      meta: { ...meta, version: 2 },
+    });
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBe("v2");
+  });
+
+  it("should store in correct disk path hierarchy", () => {
+    const content = "# Path test";
+    const meta: GroupMdMeta = {
+      version: 1,
+      updated_at: null,
+      updated_by: "u1",
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content, meta });
+
+    const expectedPath = join(tmpBase, ".openclaw", "workspace", "dmwork", accountId, "groups", groupNo, "threads", shortId, "THREAD.md");
+    expect(existsSync(expectedPath)).toBe(true);
+    expect(readFileSync(expectedPath, "utf-8")).toBe(content);
+
+    const expectedMetaPath = join(tmpBase, ".openclaw", "workspace", "dmwork", accountId, "groups", groupNo, "threads", shortId, "THREAD.meta.json");
+    expect(existsSync(expectedMetaPath)).toBe(true);
+  });
+});
+
+describe("deleteThreadMdFromDisk", () => {
+  const accountId = "jeff";
+  const groupNo = "grp_del";
+  const shortId = "thread_del";
+
+  it("should delete THREAD.md and meta files", () => {
+    const meta: GroupMdMeta = {
+      version: 1,
+      updated_at: null,
+      updated_by: "u1",
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content: "test", meta });
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBe("test");
+
+    deleteThreadMdFromDisk(accountId, groupNo, shortId);
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBeNull();
+  });
+
+  it("should not throw when files don't exist", () => {
+    expect(() => deleteThreadMdFromDisk(accountId, groupNo, "nonexistent")).not.toThrow();
+  });
+});
+
+describe("broadcastThreadMdUpdate", () => {
+  it("should write thread md to disk", () => {
+    broadcastThreadMdUpdate({
+      accountId: "acct1",
+      groupNo: "grp1",
+      shortId: "thr1",
+      content: "# Broadcast test",
+      version: 5,
+    });
+
+    const content = readThreadMdFromDisk("acct1", "grp1", "thr1");
+    expect(content).toBe("# Broadcast test");
+  });
+});
+
+// =========================================================================
+// P0: getGroupMdForPrompt with thread channelIds
+// =========================================================================
+
+describe("getGroupMdForPrompt (thread support)", () => {
+  const agentId = "testAgent";
+  const accountId = "jeff";
+  const groupNo = "grp_thread";
+  const shortId = "thr_123";
+
+  it("should return group-level GROUP.md for thread sessionKey", () => {
+    registerGroupAccount(groupNo, accountId, agentId);
+    const content = "# Group Rules\nBe nice.";
+    const meta: GroupMdMeta = {
+      version: 1,
+      updated_at: null,
+      updated_by: "admin",
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+    writeGroupMdToDisk({ accountId, groupNo, content, meta });
+
+    // Thread sessionKey contains "groupNo____shortId"
+    const result = getGroupMdForPrompt({
+      sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
+      agentId,
+    });
+    expect(result).toBe(content);
+  });
+
+  it("should return cascaded group + thread content when both exist", () => {
+    registerGroupAccount(groupNo, accountId, agentId);
+    const groupContent = "# Group Rules\nBe nice.";
+    const threadContent = "# Sprint 42\nGoal: auth module";
+    const meta: GroupMdMeta = {
+      version: 1,
+      updated_at: null,
+      updated_by: "admin",
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+
+    writeGroupMdToDisk({ accountId, groupNo, content: groupContent, meta });
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content: threadContent, meta });
+
+    const result = getGroupMdForPrompt({
+      sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
+      agentId,
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain(groupContent);
+    expect(result).toContain("--- THREAD CONTEXT ---");
+    expect(result).toContain(threadContent);
+  });
+
+  it("should return only group content when thread md does not exist", () => {
+    registerGroupAccount(groupNo, accountId, agentId);
+    const groupContent = "# Group only";
+    const meta: GroupMdMeta = {
+      version: 1,
+      updated_at: null,
+      updated_by: "admin",
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+    writeGroupMdToDisk({ accountId, groupNo, content: groupContent, meta });
+
+    const result = getGroupMdForPrompt({
+      sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
+      agentId,
+    });
+    expect(result).toBe(groupContent);
+    expect(result).not.toContain("--- THREAD CONTEXT ---");
+  });
+
+  it("should return only thread content when group md does not exist", () => {
+    registerGroupAccount(groupNo, accountId, agentId);
+    const threadContent = "# Thread only content";
+    const meta: GroupMdMeta = {
+      version: 1,
+      updated_at: null,
+      updated_by: "admin",
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content: threadContent, meta });
+
+    const result = getGroupMdForPrompt({
+      sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
+      agentId,
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain("--- THREAD CONTEXT ---");
+    expect(result).toContain(threadContent);
+  });
+
+  it("should return null when neither group nor thread md exist", () => {
+    registerGroupAccount(groupNo, accountId, agentId);
+    const result = getGroupMdForPrompt({
+      sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
+      agentId,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("should not include thread context for plain group sessionKey", () => {
+    registerGroupAccount(groupNo, accountId, agentId);
+    const groupContent = "# Group Rules";
+    const threadContent = "# Thread content";
+    const meta: GroupMdMeta = {
+      version: 1,
+      updated_at: null,
+      updated_by: "admin",
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+    writeGroupMdToDisk({ accountId, groupNo, content: groupContent, meta });
+    // Write thread md under the same group — but sessionKey is for plain group
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content: threadContent, meta });
+
+    const result = getGroupMdForPrompt({
+      sessionKey: `agent:${agentId}:dmwork:group:${groupNo}`,
+      agentId,
+    });
+    // Should only get group content, not thread content
+    expect(result).toBe(groupContent);
+    expect(result).not.toContain("--- THREAD CONTEXT ---");
+  });
+});
+
+// =========================================================================
+// _testReset clears thread cache
+// =========================================================================
+
+describe("_testReset", () => {
+  it("should clear _checkedThreads", () => {
+    const checked = _testGetCheckedThreads();
+    checked.add("acct1/grp1/thr1");
+    expect(checked.size).toBe(1);
+
+    _testReset();
+    expect(checked.size).toBe(0);
+  });
+});
+
+// =========================================================================
+// Event type recognition for thread events
+// =========================================================================
+
+describe("event recognition (thread_md events)", () => {
+  it("should recognize thread_md_updated event type", () => {
+    const payload = {
+      type: 1,
+      content: "",
+      event: {
+        type: "thread_md_updated",
+        version: 4,
+        updated_by: "user123",
+        group_no: "grp_abc",
+        short_id: "thr_123",
+      },
+    };
+    expect(payload.event?.type).toBe("thread_md_updated");
+    expect(payload.event?.group_no).toBe("grp_abc");
+    expect(payload.event?.short_id).toBe("thr_123");
+  });
+
+  it("should recognize thread_md_deleted event type", () => {
+    const payload = {
+      type: 1,
+      content: "",
+      event: {
+        type: "thread_md_deleted",
+        group_no: "grp_abc",
+        short_id: "thr_123",
+      },
+    };
+    expect(payload.event?.type).toBe("thread_md_deleted");
+  });
+});
+
+// =========================================================================
+// ensureThreadMd (with mocked fetch)
+// =========================================================================
+
+describe("ensureThreadMd", () => {
+  const accountId = "acct1";
+  const groupNo = "grp1";
+  const shortId = "thr1";
+  const baseParams = {
+    agentId: "agent1",
+    accountId,
+    groupNo,
+    shortId,
+    apiUrl: "http://api.test",
+    botToken: "tok",
+  };
+
+  it("should fetch from API and write to disk on first call", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: "# Thread rules", version: 2, updated_at: "2026-04-13T00:00:00Z", updated_by: "user1" }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+    await ensureThreadMd(baseParams);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBe("# Thread rules");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should skip fetch on second call (same session)", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: "# Rules", version: 1, updated_at: null, updated_by: "u1" }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+    await ensureThreadMd(baseParams);
+    await ensureThreadMd(baseParams);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should not write to disk when API returns 404", async () => {
+    const mockResponse = { ok: false, status: 404 };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+    await ensureThreadMd(baseParams);
+
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBeNull();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should not write when API returns version=0 and empty content", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: "", version: 0, updated_at: null, updated_by: "" }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+    await ensureThreadMd(baseParams);
+
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBeNull();
+
+    fetchSpy.mockRestore();
+  });
+});
+
+// =========================================================================
+// handleThreadMdEvent (with mocked fetch)
+// =========================================================================
+
+describe("handleThreadMdEvent", () => {
+  const accountId = "acct1";
+  const groupNo = "grp1";
+  const shortId = "thr1";
+  const baseParams = {
+    agentId: "agent1",
+    accountId,
+    groupNo,
+    shortId,
+    apiUrl: "http://api.test",
+    botToken: "tok",
+  };
+
+  it("should delete disk cache on thread_md_deleted", async () => {
+    // Pre-populate disk
+    const meta: GroupMdMeta = {
+      version: 1, updated_at: null, updated_by: "u1",
+      fetched_at: new Date().toISOString(), account_id: accountId,
+    };
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content: "old", meta });
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBe("old");
+
+    await handleThreadMdEvent({ ...baseParams, eventType: "thread_md_deleted" });
+
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBeNull();
+  });
+
+  it("should re-fetch and update disk on thread_md_updated", async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: "# Updated", version: 5, updated_at: "2026-04-13T12:00:00Z", updated_by: "admin" }),
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+    await handleThreadMdEvent({ ...baseParams, eventType: "thread_md_updated" });
+
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBe("# Updated");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should clear checked flag on thread_md_deleted", async () => {
+    const checked = _testGetCheckedThreads();
+    checked.add(`${accountId}/${groupNo}/${shortId}`);
+
+    await handleThreadMdEvent({ ...baseParams, eventType: "thread_md_deleted" });
+
+    expect(checked.has(`${accountId}/${groupNo}/${shortId}`)).toBe(false);
+  });
+
+  it("should handle fetch failure on thread_md_updated gracefully", async () => {
+    const mockResponse = { ok: false, status: 500, text: async () => "Server Error" };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+    // Should not throw
+    await handleThreadMdEvent({ ...baseParams, eventType: "thread_md_updated" });
+
+    expect(readThreadMdFromDisk(accountId, groupNo, shortId)).toBeNull();
+
+    fetchSpy.mockRestore();
   });
 });

--- a/openclaw-channel-dmwork/src/group-md.ts
+++ b/openclaw-channel-dmwork/src/group-md.ts
@@ -403,8 +403,12 @@ export function broadcastGroupMdUpdate(params: {
     fetched_at: new Date().toISOString(),
     account_id: accountId,
   };
-  writeGroupMdToDisk({ accountId, groupNo, content, meta });
-  console.error(`[dmwork] broadcastGroupMdUpdate: updated disk cache group=${groupNo} v=${version}`);
+  try {
+    writeGroupMdToDisk({ accountId, groupNo, content, meta });
+    console.error(`[dmwork] broadcastGroupMdUpdate: updated disk cache group=${groupNo} v=${version}`);
+  } catch (err) {
+    console.error(`[dmwork] broadcastGroupMdUpdate failed for group=${groupNo}: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 /**
@@ -619,7 +623,12 @@ export function broadcastThreadMdUpdate(params: {
     fetched_at: new Date().toISOString(),
     account_id: accountId,
   };
-  writeThreadMdToDisk({ accountId, groupNo, shortId, content, meta });
+  try {
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content, meta });
+    console.error(`[dmwork] broadcastThreadMdUpdate: updated disk cache thread=${groupNo}/${shortId} v=${version}`);
+  } catch (err) {
+    console.error(`[dmwork] broadcastThreadMdUpdate failed for thread=${groupNo}/${shortId}: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 // --- Test helpers (exported for unit tests) ---

--- a/openclaw-channel-dmwork/src/group-md.ts
+++ b/openclaw-channel-dmwork/src/group-md.ts
@@ -15,6 +15,39 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import type { ChannelLogSink } from "openclaw/plugin-sdk";
 
+// --- Channel ID helpers ---
+
+/**
+ * Extract the parent group number from a channelId.
+ * Thread channelId format: "groupNo____shortId"
+ * Group channelId format: "groupNo"
+ */
+export function extractParentGroupNo(channelId: string): string {
+  const sep = channelId.indexOf("____");
+  return sep >= 0 ? channelId.slice(0, sep) : channelId;
+}
+
+/**
+ * Extract the thread shortId from a channelId.
+ * Only thread channelIds contain a shortId; group channelIds return null.
+ *
+ * Edge case: if channelId ends with "____" (no shortId portion), returns "".
+ * Callers that require a non-empty shortId should check for falsy values.
+ */
+export function extractThreadShortId(channelId: string): string | null {
+  const sep = channelId.indexOf("____");
+  if (sep < 0) return null;
+  const id = channelId.slice(sep + 4);
+  return id || null;
+}
+
+/**
+ * Check if a channelId is a thread (community topic) format.
+ */
+export function isThreadChannelId(channelId: string): boolean {
+  return channelId.includes("____");
+}
+
 export interface GroupMdMeta {
   version: number;
   updated_at: string | null;
@@ -304,6 +337,7 @@ export async function handleGroupMdEvent(params: {
  * Get GROUP.md content for prompt injection.
  * Called by the before_prompt_build hook.
  * Only does disk reads — no network calls.
+ * For thread sessions, returns cascaded group + thread content.
  */
 export function getGroupMdForPrompt(ctx: {
   sessionKey?: string;
@@ -314,13 +348,34 @@ export function getGroupMdForPrompt(ctx: {
 
   const match = DMWORK_GROUP_RE.exec(sessionKey);
   if (!match) return null;
-  const groupNo = match[1];
+  const rawId = match[1];  // may be "groupNo" or "groupNo____shortId"
 
-  const accountId = resolveAccountId(agentId, groupNo);
+  const parentGroupNo = extractParentGroupNo(rawId);
+  const shortId = extractThreadShortId(rawId);
+
+  const accountId = resolveAccountId(agentId, parentGroupNo);
   if (!accountId) return null;
 
-  const content = readGroupMdFromDisk(accountId, groupNo);
-  return content;
+  // 1. Always read group-level GROUP.md
+  const groupMd = readGroupMdFromDisk(accountId, parentGroupNo);
+
+  // 2. If thread session, also read thread-level THREAD.md
+  let threadMd: string | null = null;
+  if (shortId) {
+    threadMd = readThreadMdFromDisk(accountId, parentGroupNo, shortId);
+  }
+
+  // 3. Combine output
+  if (!groupMd && !threadMd) return null;
+
+  const parts: string[] = [];
+  if (groupMd) {
+    parts.push(groupMd);
+  }
+  if (threadMd) {
+    parts.push(`--- THREAD CONTEXT ---\n${threadMd}`);
+  }
+  return parts.join("\n\n");
 }
 
 /**
@@ -375,6 +430,198 @@ export function getKnownGroupIds(): Set<string> {
   return ids;
 }
 
+// --- Thread (子区) THREAD.md disk cache ---
+
+/** Tracks threads checked this session to avoid redundant API calls */
+const _checkedThreads = new Set<string>(); // "accountId/groupNo/shortId"
+
+function threadDir(accountId: string, groupNo: string, shortId: string): string {
+  return join(workspaceBase(), accountId, "groups", groupNo, "threads", shortId);
+}
+
+function threadMdPath(accountId: string, groupNo: string, shortId: string): string {
+  return join(threadDir(accountId, groupNo, shortId), "THREAD.md");
+}
+
+function threadMetaPath(accountId: string, groupNo: string, shortId: string): string {
+  return join(threadDir(accountId, groupNo, shortId), "THREAD.meta.json");
+}
+
+export function writeThreadMdToDisk(params: {
+  accountId: string;
+  groupNo: string;
+  shortId: string;
+  content: string;
+  meta: GroupMdMeta;
+}): void {
+  const dir = threadDir(params.accountId, params.groupNo, params.shortId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(threadMdPath(params.accountId, params.groupNo, params.shortId), params.content, "utf-8");
+  writeFileSync(threadMetaPath(params.accountId, params.groupNo, params.shortId), JSON.stringify(params.meta, null, 2), "utf-8");
+}
+
+export function readThreadMdFromDisk(accountId: string, groupNo: string, shortId: string): string | null {
+  try {
+    return readFileSync(threadMdPath(accountId, groupNo, shortId), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function readThreadMeta(accountId: string, groupNo: string, shortId: string): GroupMdMeta | null {
+  try {
+    return JSON.parse(readFileSync(threadMetaPath(accountId, groupNo, shortId), "utf-8")) as GroupMdMeta;
+  } catch {
+    return null;
+  }
+}
+
+export function deleteThreadMdFromDisk(accountId: string, groupNo: string, shortId: string): void {
+  try { unlinkSync(threadMdPath(accountId, groupNo, shortId)); } catch { /* ok */ }
+  try { unlinkSync(threadMetaPath(accountId, groupNo, shortId)); } catch { /* ok */ }
+}
+
+/**
+ * Fetch thread THREAD.md from the API (internal, used by ensureThreadMd / handleThreadMdEvent).
+ * Returns null on 404 or network error — callers treat missing THREAD.md as normal.
+ *
+ * Contrast with api-fetch.ts `getThreadMd()` which throws on non-2xx responses
+ * and is used by agent-tools where the caller needs explicit error propagation.
+ */
+async function fetchThreadMdFromApi(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  log?: ChannelLogSink;
+}): Promise<GroupMdApiResponse | null> {
+  const { apiUrl, botToken, groupNo, shortId, log } = params;
+  const url = `${apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${encodeURIComponent(groupNo)}/threads/${encodeURIComponent(shortId)}/md`;
+  try {
+    const resp = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${botToken}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (resp.status === 404) return null;
+    if (!resp.ok) {
+      log?.warn?.(`dmwork: [THREAD.md] fetch failed for ${groupNo}/${shortId}: ${resp.status}`);
+      return null;
+    }
+    const data = (await resp.json()) as GroupMdApiResponse;
+    // API returns version=0 + content="" for nonexistent thread md
+    if (!data.content && data.version === 0) return null;
+    return data;
+  } catch (err) {
+    log?.warn?.(`dmwork: [THREAD.md] fetch error for ${groupNo}/${shortId}: ${String(err)}`);
+    return null;
+  }
+}
+
+/**
+ * Ensure thread THREAD.md is cached on disk.
+ * Only checks once per session per thread.
+ */
+export async function ensureThreadMd(params: {
+  agentId: string;
+  accountId: string;
+  groupNo: string;
+  shortId: string;
+  apiUrl: string;
+  botToken: string;
+  log?: ChannelLogSink;
+}): Promise<void> {
+  const { accountId, groupNo, shortId, apiUrl, botToken, log } = params;
+  const key = `${accountId}/${groupNo}/${shortId}`;
+  if (_checkedThreads.has(key)) return;
+  _checkedThreads.add(key);
+
+  const apiData = await fetchThreadMdFromApi({ apiUrl, botToken, groupNo, shortId, log });
+  if (!apiData) return;
+
+  const existingMeta = readThreadMeta(accountId, groupNo, shortId);
+  if (existingMeta && existingMeta.version === apiData.version) {
+    log?.debug?.(`dmwork: [THREAD.md] cache up-to-date for ${groupNo}/${shortId} (v${apiData.version})`);
+    return;
+  }
+
+  const meta: GroupMdMeta = {
+    version: apiData.version,
+    updated_at: apiData.updated_at,
+    updated_by: apiData.updated_by,
+    fetched_at: new Date().toISOString(),
+    account_id: accountId,
+  };
+
+  writeThreadMdToDisk({ accountId, groupNo, shortId, content: apiData.content, meta });
+  log?.info?.(`dmwork: [THREAD.md] cached v${apiData.version} for thread ${groupNo}/${shortId}`);
+}
+
+/**
+ * Handle thread_md_updated / thread_md_deleted events.
+ */
+export async function handleThreadMdEvent(params: {
+  agentId: string;
+  accountId: string;
+  groupNo: string;
+  shortId: string;
+  eventType: string;
+  apiUrl: string;
+  botToken: string;
+  log?: ChannelLogSink;
+}): Promise<void> {
+  const { accountId, groupNo, shortId, eventType, apiUrl, botToken, log } = params;
+
+  if (eventType === "thread_md_deleted") {
+    deleteThreadMdFromDisk(accountId, groupNo, shortId);
+    _checkedThreads.delete(`${accountId}/${groupNo}/${shortId}`);
+    log?.info?.(`dmwork: [THREAD.md] deleted cache for thread ${groupNo}/${shortId}`);
+    return;
+  }
+
+  if (eventType === "thread_md_updated") {
+    _checkedThreads.delete(`${accountId}/${groupNo}/${shortId}`);
+    const apiData = await fetchThreadMdFromApi({ apiUrl, botToken, groupNo, shortId, log });
+    if (!apiData) {
+      log?.warn?.(`dmwork: [THREAD.md] update event but fetch returned null for ${groupNo}/${shortId}`);
+      return;
+    }
+
+    const meta: GroupMdMeta = {
+      version: apiData.version,
+      updated_at: apiData.updated_at,
+      updated_by: apiData.updated_by,
+      fetched_at: new Date().toISOString(),
+      account_id: accountId,
+    };
+
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content: apiData.content, meta });
+    _checkedThreads.add(`${accountId}/${groupNo}/${shortId}`);
+    log?.info?.(`dmwork: [THREAD.md] updated cache to v${apiData.version} for thread ${groupNo}/${shortId}`);
+  }
+}
+
+/**
+ * Update thread THREAD.md disk cache (called after tool updates).
+ */
+export function broadcastThreadMdUpdate(params: {
+  accountId: string;
+  groupNo: string;
+  shortId: string;
+  content: string;
+  version: number;
+}): void {
+  const { accountId, groupNo, shortId, content, version } = params;
+  const meta: GroupMdMeta = {
+    version,
+    updated_at: new Date().toISOString(),
+    updated_by: "event",
+    fetched_at: new Date().toISOString(),
+    account_id: accountId,
+  };
+  writeThreadMdToDisk({ accountId, groupNo, shortId, content, meta });
+}
+
 // --- Test helpers (exported for unit tests) ---
 
 export function _testGetGroupAccountMap(): Map<string, string> {
@@ -385,9 +632,14 @@ export function _testGetCheckedGroups(): Set<string> {
   return _checkedGroups;
 }
 
+export function _testGetCheckedThreads(): Set<string> {
+  return _checkedThreads;
+}
+
 export function _testReset(): void {
   _groupAccountMap.clear();
   _checkedGroups.clear();
   _groupMdCache.clear();
   _allBotGroupIds.clear();
+  _checkedThreads.clear();
 }

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -16,7 +16,7 @@ import {
   buildEntitiesFromFallback,
 } from "./mention-utils.js";
 import type { MentionPayload, MentionEntity } from "./types.js";
-import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate } from "./group-md.js";
+import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate, extractParentGroupNo, extractThreadShortId, ensureThreadMd, handleThreadMdEvent } from "./group-md.js";
 import { createWriteStream } from "node:fs";
 import { mkdir, unlink, readdir, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
@@ -948,7 +948,8 @@ export async function handleInboundMessage(params: {
   // Detect GROUP.md update/delete notification — refresh both memory + disk cache, do NOT pass to LLM
   const earlyEventType = (message.payload as any)?.event?.type;
   if ((earlyEventType === "group_md_updated" || earlyEventType === "group_md_deleted") && message.channel_id) {
-    log?.info?.(`dmwork: GROUP.md ${earlyEventType} notification for group ${message.channel_id}`);
+    const groupNo = extractParentGroupNo(message.channel_id);
+    log?.info?.(`dmwork: GROUP.md ${earlyEventType} notification for group ${groupNo}`);
 
     // Update memory cache
     if (earlyEventType === "group_md_updated" && groupMdCache) {
@@ -956,27 +957,27 @@ export async function handleInboundMessage(params: {
         const md = await getGroupMd({
           apiUrl: account.config.apiUrl,
           botToken: account.config.botToken ?? "",
-          groupNo: message.channel_id,
+          groupNo,
           log,
         });
         if (md.content) {
-          groupMdCache.set(message.channel_id, { content: md.content, version: md.version });
-          log?.info?.(`dmwork: GROUP.md memory cache updated for ${message.channel_id} (v${md.version})`);
+          groupMdCache.set(groupNo, { content: md.content, version: md.version });
+          log?.info?.(`dmwork: GROUP.md memory cache updated for ${groupNo} (v${md.version})`);
         }
       } catch (err) {
         log?.error?.(`dmwork: failed to refresh GROUP.md memory cache: ${String(err)}`);
       }
     } else if (earlyEventType === "group_md_deleted" && groupMdCache) {
-      groupMdCache.delete(message.channel_id);
+      groupMdCache.delete(groupNo);
     }
 
     // Update disk cache (for before_prompt_build hook)
     if (earlyEventType === "group_md_updated" && groupMdCache) {
-      const cached = groupMdCache.get(message.channel_id);
+      const cached = groupMdCache.get(groupNo);
       if (cached) {
         broadcastGroupMdUpdate({
           accountId: account.accountId,
-          groupNo: message.channel_id,
+          groupNo,
           content: cached.content,
           version: cached.version,
         });
@@ -985,11 +986,52 @@ export async function handleInboundMessage(params: {
       // Delete disk cache
       broadcastGroupMdUpdate({
         accountId: account.accountId,
-        groupNo: message.channel_id,
+        groupNo,
         content: "",
         version: 0,
       });
     }
+
+    return;
+  }
+
+  // Detect thread THREAD.md update/delete notification — refresh disk cache, do NOT pass to LLM
+  if ((earlyEventType === "thread_md_updated" || earlyEventType === "thread_md_deleted") && message.channel_id) {
+    const event = (message.payload as any)?.event;
+    const groupNo = event?.group_no ?? extractParentGroupNo(message.channel_id);
+    const shortId = event?.short_id ?? extractThreadShortId(message.channel_id);
+
+    if (!groupNo || !shortId) {
+      log?.warn?.(`dmwork: thread_md event missing group_no/short_id`);
+      return;
+    }
+
+    log?.info?.(`dmwork: THREAD.md ${earlyEventType} notification for ${groupNo}/${shortId}`);
+
+    // Resolve agentId from route/account (same pattern as group events below)
+    let threadAgentId = "";
+    try {
+      const _core = getDmworkRuntime();
+      const _cfg = _core.config.loadConfig() as OpenClawConfig;
+      const _route = _core.channel.routing.resolveAgentRoute({
+        cfg: _cfg, channel: "dmwork", accountId: account.accountId,
+        peer: { kind: "group", id: message.channel_id },
+      });
+      threadAgentId = _route?.agentId ?? "";
+    } catch {
+      // fallback to empty — handleThreadMdEvent only uses agentId for logging
+    }
+
+    handleThreadMdEvent({
+      agentId: threadAgentId,
+      accountId: account.accountId,
+      groupNo,
+      shortId,
+      eventType: earlyEventType,
+      apiUrl: account.config.apiUrl,
+      botToken: account.config.botToken ?? "",
+      log,
+    }).catch((err) => log?.error?.(`dmwork: handleThreadMdEvent failed: ${String(err)}`));
 
     return;
   }
@@ -1001,6 +1043,7 @@ export async function handleInboundMessage(params: {
 
   // --- GROUP.md: register group→account mapping and handle structured events ---
   if (isGroup && message.channel_id) {
+    const parentGroupNo = extractParentGroupNo(message.channel_id);
     // Resolve agentId for the group→account mapping
     try {
       const _core = getDmworkRuntime();
@@ -1009,9 +1052,9 @@ export async function handleInboundMessage(params: {
         cfg: _cfg, channel: "dmwork", accountId: account.accountId,
         peer: { kind: "group", id: message.channel_id },
       });
-      registerGroupAccount(message.channel_id, account.accountId, _route?.agentId);
+      registerGroupAccount(parentGroupNo, account.accountId, _route?.agentId);
     } catch {
-      registerGroupAccount(message.channel_id, account.accountId);
+      registerGroupAccount(parentGroupNo, account.accountId);
     }
 
     // Note: group_md_updated/deleted events are handled by the early handler above (line ~530)
@@ -1128,8 +1171,12 @@ export async function handleInboundMessage(params: {
   const originalMentionUids: string[] = (message.payload?.mention?.uids ?? []).filter((uid: string) => uid !== botUid);
 
     // Refresh group member cache if needed (on first message or after expiry)
+  // Use parent groupNo for member cache API calls (thread channelIds are compound)
+  const memberCacheGroupNo = isGroup
+    ? extractParentGroupNo(message.channel_id!)
+    : sessionId;
   if (isGroup) {
-    await refreshGroupMemberCache({ sessionId, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", log });
+    await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", log });
   }
 
   // Compute isMentioned at top level so it's available for WasMentioned in finalizeInboundContext
@@ -1289,14 +1336,31 @@ export async function handleInboundMessage(params: {
 
   // Fire-and-forget: ensure GROUP.md is cached for this group
   if (isGroup && message.channel_id) {
+    const _parentGroupNo = extractParentGroupNo(message.channel_id);
+    const _threadShortId = extractThreadShortId(message.channel_id);
+
+    // Always ensure group-level GROUP.md is cached
     ensureGroupMd({
       agentId: route.agentId,
       accountId: account.accountId,
-      groupNo: message.channel_id,
+      groupNo: _parentGroupNo,
       apiUrl: account.config.apiUrl,
       botToken: account.config.botToken ?? "",
       log,
     }).catch((err) => log?.warn?.(`dmwork: [GROUP.md] ensureGroupMd failed: ${String(err)}`));
+
+    // For thread messages, also ensure thread-level THREAD.md is cached
+    if (_threadShortId) {
+      ensureThreadMd({
+        agentId: route.agentId,
+        accountId: account.accountId,
+        groupNo: _parentGroupNo,
+        shortId: _threadShortId,
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken ?? "",
+        log,
+      }).catch((err) => log?.warn?.(`dmwork: [THREAD.md] ensureThreadMd failed: ${String(err)}`));
+    }
   }
 
   const fromLabel = isGroup
@@ -1330,7 +1394,9 @@ export async function handleInboundMessage(params: {
   });
 
   // Inject GROUP.md as GroupSystemPrompt for group messages
-  const groupSystemPrompt = isGroup && groupMdCache ? groupMdCache.get(message.channel_id!)?.content : undefined;
+  const groupSystemPrompt = isGroup && groupMdCache && message.channel_id
+    ? groupMdCache.get(extractParentGroupNo(message.channel_id))?.content
+    : undefined;
 
   // Resolve sender display name — async fallback for DM users not in cache
   let senderName = resolveSenderName(message.from_uid, uidToNameMap);
@@ -1579,7 +1645,7 @@ export async function handleInboundMessage(params: {
 
             if (unresolvedNames.length > 0) {
               log?.info?.(`dmwork: [REPLY] ${unresolvedNames.length} unresolved names, force refreshing cache...`);
-              const refreshed = await refreshGroupMemberCache({ sessionId, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", forceRefresh: true, log });
+              const refreshed = await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", forceRefresh: true, log });
               if (refreshed) {
                 for (const { name, index } of unresolvedNames) {
                   const uid = findUidByName(name, memberMap);

--- a/openclaw-channel-dmwork/src/types.ts
+++ b/openclaw-channel-dmwork/src/types.ts
@@ -80,9 +80,11 @@ export interface MessagePayload {
   mention?: MentionPayload;
   reply?: ReplyPayload;
   event?: {
-    type: string;       // "group_md_updated" | "group_md_deleted"
+    type: string;       // "group_md_updated" | "group_md_deleted" | "thread_md_updated" | "thread_md_deleted"
     version?: number;
     updated_by?: string;
+    group_no?: string;   // thread_md_* events only
+    short_id?: string;   // thread_md_* events only
   };
   [key: string]: unknown;
 }


### PR DESCRIPTION
Add GROUP.md support at the thread (sub-channel) level in the adapter layer.

## Changes
- thread-md-read and thread-md-update actions in dmwork_management tool
- GROUP.md prompt injection for thread context
- Cache management for thread-level GROUP.md
- 500/500 tests passing

Closes #176