### PR TITLE
fix: findGlobalOpenclaw 增加 node_modules 过滤

### DIFF
--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -18,6 +18,7 @@ import { resolve } from "node:path";
  */
 function findGlobalOpenclaw(): string {
   // Strategy 1: use "which -a" (Unix) or "where" (Windows) to find all openclaw paths
+  // Skip: _npx (npx cache), npx-cache, node_modules (project-local devDependency)
   for (const cmd of ["which -a openclaw", "where openclaw"]) {
     try {
       const output = execSync(cmd, {
@@ -27,7 +28,12 @@ function findGlobalOpenclaw(): string {
       const paths = output
         .split(/\r?\n/)
         .map((p) => p.trim())
-        .filter((p) => p.length > 0 && !p.includes("_npx") && !p.includes("npx-cache"));
+        .filter((p) =>
+          p.length > 0 &&
+          !p.includes("_npx") &&
+          !p.includes("npx-cache") &&
+          !p.includes("node_modules"),
+        );
       if (paths.length > 0) return paths[0];
     } catch {
       // command not available on this platform


### PR DESCRIPTION
## Summary

PR #181 合并后发现 findGlobalOpenclaw 还有遗漏：

npx 环境下 `which -a openclaw` 除了 `_npx` 路径外，还会返回项目本地的 `node_modules/.bin/openclaw`（devDependency 2026.3.2），导致选错版本。

修复：过滤条件增加 `!p.includes("node_modules")`。

## Test plan

- [ ] `npm test` 通过
- [ ] npx 环境下 info 显示全局 openclaw 版本而非 node_modules 里的

🤖 Generated with [Claude Code](https://claude.com/claude-code)