### PR TITLE
fix: 修复 thread 消息 channel_type 字符串比较失败导致串频道

### DIFF
--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -820,6 +820,11 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         token: credentials.im_token,
 
         onMessage: (msg: BotMessage) => {
+          // Normalize channel_type to number — WuKongIM may send it as string "5"
+          // which breaks strict === comparisons with ChannelType enum values.
+          if (msg.channel_type != null) {
+            msg.channel_type = Number(msg.channel_type) as ChannelType;
+          }
           // Allow structured event messages (e.g. group_md_updated) even from self/bots
           const isEvent = !!(msg.payload as any)?.event?.type; // TODO: remove when SDK types support this
           if (msg.payload?.type === 1 && (msg.payload as any)?.event) { // TODO: remove when SDK types support this

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -994,6 +994,11 @@ export async function handleInboundMessage(params: {
     return;
   }
 
+  // Normalize channel_type (defense-in-depth — channel.ts should have done this already)
+  if (message.channel_type != null) {
+    message.channel_type = Number(message.channel_type) as ChannelType;
+  }
+
   const isGroup =
     typeof message.channel_id === "string" &&
     message.channel_id.length > 0 &&


### PR DESCRIPTION
## Summary

WuKongIM 在 CommunityTopic(子区) 场景下可能推送 `channel_type` 为字符串 `"5"` 而非数字 `5`，JavaScript 的 `===` 不做类型转换，导致：

1. `isGroup` 判定为 false，thread 消息被当成 DM 处理
2. readReceipt + typing 发到私聊而非 thread
3. session 路由到 direct 而非 thread session

## Fix

在消息入口统一 `Number()` 转换 `channel_type`：
- `channel.ts` onMessage 回调入口
- `inbound.ts` handleInboundMessage 入口（defense-in-depth）

## Test plan

- [ ] `npm run build` 通过
- [ ] `npm test` 476 通过
- [ ] thread 里 @bot 发消息，回复在 thread 里而非私聊

🤖 Generated with [Claude Code](https://claude.com/claude-code)