### PR TITLE
fix: 升级流程 6 个兼容性问题修复

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,12 +66,12 @@ publish_npm_dev:
   only:
     - develop
   script:
-    - echo "🏗️ Building for dev publish..."
-    - npm run build
     - CURRENT_VERSION=$(node -p "require('./package.json').version")
     - DEV_VERSION="${CURRENT_VERSION}-dev.${CI_COMMIT_SHORT_SHA}"
     - echo "📦 Publishing dev version ${DEV_VERSION}"
     - npm version ${DEV_VERSION} --no-git-tag-version
+    - echo "🏗️ Building for dev publish..."
+    - npm run build
     - npm publish --access public --tag dev
   environment:
     name: npm-dev
@@ -87,11 +87,11 @@ publish_npm:
   only:
     - /^v\d+\.\d+\.\d+$/
   script:
-    - "echo '🏗️ Building for publish...'"
-    - "npm run build"
     - "TAG_VERSION=${CI_COMMIT_TAG#v}"
     - "echo '📦 Publishing version: ${TAG_VERSION}'"
     - "npm version ${TAG_VERSION} --no-git-tag-version"
+    - "echo '🏗️ Building for publish...'"
+    - "npm run build"
     - "npm publish --access public --tag latest"
   environment:
     name: npm

--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -7,13 +7,17 @@
 
 import { existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   cleanupLegacyPlugin,
+  cleanupStaleStageDirectories,
   configGet,
   configGetJson,
   configSet,
   gatewayRestart,
   gatewayStatus,
+  getConfigFilePathSafe,
   pluginsInspect,
   pluginsInstall,
   removeChannelConfigFromFile,
@@ -98,11 +102,21 @@ export async function runDoctorChecks(params: {
   // Phase 1: Fatal config issues (OpenClaw CLI may not work)
   // =========================================================================
   if (!params.inProcess && fix) {
-    // Phase 0: Clean up legacy "dmwork" plugin
+    // Phase 0a: Clean up legacy "dmwork" plugin
     const legacyActions = cleanupLegacyPlugin();
     for (const action of legacyActions) {
       checks.push({
         name: "Legacy plugin cleanup",
+        status: "FIXED",
+        detail: action,
+      });
+    }
+
+    // Phase 0b: Clean up stale install stage directories (DMWork only, >10min old)
+    const stageActions = cleanupStaleStageDirectories();
+    for (const action of stageActions) {
+      checks.push({
+        name: "Stage directory cleanup",
         status: "FIXED",
         detail: action,
       });
@@ -164,7 +178,7 @@ export async function runDoctorChecks(params: {
   // =========================================================================
   const reader = params.reader ?? cliConfigReader;
 
-  // 1. Plugin installed
+  // 1. Plugin installed (with fallback for inspect failures)
   if (!params.inProcess) {
     const inspect = pluginsInspect(PLUGIN_ID);
     if (inspect?.plugin) {
@@ -173,30 +187,51 @@ export async function runDoctorChecks(params: {
         status: "PASS",
         detail: `v${inspect.plugin.version}`,
       });
-    } else if (fix) {
-      try {
-        pluginsInstall(PLUGIN_ID, true);
-        const after = pluginsInspect(PLUGIN_ID);
+    } else {
+      // Fallback: inspect failed, check if plugin directory exists on disk
+      const extensionsDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+      const pluginDir = resolve(extensionsDir, "openclaw-channel-dmwork");
+      let fallbackVersion: string | null = null;
+      if (existsSync(pluginDir)) {
+        try {
+          const pkg = JSON.parse(readFileSync(resolve(pluginDir, "package.json"), "utf-8"));
+          fallbackVersion = pkg.version ?? null;
+        } catch { /* no package.json */ }
+      }
+
+      if (fallbackVersion) {
+        // Plugin exists on disk but inspect can't see it
         checks.push({
           name: "Plugin installed",
-          status: "FIXED",
-          detail: `Installed v${after?.plugin?.version ?? "unknown"}`,
+          status: "WARN",
+          detail: `v${fallbackVersion} (directory exists but openclaw inspect failed — try: openclaw gateway restart)`,
         });
-      } catch {
+      } else if (fix) {
+        try {
+          const { runSafeInstall } = await import("./install.js");
+          runSafeInstall(PLUGIN_ID, true);
+          const after = pluginsInspect(PLUGIN_ID);
+          checks.push({
+            name: "Plugin installed",
+            status: "FIXED",
+            detail: `Installed v${after?.plugin?.version ?? "unknown"}`,
+          });
+        } catch {
+          checks.push({
+            name: "Plugin installed",
+            status: "FAIL",
+            detail: "Not installed (auto-install failed)",
+          });
+          return summarize(checks);
+        }
+      } else {
         checks.push({
           name: "Plugin installed",
           status: "FAIL",
-          detail: "Not installed (auto-install failed)",
+          detail: "Not installed",
         });
         return summarize(checks);
       }
-    } else {
-      checks.push({
-        name: "Plugin installed",
-        status: "FAIL",
-        detail: "Not installed",
-      });
-      return summarize(checks);
     }
   }
 

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -5,8 +5,11 @@
  * workspace, agent.md) is left to the user via `openclaw agents add`.
  */
 
+import { copyFileSync, existsSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   cleanupLegacyPlugin,
+  cleanupStalePluginDir,
   configGet,
   configGetJson,
   configSet,
@@ -14,6 +17,11 @@ import {
   gatewayRestart,
   pluginsInspect,
   pluginsInstall,
+  readConfigFromFile,
+  removeChannelConfigFromFile,
+  restoreChannelConfigToFile,
+  saveChannelConfigFromFile,
+  getConfigFilePathSafe,
 } from "./openclaw-cli.js";
 import {
   PLUGIN_ID,
@@ -38,14 +46,7 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
   // 1. Pre-check
   ensureOpenClawCompat();
 
-  // 1.5. Clean up legacy "dmwork" plugin if present
-  const legacyActions = cleanupLegacyPlugin();
-  if (legacyActions.length > 0) {
-    console.log("Cleaned up legacy DMWork plugin:");
-    legacyActions.forEach((a) => console.log(`  ${a}`));
-  }
-
-  // 2. Plugin install (delegate to official CLI)
+  // 2. Safe install (handles legacy cleanup, deadlock, stale dirs)
   const inspect = pluginsInspect(PLUGIN_ID);
   if (inspect?.plugin && !opts.force) {
     console.log(
@@ -53,9 +54,7 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
     );
   } else {
     const spec = opts.dev ? `${PLUGIN_ID}@dev` : PLUGIN_ID;
-    console.log(`Installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
-    pluginsInstall(spec, false, opts.force);
-    console.log("Plugin installed successfully.");
+    runSafeInstall(spec, opts.force);
   }
 
   // 3. Legacy config migration + 4. DMWork config (unless --skip-config)
@@ -77,6 +76,121 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Safe install: handles legacy cleanup, config deadlock, stale dirs
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared install logic used by both install and update commands.
+ * Handles: legacy plugin cleanup, stale directory cleanup,
+ * config deadlock (chicken-egg problem), and --force retry.
+ */
+export function runSafeInstall(spec: string, force?: boolean, quiet?: boolean): void {
+  const log = quiet ? (() => {}) : console.log.bind(console);
+  // 1. Clean up legacy "dmwork" plugin
+  const legacyActions = cleanupLegacyPlugin();
+  if (legacyActions.length > 0) {
+    log("Cleaned up legacy DMWork plugin:");
+    legacyActions.forEach((a) => log(`  ${a}`));
+  }
+
+  // 2. Clean up stale openclaw-channel-dmwork directory
+  const staleActions = cleanupStalePluginDir();
+  if (staleActions.length > 0) {
+    log("Cleaned up stale plugin directory:");
+    staleActions.forEach((a) => log(`  ${a}`));
+  }
+
+  // 3. Handle config deadlock (chicken-egg problem):
+  //    channels.dmwork exists but plugin not installed → config validation blocks install
+  const cfg = readConfigFromFile();
+  const hasDmworkChannel = Boolean(cfg?.channels?.dmwork);
+  const hasStaleEntries = Boolean(cfg?.plugins?.entries?.["openclaw-channel-dmwork"]);
+  const hasStaleInstalls = Boolean(cfg?.plugins?.installs?.["openclaw-channel-dmwork"]);
+
+  // Only enter deadlock fix if plugin is genuinely not present:
+  // - inspect returns null AND plugin directory doesn't exist on disk
+  // This prevents treating "inspect anomaly + plugin still running" as deadlock
+  const inspectResult = pluginsInspect(PLUGIN_ID);
+  const extensionsDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+  const pluginDirExists = existsSync(resolve(extensionsDir, "openclaw-channel-dmwork"));
+  const pluginGenuinelyMissing = !inspectResult?.plugin && !pluginDirExists;
+  const needsDeadlockFix = hasDmworkChannel && pluginGenuinelyMissing;
+
+  if (needsDeadlockFix) {
+    log("Detected config deadlock (channels.dmwork exists but plugin not installed).");
+    log("Temporarily removing stale config to allow installation...");
+
+    // Backup full config file for disaster recovery
+    const configPath = getConfigFilePathSafe();
+    const backupPath = configPath + ".dmwork-upgrade-backup";
+    copyFileSync(configPath, backupPath);
+
+    // Save channels.dmwork for restore after install
+    const savedDmwork = saveChannelConfigFromFile();
+
+    // Temporarily remove stale config entries
+    removeChannelConfigFromFile();
+    if (hasStaleEntries) {
+      try {
+        const c = readConfigFromFile();
+        if (c?.plugins?.entries?.["openclaw-channel-dmwork"]) {
+          delete c.plugins.entries["openclaw-channel-dmwork"];
+          copyFileSync(configPath, configPath + ".bak");
+          writeFileSync(configPath, JSON.stringify(c, null, 2), "utf-8");
+        }
+      } catch { /* best effort */ }
+    }
+    if (hasStaleInstalls) {
+      try {
+        const c = readConfigFromFile();
+        if (c?.plugins?.installs?.["openclaw-channel-dmwork"]) {
+          delete c.plugins.installs["openclaw-channel-dmwork"];
+          writeFileSync(configPath, JSON.stringify(c, null, 2), "utf-8");
+        }
+      } catch { /* best effort */ }
+    }
+
+    try {
+      log(`Installing DMWork plugin...`);
+      pluginsInstall(spec, quiet, force);
+      log("Plugin installed successfully.");
+      // Success: patch channels.dmwork back (preserves new entries/installs from plugins install)
+      if (savedDmwork) {
+        restoreChannelConfigToFile(savedDmwork);
+        log("Restored channels.dmwork config.");
+      }
+    } catch (installErr) {
+      // Install failed: restore full config from backup to avoid leaving user worse off
+      console.error("Plugin install failed. Restoring original config...");
+      try {
+        copyFileSync(backupPath, configPath);
+        log("Original config restored from backup.");
+      } catch {
+        console.error(`Warning: Could not restore backup. Manual restore: cp ${backupPath} ${configPath}`);
+      }
+      throw installErr;
+    }
+  } else {
+    // Normal install path (no deadlock)
+    try {
+      log(`Installing DMWork plugin...`);
+      pluginsInstall(spec, quiet, force);
+      log("Plugin installed successfully.");
+    } catch (err) {
+      // If "already exists" → retry with --force
+      const msg = String(err);
+      if (msg.includes("already exists") && !force) {
+        log("Plugin directory exists, retrying with --force...");
+        pluginsInstall(spec, quiet, true);
+        log("Plugin installed successfully (forced).");
+      } else {
+        throw err;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Legacy config migration
 // ---------------------------------------------------------------------------
 
@@ -84,22 +198,14 @@ async function migrateLegacyConfig(): Promise<void> {
   const legacyToken = configGet("channels.dmwork.botToken");
   const accounts = configGetJson("channels.dmwork.accounts");
 
-  // Has top-level botToken but no accounts map → legacy flat config
   if (legacyToken && (!accounts || Object.keys(accounts).length === 0)) {
     console.log("Detected legacy flat config. Migrating to accounts model...");
-
-    // Copy token to accounts.default
     configSet("channels.dmwork.accounts.default.botToken", legacyToken);
-
-    // Copy apiUrl if present
     const legacyApiUrl = configGet("channels.dmwork.apiUrl");
     if (legacyApiUrl) {
       configSet("channels.dmwork.accounts.default.apiUrl", legacyApiUrl);
     }
-
-    // Remove top-level botToken (keep apiUrl as shared default)
     configUnset("channels.dmwork.botToken");
-
     console.log("Migrated legacy config to accounts.default.");
   }
 }
@@ -109,7 +215,6 @@ async function migrateLegacyConfig(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
-  // Collect accountId
   let accountId = opts.accountId;
   if (!accountId) {
     accountId = await prompt("Enter bot account ID (e.g. my_bot):");
@@ -126,7 +231,6 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
     process.exit(1);
   }
 
-  // Check if account already exists
   const existingToken = configGet(
     `channels.dmwork.accounts.${accountId}.botToken`,
   );
@@ -159,7 +263,6 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
     }
   }
 
-  // Collect botToken
   let botToken = opts.botToken;
   if (!botToken) {
     botToken = await prompt("Enter bot token (bf_...):");
@@ -169,7 +272,6 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
     process.exit(1);
   }
 
-  // Collect apiUrl
   let apiUrl = opts.apiUrl;
   if (!apiUrl) {
     apiUrl = await prompt("Enter API server URL:");
@@ -179,7 +281,6 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
     process.exit(1);
   }
 
-  // Write account config
   configSet(`channels.dmwork.accounts.${accountId}.botToken`, botToken);
   configSet(`channels.dmwork.accounts.${accountId}.apiUrl`, apiUrl);
   console.log(`Configured bot account: ${accountId}`);

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -5,7 +5,7 @@
  */
 
 import { execFileSync, execSync } from "node:child_process";
-import { readFileSync, writeFileSync, copyFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, copyFileSync, existsSync, rmSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 
@@ -68,7 +68,12 @@ function expandHome(p: string): string {
 // ---------------------------------------------------------------------------
 
 export function getConfigFilePath(): string {
-  return execFileSync(OPENCLAW, ["config", "file"], { encoding: "utf-8" }).trim();
+  const out = execFileSync(OPENCLAW, ["config", "file"], { encoding: "utf-8" });
+  // openclaw may prepend warnings/box-drawing to stdout; extract the actual path
+  // The path is typically the last non-empty line containing openclaw.json
+  const lines = out.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
+  const pathLine = lines.find((l) => l.endsWith("openclaw.json")) ?? lines[lines.length - 1];
+  return pathLine ?? out.trim();
 }
 
 export function configGet(path: string): string | null {
@@ -134,12 +139,39 @@ export function configUnset(path: string): void {
 // Plugin helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Check if an error indicates an unsupported CLI option.
+ * Checks stderr/stdout/message across different Node versions and shells.
+ */
+function isUnsupportedOptionError(err: unknown): boolean {
+  const sources = [
+    (err as any)?.stderr?.toString?.(),
+    (err as any)?.stdout?.toString?.(),
+    (err as any)?.message,
+    String(err),
+  ];
+  return sources.some(
+    (s) => s && (/unknown option|unrecognized option/i.test(s)),
+  );
+}
+
 export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): void {
-  const args = ["plugins", "install", spec, "--dangerously-force-unsafe-install"];
+  const args = ["plugins", "install", spec];
   if (force) args.push("--force");
-  execFileSync(OPENCLAW, args, {
-    stdio: quiet ? ["pipe", "pipe", "pipe"] : "inherit",
-  });
+  const stdioOpt: import("node:child_process").StdioOptions = quiet
+    ? ["pipe", "pipe", "pipe"]
+    : "inherit";
+
+  // Try with --dangerously-force-unsafe-install first; fall back if unsupported
+  try {
+    execFileSync(OPENCLAW, [...args, "--dangerously-force-unsafe-install"], { stdio: stdioOpt });
+  } catch (err) {
+    if (isUnsupportedOptionError(err)) {
+      execFileSync(OPENCLAW, args, { stdio: stdioOpt });
+    } else {
+      throw err;
+    }
+  }
 }
 
 export function pluginsUpdate(id: string, quiet?: boolean): void {
@@ -248,7 +280,7 @@ export function getOpenClawVersion(): string | null {
  */
 export function saveChannelConfigFromFile(): Record<string, unknown> | null {
   try {
-    const configPath = expandHome(getConfigFilePath());
+    const configPath = getConfigFilePathSafe();
     const raw = readFileSync(configPath, "utf-8");
     const cfg = JSON.parse(raw);
     return cfg?.channels?.dmwork ?? null;
@@ -265,7 +297,7 @@ export function saveChannelConfigFromFile(): Record<string, unknown> | null {
 export function restoreChannelConfigToFile(
   dmworkConfig: Record<string, unknown>,
 ): void {
-  const configPath = expandHome(getConfigFilePath());
+  const configPath = getConfigFilePathSafe();
   // Backup
   copyFileSync(configPath, configPath + ".bak");
   // Read, merge, write
@@ -286,7 +318,7 @@ export function restoreChannelConfigToFile(
  * Falls back to the standard default when CLI is unavailable
  * (e.g. during uninstall when config validation fails).
  */
-function getConfigFilePathSafe(): string {
+export function getConfigFilePathSafe(): string {
   try {
     return expandHome(getConfigFilePath());
   } catch {
@@ -388,7 +420,6 @@ export function cleanupLegacyPlugin(): string[] {
 
     // Remove legacy directory
     try {
-      const { rmSync } = require("node:fs") as typeof import("node:fs");
       rmSync(legacyDir, { recursive: true, force: true });
       actions.push(`Removed legacy directory: ${legacyDir}`);
     } catch {
@@ -416,6 +447,94 @@ export function cleanupLegacyPlugin(): string[] {
   } catch {
     // best effort
   }
+
+  return actions;
+}
+
+/**
+ * Clean up stale openclaw-channel-dmwork directory that is not registered
+ * in plugins.installs (orphaned from a failed previous install).
+ *
+ * Only removes the directory if ALL of these are true:
+ * 1. The directory exists
+ * 2. pluginsInspect returns null (openclaw doesn't recognize it)
+ * 3. plugins.installs has no record for openclaw-channel-dmwork
+ */
+export function cleanupStalePluginDir(): string[] {
+  const actions: string[] = [];
+  const extensionsDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+  const pluginDir = resolve(extensionsDir, "openclaw-channel-dmwork");
+
+  if (!existsSync(pluginDir)) return actions;
+
+  // Check if openclaw recognizes it
+  const inspect = pluginsInspect("openclaw-channel-dmwork");
+  if (inspect?.plugin) return actions; // recognized, don't touch
+
+  // Check if it's in installs registry
+  try {
+    const cfg = readConfigFromFile();
+    if (cfg?.plugins?.installs?.["openclaw-channel-dmwork"]) {
+      return actions; // has install record, might just be inspect anomaly
+    }
+  } catch { /* proceed with cleanup */ }
+
+  // All three conditions met: exists + not recognized + not in registry → stale
+  try {
+    rmSync(pluginDir, { recursive: true, force: true });
+    actions.push(`Removed stale plugin directory: ${pluginDir}`);
+  } catch {
+    actions.push(`Warning: could not remove stale directory: ${pluginDir}`);
+  }
+
+  return actions;
+}
+
+/**
+ * Clean up stale openclaw-install-stage directories that belong to DMWork.
+ * Only removes directories that:
+ * 1. Match .openclaw-install-stage-* pattern
+ * 2. Are older than 10 minutes (not a current installation)
+ * 3. Contain a package.json with name "openclaw-channel-dmwork"
+ */
+export function cleanupStaleStageDirectories(): string[] {
+  const actions: string[] = [];
+  const extensionsDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+
+  try {
+    const entries = readdirSync(extensionsDir);
+    const now = Date.now();
+    const TEN_MINUTES = 10 * 60 * 1000;
+
+    for (const entry of entries) {
+      if (!entry.startsWith(".openclaw-install-stage-")) continue;
+      const stagePath = resolve(extensionsDir, entry);
+      try {
+        const stat = statSync(stagePath);
+        if (!stat.isDirectory()) continue;
+        if (now - stat.mtimeMs < TEN_MINUTES) continue; // too recent, skip
+
+        // Check if it's DMWork's stage directory
+        const pkgPath = resolve(stagePath, "package", "package.json");
+        const altPkgPath = resolve(stagePath, "package.json");
+        let isDmwork = false;
+        for (const p of [pkgPath, altPkgPath]) {
+          try {
+            const pkg = JSON.parse(readFileSync(p, "utf-8"));
+            if (pkg.name === "openclaw-channel-dmwork") {
+              isDmwork = true;
+              break;
+            }
+          } catch { /* try next */ }
+        }
+
+        if (!isDmwork) continue; // not ours, don't touch
+
+        rmSync(stagePath, { recursive: true, force: true });
+        actions.push(`Removed stale stage directory: ${entry}`);
+      } catch { /* skip this entry */ }
+    }
+  } catch { /* best effort */ }
 
   return actions;
 }

--- a/openclaw-channel-dmwork/cli/update.ts
+++ b/openclaw-channel-dmwork/cli/update.ts
@@ -6,11 +6,11 @@
  */
 
 import {
-  cleanupLegacyPlugin,
   gatewayRestart,
   pluginsInspect,
   pluginsInstall,
 } from "./openclaw-cli.js";
+import { runSafeInstall } from "./install.js";
 import { PLUGIN_ID, ensureOpenClawCompat } from "./utils.js";
 import { execFileSync } from "node:child_process";
 
@@ -38,21 +38,29 @@ export async function runUpdate(opts: UpdateOptions): Promise<void> {
 
   const inspect = pluginsInspect(PLUGIN_ID);
   if (!inspect?.plugin) {
-    if (opts.json) {
-      console.log(JSON.stringify({ success: false, error: "not_installed" }));
-    } else {
-      console.error("DMWork plugin is not installed. Use 'install' first.");
-    }
-    process.exit(1);
-  }
-
-  // Clean up legacy "dmwork" plugin AFTER confirming new version exists
-  const legacyActions = cleanupLegacyPlugin();
-  if (legacyActions.length > 0) {
+    // Plugin not found — use full safe install path (handles deadlock, stale dirs, legacy cleanup)
     if (!opts.json) {
-      console.log("Cleaned up legacy DMWork plugin:");
-      legacyActions.forEach((a) => console.log(`  ${a}`));
+      console.log("DMWork plugin not found. Attempting install...");
     }
+    const tag = opts.dev ? "dev" : "latest";
+    runSafeInstall(`${PLUGIN_ID}@${tag}`, true, opts.json);
+
+    if (!opts.json) {
+      console.log("Restarting gateway...");
+    }
+    if (!gatewayRestart(opts.json)) {
+      if (!opts.json) {
+        console.log("Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.");
+      }
+    }
+
+    const after = pluginsInspect(PLUGIN_ID);
+    if (opts.json) {
+      console.log(JSON.stringify({ success: true, previousVersion: null, currentVersion: after?.plugin?.version ?? "unknown" }));
+    } else {
+      console.log(`Installed: v${after?.plugin?.version ?? "unknown"}`);
+    }
+    return;
   }
 
   const currentVersion = inspect.plugin.version;


### PR DESCRIPTION
## Summary

修复用户从旧版（0.5.17）升级到 0.5.21 时遇到的 6 个问题。

### 问题修复

1. **update 未安装时自动转 install** — 复用 `runSafeInstall()` 完整兼容路径，不再直接退出
2. **`--dangerously-force-unsafe-install` 兼容** — 能力探测降级，旧版 openclaw 不支持时自动不带此参数
3. **plugin already exists** — 三条件判定残留目录后清理 + `--force` 兜底
4. **鸡蛋问题（config deadlock）** — install 前临时移除 channels.dmwork + stale entries/installs，成功后 patch 恢复，失败后从备份还原完整配置
5. **doctor inspect fallback** — inspect 失败时检查插件目录 + 读 package.json 获取版本
6. **stage 目录清理** — 只清理 DMWork 的且超过 10 分钟的陈旧残留
7. **CI 版本号顺序** — tag 和 dev 发布都先 npm version 再 build
8. **getConfigFilePath 输出清洗** — openclaw warning 污染 stdout 时提取正确路径
9. **ESM require 修复** — 所有 `require("node:fs")` 改为顶层 import

### 本地测试通过

- 鸡蛋问题：channels.dmwork 残留 + 插件未装 → 自动检测、临时移除、安装、恢复配置 ✅
- 编译 + 533 测试全绿 ✅
- 编译产物无残留 `require("node:fs")` ✅

## Test plan

- [ ] `npm run build` 通过
- [ ] `npm test` 533 通过
- [ ] 鸡蛋问题场景：卸载插件 → 注入 channels.dmwork → install 自动处理
- [ ] 旧版 openclaw 不报 unknown option
- [ ] update 未安装 → 自动转 install
- [ ] doctor inspect 失败 → fallback 检测目录

🤖 Generated with [Claude Code](https://claude.com/claude-code)