### PR TITLE
fix: 自动检测并清理旧版 dmwork 插件残留

### DIFF
--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -8,6 +8,7 @@
 import { existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import {
+  cleanupLegacyPlugin,
   configGet,
   configGetJson,
   configSet,
@@ -97,6 +98,16 @@ export async function runDoctorChecks(params: {
   // Phase 1: Fatal config issues (OpenClaw CLI may not work)
   // =========================================================================
   if (!params.inProcess && fix) {
+    // Phase 0: Clean up legacy "dmwork" plugin
+    const legacyActions = cleanupLegacyPlugin();
+    for (const action of legacyActions) {
+      checks.push({
+        name: "Legacy plugin cleanup",
+        status: "FIXED",
+        detail: action,
+      });
+    }
+
     const cfg = readConfigFromFile();
     if (cfg) {
       const hasDmworkChannel = Boolean(cfg.channels?.dmwork);

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  cleanupLegacyPlugin,
   configGet,
   configGetJson,
   configSet,
@@ -36,6 +37,13 @@ export interface InstallOptions {
 export async function runInstall(opts: InstallOptions): Promise<void> {
   // 1. Pre-check
   ensureOpenClawCompat();
+
+  // 1.5. Clean up legacy "dmwork" plugin if present
+  const legacyActions = cleanupLegacyPlugin();
+  if (legacyActions.length > 0) {
+    console.log("Cleaned up legacy DMWork plugin:");
+    legacyActions.forEach((a) => console.log(`  ${a}`));
+  }
 
   // 2. Plugin install (delegate to official CLI)
   const inspect = pluginsInspect(PLUGIN_ID);

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -348,3 +348,74 @@ export function removeOrphanedBindingsFromFile(
     // best effort
   }
 }
+
+// ---------------------------------------------------------------------------
+// Legacy plugin cleanup
+// ---------------------------------------------------------------------------
+
+const LEGACY_PLUGIN_ID = "dmwork";
+
+/**
+ * Detect and clean up legacy DMWork plugin installations that conflict
+ * with the current openclaw-channel-dmwork plugin.
+ *
+ * Known legacy artifacts:
+ * - ~/.openclaw/extensions/dmwork/ (old plugin directory, id="dmwork")
+ * - plugins.entries.dmwork in openclaw.json
+ *
+ * Returns a list of actions taken (for logging).
+ */
+export function cleanupLegacyPlugin(): string[] {
+  const actions: string[] = [];
+
+  // 1. Check if legacy plugin directory exists
+  const legacyDir = resolve(
+    getConfigFilePathSafe().replace(/openclaw\.json$/, ""),
+    "extensions",
+    LEGACY_PLUGIN_ID,
+  );
+
+  if (existsSync(legacyDir)) {
+    // Try to uninstall via openclaw CLI first (removes entries/installs/allow)
+    try {
+      execFileSync(OPENCLAW, ["plugins", "uninstall", LEGACY_PLUGIN_ID, "--force", "--keep-files"], {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      actions.push(`Unregistered legacy plugin "${LEGACY_PLUGIN_ID}"`);
+    } catch {
+      // May fail if plugin not in registry, clean up config manually
+    }
+
+    // Remove legacy directory
+    try {
+      const { rmSync } = require("node:fs") as typeof import("node:fs");
+      rmSync(legacyDir, { recursive: true, force: true });
+      actions.push(`Removed legacy directory: ${legacyDir}`);
+    } catch {
+      actions.push(`Warning: could not remove ${legacyDir}`);
+    }
+  }
+
+  // 2. Check for stale config entries (in case uninstall didn't clean them)
+  try {
+    const cfg = readConfigFromFile();
+    if (cfg?.plugins?.entries?.[LEGACY_PLUGIN_ID]) {
+      const configPath = getConfigFilePathSafe();
+      copyFileSync(configPath, configPath + ".bak");
+      delete cfg.plugins.entries[LEGACY_PLUGIN_ID];
+      // Also clean installs and allow
+      if (cfg.plugins?.installs?.[LEGACY_PLUGIN_ID]) {
+        delete cfg.plugins.installs[LEGACY_PLUGIN_ID];
+      }
+      if (Array.isArray(cfg.plugins?.allow)) {
+        cfg.plugins.allow = cfg.plugins.allow.filter((id: string) => id !== LEGACY_PLUGIN_ID);
+      }
+      writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+      actions.push(`Cleaned legacy entries from openclaw.json`);
+    }
+  } catch {
+    // best effort
+  }
+
+  return actions;
+}

--- a/openclaw-channel-dmwork/cli/update.ts
+++ b/openclaw-channel-dmwork/cli/update.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  cleanupLegacyPlugin,
   gatewayRestart,
   pluginsInspect,
   pluginsInstall,
@@ -43,6 +44,15 @@ export async function runUpdate(opts: UpdateOptions): Promise<void> {
       console.error("DMWork plugin is not installed. Use 'install' first.");
     }
     process.exit(1);
+  }
+
+  // Clean up legacy "dmwork" plugin AFTER confirming new version exists
+  const legacyActions = cleanupLegacyPlugin();
+  if (legacyActions.length > 0) {
+    if (!opts.json) {
+      console.log("Cleaned up legacy DMWork plugin:");
+      legacyActions.forEach((a) => console.log(`  ${a}`));
+    }
   }
 
   const currentVersion = inspect.plugin.version;


### PR DESCRIPTION
## Summary

用户可能有旧版插件 `~/.openclaw/extensions/dmwork/`（id="dmwork"，v0.5.4 等），
与新版 `openclaw-channel-dmwork` 冲突。旧版先注册 channel 后，新版被跳过无法加载。

## 修复

在 install、update、doctor --fix 中自动检测并清理旧版残留：
- 卸载旧版插件注册信息（`openclaw plugins uninstall dmwork`）
- 删除旧版目录（`~/.openclaw/extensions/dmwork/`）
- 清理 openclaw.json 中残留的 `plugins.entries.dmwork`

**安全性**：
- 只清理 id="dmwork" 的旧版，不动 openclaw-channel-dmwork
- 无残留时 0 操作，不影响正常用户
- update 先确认新版存在再清理旧版，不会先破坏再报错

## Test plan

- [ ] `npm run build` 通过
- [ ] `npm test` 533 通过
- [ ] 有旧版残留时 install/update/doctor --fix 自动清理
- [ ] 无旧版残留时无任何副作用

🤖 Generated with [Claude Code](https://claude.com/claude-code)