### PR TITLE
fix: 强制使用用户全局 openclaw，修复版本不兼容 + CI tag 发版

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,35 +78,21 @@ publish_npm_dev:
     url: https://www.npmjs.com/package/openclaw-channel-dmwork
 
 # ============================================================
-# 发布到 npm - latest 版本（main 分支）
-# 版本号直接从 package.json 读取
-# ============================================================
-publish_npm_stable:
-  <<: *publish
-  only:
-    - main
-  script:
-    - echo "🏗️ Building for stable publish..."
-    - npm run build
-    - CURRENT_VERSION=$(node -p "require('./package.json').version")
-    - echo "📦 Publishing stable version ${CURRENT_VERSION}"
-    - npm publish --access public --tag latest
-  environment:
-    name: npm
-    url: https://www.npmjs.com/package/openclaw-channel-dmwork
-
-# ============================================================
-# 发布到 npm - latest 版本（tag 触发）
+# 发布到 npm - latest 版本（仅 v* tag 触发）
+# tag 格式: v0.5.21 → 自动写入 package.json 版本号 0.5.21
+# 不再由 main 分支直接触发发布
 # ============================================================
 publish_npm:
   <<: *publish
   only:
-    - tags
+    - /^v\d+\.\d+\.\d+$/
   script:
     - "echo '🏗️ Building for publish...'"
     - "npm run build"
-    - "echo '📦 Publishing version: ${CI_COMMIT_TAG}'"
-    - "npm publish --access public"
+    - "TAG_VERSION=${CI_COMMIT_TAG#v}"
+    - "echo '📦 Publishing version: ${TAG_VERSION}'"
+    - "npm version ${TAG_VERSION} --no-git-tag-version"
+    - "npm publish --access public --tag latest"
   environment:
     name: npm
     url: https://www.npmjs.com/package/openclaw-channel-dmwork

--- a/openclaw-channel-dmwork/cli/config-preserve.test.ts
+++ b/openclaw-channel-dmwork/cli/config-preserve.test.ts
@@ -4,11 +4,13 @@ import { execFileSync } from "node:child_process";
 
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
+  execSync: vi.fn(() => ""),
 }));
 vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
   copyFileSync: vi.fn(),
+  existsSync: vi.fn(() => false),
 }));
 
 const mockExecFileSync = vi.mocked(execFileSync);

--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -18,18 +18,19 @@ import { createRequire } from "node:module";
 
 const program = new Command();
 
+const _require = createRequire(import.meta.url);
+const _pkg = _require("../package.json");
+
 program
   .name("openclaw-channel-dmwork")
   .description("DMWork channel plugin CLI for OpenClaw")
-  .version("0.5.19");
+  .version(_pkg.version);
 
 // --- info ---
 program
   .command("info")
   .description("Show CLI and plugin version info")
   .action(() => {
-    const require = createRequire(import.meta.url);
-    const cliPkg = require("../package.json");
     const openclawVersion = getOpenClawVersion() ?? "not found";
     const inspect = pluginsInspect(PLUGIN_ID);
     const installedVersion = inspect?.plugin?.version ?? "not installed";
@@ -40,7 +41,7 @@ program
     const u = "\x1b[4m";   // underline
     const r = "\x1b[0m";   // reset
 
-    console.log(`${b}openclaw-channel-dmwork-cli:${r} ${g}${cliPkg.version}${r}`);
+    console.log(`${b}openclaw-channel-dmwork-cli:${r} ${g}${_pkg.version}${r}`);
     console.log(`${b}openclaw:${r} ${g}${openclawVersion}${r}`);
     console.log(`${b}openclaw-channel-dmwork:${r} ${g}${installedVersion}${r}`);
     console.log(`${b}plugin package:${r} ${g}${PLUGIN_ID}${r}`);

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -50,11 +50,9 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
     console.log("Plugin installed successfully.");
   }
 
-  // 3. Legacy config migration
-  await migrateLegacyConfig();
-
-  // 4. DMWork config (unless --skip-config)
+  // 3. Legacy config migration + 4. DMWork config (unless --skip-config)
   if (!opts.skipConfig) {
+    await migrateLegacyConfig();
     await configureDmworkAccount(opts);
   }
 

--- a/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
@@ -4,7 +4,12 @@ import { execFileSync } from "node:child_process";
 // Mock child_process at module level
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
+  execSync: vi.fn(() => ""),
 }));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, existsSync: vi.fn(() => false) };
+});
 
 const mockExecFileSync = vi.mocked(execFileSync);
 
@@ -118,5 +123,69 @@ describe("configGet / configSet", () => {
     mockExecFileSync.mockReturnValue("\n");
 
     expect(configGet("nonexistent.path")).toBeNull();
+  });
+});
+
+describe("findGlobalOpenclaw (via module load)", () => {
+  it("should skip _npx paths and pick global path", async () => {
+    const { execSync } = await import("node:child_process");
+    vi.mocked(execSync).mockReturnValue(
+      "/Users/test/.npm/_npx/abc123/node_modules/.bin/openclaw\n/usr/local/bin/openclaw\n",
+    );
+    const mod = await loadModule();
+    mockExecFileSync.mockReturnValue("test\n");
+    mod.configGet("test.path");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "/usr/local/bin/openclaw",
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
+  it("should handle CRLF output from Windows", async () => {
+    const { execSync } = await import("node:child_process");
+    vi.mocked(execSync).mockReturnValue(
+      "C:\\npm\\_npx\\openclaw.cmd\r\nC:\\Program Files\\openclaw\\openclaw.exe\r\n",
+    );
+    const mod = await loadModule();
+    mockExecFileSync.mockReturnValue("test\n");
+    mod.configGet("test.path");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "C:\\Program Files\\openclaw\\openclaw.exe",
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
+  it("should fallback to candidate paths when which/where fails", async () => {
+    const { execSync } = await import("node:child_process");
+    const { existsSync } = await import("node:fs");
+    vi.mocked(execSync).mockImplementation(() => { throw new Error("not found"); });
+    vi.mocked(existsSync).mockImplementation((p) =>
+      String(p) === "/usr/local/bin/openclaw",
+    );
+    const mod = await loadModule();
+    mockExecFileSync.mockReturnValue("test\n");
+    mod.configGet("test.path");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "/usr/local/bin/openclaw",
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
+  it("should fallback to 'openclaw' when nothing found", async () => {
+    const { execSync } = await import("node:child_process");
+    const { existsSync } = await import("node:fs");
+    vi.mocked(execSync).mockImplementation(() => { throw new Error("not found"); });
+    vi.mocked(existsSync).mockReturnValue(false);
+    const mod = await loadModule();
+    mockExecFileSync.mockReturnValue("test\n");
+    mod.configGet("test.path");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "openclaw",
+      expect.any(Array),
+      expect.any(Object),
+    );
   });
 });

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -4,12 +4,52 @@
  * argument arrays to avoid shell-quoting issues.
  */
 
-import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { execFileSync, execSync } from "node:child_process";
+import { readFileSync, writeFileSync, copyFileSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 
-const OPENCLAW = "openclaw";
+/**
+ * Find the user's globally installed openclaw, skipping the npx environment.
+ *
+ * npx installs openclaw as a peerDependency, which may be a newer version
+ * than the user's server. Using the npx version to write openclaw.json
+ * causes version incompatibility crashes on older OpenClaw servers.
+ */
+function findGlobalOpenclaw(): string {
+  // Strategy 1: use "which -a" (Unix) or "where" (Windows) to find all openclaw paths
+  for (const cmd of ["which -a openclaw", "where openclaw"]) {
+    try {
+      const output = execSync(cmd, {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const paths = output
+        .split(/\r?\n/)
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0 && !p.includes("_npx") && !p.includes("npx-cache"));
+      if (paths.length > 0) return paths[0];
+    } catch {
+      // command not available on this platform
+    }
+  }
+
+  // Strategy 2: check common global install paths
+  const candidates = [
+    "/opt/homebrew/bin/openclaw",
+    "/usr/local/bin/openclaw",
+    "/usr/bin/openclaw",
+    resolve(homedir(), ".npm-global", "bin", "openclaw"),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+
+  // Last resort: use PATH (may still be npx version)
+  return "openclaw";
+}
+
+const OPENCLAW = findGlobalOpenclaw();
 
 /** Expand ~ to home directory */
 function expandHome(p: string): string {


### PR DESCRIPTION
## Summary

修复 npx 环境的 openclaw 版本比用户服务器高，导致配置崩溃的问题。

### Bug 修复
- **版本不兼容崩溃**：npx 环境里的 openclaw（peerDependency）版本可能高于用户服务器，`openclaw plugins install` 写出高版本格式的 openclaw.json，旧版 OpenClaw 读不了（Ajv 爆栈）
- **越权修改其他频道配置**：同上原因，新版 openclaw 按新 schema 重写整个配置文件
- **--skip-config 漏洞**：legacy 迁移不受 skipConfig 控制，仍会写配置
- **CLI -V 版本号硬编码**：显示旧版本号

### 修复内容
- `findGlobalOpenclaw()` 查找用户全局 openclaw，跳过 npx 环境（支持跨平台、CRLF）
- `--skip-config` 也跳过 legacy 迁移
- CLI 版本号从 package.json 动态读取
- 4 个新增测试覆盖 findGlobalOpenclaw 核心路径

### CI 改进
- 删除 `publish_npm_stable`（main 分支不再直接发 latest）
- tag 发布只匹配 `v0.5.21` 格式，从 tag 读版本号写入 package.json
- 发正式版不再需要手动改版本号

## Test plan

- [ ] `npm run build` 通过
- [ ] `npm test` 533 通过
- [ ] `npx -y openclaw-channel-dmwork info` 显示全局 openclaw 版本
- [ ] 打 tag `v0.5.21` 后 CI 自动发布正确版本

🤖 Generated with [Claude Code](https://claude.com/claude-code)