### PR TITLE
fix: 安全的 legacy 升级流程 + 旧版 openclaw 兼容

### DIFF
--- a/openclaw-channel-dmwork/cli/config-preserve.test.ts
+++ b/openclaw-channel-dmwork/cli/config-preserve.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { readFileSync, writeFileSync, copyFileSync, renameSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
 vi.mock("node:child_process", () => ({
@@ -10,6 +10,7 @@ vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
   copyFileSync: vi.fn(),
+  renameSync: vi.fn(),
   existsSync: vi.fn(() => false),
 }));
 

--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -10,11 +10,13 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  cleanupBrokenInstall,
   cleanupLegacyPlugin,
   cleanupStaleStageDirectories,
   configGet,
   configGetJson,
   configSet,
+  detectScenario,
   gatewayRestart,
   gatewayStatus,
   getConfigFilePathSafe,
@@ -208,8 +210,20 @@ export async function runDoctorChecks(params: {
         });
       } else if (fix) {
         try {
-          const { runSafeInstall } = await import("./install.js");
-          runSafeInstall(PLUGIN_ID, true);
+          // Use scenario-aware install (handles legacy, deadlock, broken)
+          const scenario = detectScenario();
+          if (scenario === "legacy") {
+            const { runLegacyMigrationForUpdate } = await import("./install.js");
+            runLegacyMigrationForUpdate(PLUGIN_ID, true);
+          } else if (scenario === "deadlock") {
+            const { runDeadlockRepairForUpdate } = await import("./install.js");
+            runDeadlockRepairForUpdate(PLUGIN_ID, true);
+          } else if (scenario === "broken") {
+            cleanupBrokenInstall();
+            pluginsInstall(PLUGIN_ID, true);
+          } else {
+            pluginsInstall(PLUGIN_ID, true);
+          }
           const after = pluginsInspect(PLUGIN_ID);
           checks.push({
             name: "Plugin installed",

--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -104,15 +104,9 @@ export async function runDoctorChecks(params: {
   // Phase 1: Fatal config issues (OpenClaw CLI may not work)
   // =========================================================================
   if (!params.inProcess && fix) {
-    // Phase 0a: Clean up legacy "dmwork" plugin
-    const legacyActions = cleanupLegacyPlugin();
-    for (const action of legacyActions) {
-      checks.push({
-        name: "Legacy plugin cleanup",
-        status: "FIXED",
-        detail: action,
-      });
-    }
+    // Phase 0a: Use scenario detection — don't use old destructive cleanupLegacyPlugin()
+    // Legacy and deadlock scenarios are handled in Phase 2 plugin install section
+    // Here we only do non-destructive cleanup: stage directories and orphaned bindings
 
     // Phase 0b: Clean up stale install stage directories (DMWork only, >10min old)
     const stageActions = cleanupStaleStageDirectories();
@@ -127,21 +121,6 @@ export async function runDoctorChecks(params: {
     const cfg = readConfigFromFile();
     if (cfg) {
       const hasDmworkChannel = Boolean(cfg.channels?.dmwork);
-      // Check if plugin actually exists on disk, not just config records
-      const installPath = cfg.plugins?.installs?.["openclaw-channel-dmwork"]?.installPath;
-      const pluginOnDisk = installPath
-        ? existsSync(installPath.replace(/^~/, process.env.HOME ?? ""))
-        : false;
-
-      // channels.dmwork exists but plugin not on disk → residual config
-      if (hasDmworkChannel && !pluginOnDisk) {
-        removeChannelConfigFromFile();
-        checks.push({
-          name: "Residual channels.dmwork",
-          status: "FIXED",
-          detail: "Removed orphaned channel config (plugin not installed)",
-        });
-      }
 
       // Orphaned dmwork bindings
       const bindings = cfg.bindings as Array<{ agentId: string; match?: { channel?: string; accountId?: string } }> | undefined;

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -1,27 +1,40 @@
 /**
  * install command: install plugin via official CLI + interactive config setup.
  *
- * Only manages channels.dmwork account config. Agent creation (binding,
- * workspace, agent.md) is left to the user via `openclaw agents add`.
+ * Handles 4 upgrade scenarios:
+ * 1. Legacy migration (dmwork → openclaw-channel-dmwork)
+ * 2. Normal update (openclaw-channel-dmwork → openclaw-channel-dmwork)
+ * 3. Fresh install (nothing installed)
+ * 4. Deadlock repair (channels.dmwork exists but no plugin)
+ * + broken install cleanup
  */
 
-import { copyFileSync, existsSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, writeFileSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import {
-  cleanupLegacyPlugin,
-  cleanupStalePluginDir,
+  cleanupBrokenInstall,
   configGet,
   configGetJson,
   configSet,
   configUnset,
+  deleteLegacyBackup,
+  detectScenario,
+  ensurePluginsAllow,
   gatewayRestart,
+  getConfigFilePathSafe,
+  isHealthyInstall,
   pluginsInspect,
   pluginsInstall,
+  pluginsUpdateCompat,
   readConfigFromFile,
+  removeLegacyFromConfig,
+  renameLegacyDir,
+  restoreChannelConfigFromDisk,
+  restoreLegacyDir,
+  saveChannelConfigToDisk,
   removeChannelConfigFromFile,
-  restoreChannelConfigToFile,
   saveChannelConfigFromFile,
-  getConfigFilePathSafe,
+  restoreChannelConfigToFile,
 } from "./openclaw-cli.js";
 import {
   PLUGIN_ID,
@@ -43,155 +56,197 @@ export interface InstallOptions {
 }
 
 export async function runInstall(opts: InstallOptions): Promise<void> {
-  // 1. Pre-check
   ensureOpenClawCompat();
 
-  // 2. Safe install (handles legacy cleanup, deadlock, stale dirs)
-  const inspect = pluginsInspect(PLUGIN_ID);
-  if (inspect?.plugin && !opts.force) {
-    console.log(
-      `DMWork plugin is already installed (v${inspect.plugin.version}). Skipping install.`,
-    );
-  } else {
-    const spec = opts.dev ? `${PLUGIN_ID}@dev` : PLUGIN_ID;
-    runSafeInstall(spec, opts.force);
+  const scenario = detectScenario();
+  const spec = opts.dev ? `${PLUGIN_ID}@dev` : PLUGIN_ID;
+  const quiet = false;
+
+  switch (scenario) {
+    case "legacy":
+      runLegacyMigration(spec, quiet, opts.force, opts.skipConfig);
+      break;
+    case "update": {
+      const inspect = pluginsInspect(PLUGIN_ID);
+      if (inspect?.plugin && !opts.force) {
+        console.log(`DMWork plugin is already installed (v${inspect.plugin.version}). Skipping install.`);
+      } else {
+        console.log(`Installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
+        pluginsInstall(spec, quiet, opts.force);
+        console.log("Plugin installed successfully.");
+      }
+      break;
+    }
+    case "broken": {
+      console.log("Detected broken plugin install. Cleaning up...");
+      const actions = cleanupBrokenInstall();
+      actions.forEach((a) => console.log(`  ${a}`));
+      console.log(`Installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
+      pluginsInstall(spec, quiet, opts.force);
+      console.log("Plugin installed successfully.");
+      break;
+    }
+    case "deadlock":
+      runDeadlockRepair(spec, quiet, opts.skipConfig);
+      break;
+    case "fresh":
+      console.log(`Installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
+      pluginsInstall(spec, quiet, opts.force);
+      console.log("Plugin installed successfully.");
+      break;
   }
 
-  // 3. Legacy config migration + 4. DMWork config (unless --skip-config)
+  // Post-install: config + gateway
   if (!opts.skipConfig) {
     await migrateLegacyConfig();
     await configureDmworkAccount(opts);
   }
 
-  // 5. Gateway restart
   console.log("Restarting gateway...");
   if (!gatewayRestart()) {
-    console.log(
-      "Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.",
-    );
+    console.log("Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.");
   }
 
-  // 6. Success
   console.log("\nDMWork plugin setup complete!");
 }
 
 // ---------------------------------------------------------------------------
-// Safe install: handles legacy cleanup, config deadlock, stale dirs
+// Scenario 1: Legacy migration (dmwork → openclaw-channel-dmwork)
 // ---------------------------------------------------------------------------
 
-/**
- * Shared install logic used by both install and update commands.
- * Handles: legacy plugin cleanup, stale directory cleanup,
- * config deadlock (chicken-egg problem), and --force retry.
- */
-export function runSafeInstall(spec: string, force?: boolean, quiet?: boolean): void {
-  const log = quiet ? (() => {}) : console.log.bind(console);
-  // 1. Clean up legacy "dmwork" plugin
-  const legacyActions = cleanupLegacyPlugin();
-  if (legacyActions.length > 0) {
-    log("Cleaned up legacy DMWork plugin:");
-    legacyActions.forEach((a) => log(`  ${a}`));
+function runLegacyMigration(spec: string, quiet: boolean, force?: boolean, skipConfig?: boolean): void {
+  console.log("Detected legacy DMWork plugin (dmwork). Starting migration...");
+
+  // 1. Backup everything to disk
+  const configPath = getConfigFilePathSafe();
+  const backupPath = configPath + ".dmwork-upgrade-backup";
+  copyFileSync(configPath, backupPath);
+  saveChannelConfigToDisk();
+  console.log("  Backed up config and channels.dmwork to disk.");
+
+  // 2. Clean up any broken new plugin install from a previous failed attempt
+  const brokenActions = cleanupBrokenInstall();
+  if (brokenActions.length > 0) {
+    console.log("  Cleaned up broken previous install:");
+    brokenActions.forEach((a) => console.log(`    ${a}`));
   }
 
-  // 2. Clean up stale openclaw-channel-dmwork directory
-  const staleActions = cleanupStalePluginDir();
-  if (staleActions.length > 0) {
-    log("Cleaned up stale plugin directory:");
-    staleActions.forEach((a) => log(`  ${a}`));
+  // 3. Remove legacy from config FIRST (breaks deadlock)
+  removeLegacyFromConfig();
+  console.log("  Removed legacy config entries.");
+
+  // 3. Rename legacy directory (not delete!)
+  const legacyDirExists = existsSync(
+    getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions/dmwork"),
+  );
+  let renamed = false;
+  if (legacyDirExists) {
+    renamed = renameLegacyDir();
+    if (renamed) {
+      console.log("  Renamed extensions/dmwork → .dmwork-backup.");
+    } else {
+      // Cannot isolate old directory — abort to prevent conflict
+      console.error("  Failed to rename extensions/dmwork. Aborting migration.");
+      try { copyFileSync(backupPath, configPath); } catch { /* best effort */ }
+      throw new Error("Legacy migration aborted: could not rename extensions/dmwork");
+    }
   }
 
-  // 3. Handle config deadlock (chicken-egg problem):
-  //    channels.dmwork exists but plugin not installed → config validation blocks install
-  const cfg = readConfigFromFile();
-  const hasDmworkChannel = Boolean(cfg?.channels?.dmwork);
-  const hasStaleEntries = Boolean(cfg?.plugins?.entries?.["openclaw-channel-dmwork"]);
-  const hasStaleInstalls = Boolean(cfg?.plugins?.installs?.["openclaw-channel-dmwork"]);
+  // 4. Install new plugin
+  try {
+    console.log("  Installing openclaw-channel-dmwork...");
+    pluginsInstall(spec, quiet, force);
+  } catch (installErr) {
+    // FAIL: restore everything
+    console.error("  Install failed! Restoring previous state...");
+    if (renamed) restoreLegacyDir();
+    try { copyFileSync(backupPath, configPath); } catch { /* best effort */ }
+    console.error("  Previous state restored. Legacy plugin should still work.");
+    throw installErr;
+  }
 
-  // Only enter deadlock fix if plugin is genuinely not present:
-  // - inspect returns null AND plugin directory doesn't exist on disk
-  // This prevents treating "inspect anomaly + plugin still running" as deadlock
-  const inspectResult = pluginsInspect(PLUGIN_ID);
-  const extensionsDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
-  const pluginDirExists = existsSync(resolve(extensionsDir, "openclaw-channel-dmwork"));
-  const pluginGenuinelyMissing = !inspectResult?.plugin && !pluginDirExists;
-  const needsDeadlockFix = hasDmworkChannel && pluginGenuinelyMissing;
+  // 5. Verify healthy install
+  if (!isHealthyInstall()) {
+    console.error("  Install completed but verification failed. Restoring...");
+    if (renamed) restoreLegacyDir();
+    try { copyFileSync(backupPath, configPath); } catch { /* best effort */ }
+    console.error("  Previous state restored.");
+    throw new Error("Legacy migration failed: post-install verification did not pass");
+  }
 
-  if (needsDeadlockFix) {
-    log("Detected config deadlock (channels.dmwork exists but plugin not installed).");
-    log("Temporarily removing stale config to allow installation...");
+  // 6. Success: restore channels.dmwork + cleanup
+  ensurePluginsAllow();
+  restoreChannelConfigFromDisk();
 
-    // Backup full config file for disaster recovery
-    const configPath = getConfigFilePathSafe();
-    const backupPath = configPath + ".dmwork-upgrade-backup";
-    copyFileSync(configPath, backupPath);
-
-    // Save channels.dmwork for restore after install
-    const savedDmwork = saveChannelConfigFromFile();
-
-    // Temporarily remove stale config entries
-    removeChannelConfigFromFile();
-    if (hasStaleEntries) {
-      try {
-        const c = readConfigFromFile();
-        if (c?.plugins?.entries?.["openclaw-channel-dmwork"]) {
-          delete c.plugins.entries["openclaw-channel-dmwork"];
-          copyFileSync(configPath, configPath + ".bak");
-          writeFileSync(configPath, JSON.stringify(c, null, 2), "utf-8");
-        }
-      } catch { /* best effort */ }
-    }
-    if (hasStaleInstalls) {
-      try {
-        const c = readConfigFromFile();
-        if (c?.plugins?.installs?.["openclaw-channel-dmwork"]) {
-          delete c.plugins.installs["openclaw-channel-dmwork"];
-          writeFileSync(configPath, JSON.stringify(c, null, 2), "utf-8");
-        }
-      } catch { /* best effort */ }
-    }
-
-    try {
-      log(`Installing DMWork plugin...`);
-      pluginsInstall(spec, quiet, force);
-      log("Plugin installed successfully.");
-      // Success: patch channels.dmwork back (preserves new entries/installs from plugins install)
-      if (savedDmwork) {
-        restoreChannelConfigToFile(savedDmwork);
-        log("Restored channels.dmwork config.");
-      }
-    } catch (installErr) {
-      // Install failed: restore full config from backup to avoid leaving user worse off
-      console.error("Plugin install failed. Restoring original config...");
-      try {
-        copyFileSync(backupPath, configPath);
-        log("Original config restored from backup.");
-      } catch {
-        console.error(`Warning: Could not restore backup. Manual restore: cp ${backupPath} ${configPath}`);
-      }
-      throw installErr;
-    }
+  // Verify config was actually restored before deleting backups
+  const restoredCfg = readConfigFromFile();
+  if (restoredCfg?.channels?.dmwork) {
+    // Config restore succeeded — safe to delete backups
+    deleteLegacyBackup();
+    try { rmSync(backupPath, { force: true }); } catch { /* best effort */ }
   } else {
-    // Normal install path (no deadlock)
-    try {
-      log(`Installing DMWork plugin...`);
-      pluginsInstall(spec, quiet, force);
-      log("Plugin installed successfully.");
-    } catch (err) {
-      // If "already exists" → retry with --force
-      const msg = String(err);
-      if (msg.includes("already exists") && !force) {
-        log("Plugin directory exists, retrying with --force...");
-        pluginsInstall(spec, quiet, true);
-        log("Plugin installed successfully (forced).");
-      } else {
-        throw err;
-      }
-    }
+    console.log("  Warning: channels.dmwork restore may not have succeeded. Keeping backups for safety.");
   }
+  console.log("  Legacy migration complete!");
 }
 
 // ---------------------------------------------------------------------------
-// Legacy config migration
+// Scenario 4: Deadlock repair
+// ---------------------------------------------------------------------------
+
+function runDeadlockRepair(spec: string, quiet: boolean, skipConfig?: boolean): void {
+  console.log("Detected config deadlock (channels.dmwork exists but no plugin).");
+
+  // 1. Backup
+  const configPath = getConfigFilePathSafe();
+  const backupPath = configPath + ".dmwork-upgrade-backup";
+  copyFileSync(configPath, backupPath);
+  saveChannelConfigToDisk();
+
+  // 2. Remove channels.dmwork
+  removeChannelConfigFromFile();
+  console.log("  Temporarily removed channels.dmwork.");
+
+  // 3. Install
+  try {
+    console.log("  Installing openclaw-channel-dmwork...");
+    pluginsInstall(spec, quiet);
+  } catch (installErr) {
+    console.error("  Install failed! Restoring config...");
+    try { copyFileSync(backupPath, configPath); } catch { /* best effort */ }
+    throw installErr;
+  }
+
+  // 4. Verify
+  if (!isHealthyInstall()) {
+    console.error("  Install completed but verification failed. Restoring config...");
+    try { copyFileSync(backupPath, configPath); } catch { /* best effort */ }
+    throw new Error("Deadlock repair failed: post-install verification did not pass");
+  }
+
+  // 5. Success
+  ensurePluginsAllow();
+  restoreChannelConfigFromDisk();
+
+  // Verify config was restored before deleting backup
+  const restoredCfg = readConfigFromFile();
+  if (restoredCfg?.channels?.dmwork) {
+    try { rmSync(backupPath, { force: true }); } catch { /* best effort */ }
+  } else {
+    console.log("  Warning: channels.dmwork restore may not have succeeded. Keeping backup for safety.");
+  }
+  console.log("  Deadlock repaired!");
+}
+
+// ---------------------------------------------------------------------------
+// Exported for update.ts to reuse
+// ---------------------------------------------------------------------------
+
+export { runLegacyMigration as runLegacyMigrationForUpdate };
+export { runDeadlockRepair as runDeadlockRepairForUpdate };
+
+// ---------------------------------------------------------------------------
+// Legacy config migration (flat → accounts)
 // ---------------------------------------------------------------------------
 
 async function migrateLegacyConfig(): Promise<void> {
@@ -225,23 +280,17 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
   }
 
   if (!validateAccountId(accountId)) {
-    console.error(
-      `Error: Invalid account ID "${accountId}". Only letters, digits, and underscores are allowed.`,
-    );
+    console.error(`Error: Invalid account ID "${accountId}". Only letters, digits, and underscores are allowed.`);
     process.exit(1);
   }
 
-  const existingToken = configGet(
-    `channels.dmwork.accounts.${accountId}.botToken`,
-  );
+  const existingToken = configGet(`channels.dmwork.accounts.${accountId}.botToken`);
   if (existingToken) {
     if (!isInteractive()) {
       if (opts.botToken && opts.apiUrl) {
         console.log(`Overwriting existing account "${accountId}".`);
       } else if (opts.botToken || opts.apiUrl) {
-        console.error(
-          `Error: Account "${accountId}" already exists. Provide both --bot-token and --api-url to overwrite.`,
-        );
+        console.error(`Error: Account "${accountId}" already exists. Provide both --bot-token and --api-url to overwrite.`);
         process.exit(1);
       } else {
         console.log(`Account "${accountId}" already configured. Keeping existing config.`);
@@ -250,10 +299,7 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
         return;
       }
     } else {
-      const keep = await confirm(
-        `Bot account "${accountId}" is already configured. Keep current config?`,
-        true,
-      );
+      const keep = await confirm(`Bot account "${accountId}" is already configured. Keep current config?`, true);
       if (keep) {
         console.log("Keeping existing config.");
         ensureDmScope();
@@ -264,18 +310,14 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
   }
 
   let botToken = opts.botToken;
-  if (!botToken) {
-    botToken = await prompt("Enter bot token (bf_...):");
-  }
+  if (!botToken) botToken = await prompt("Enter bot token (bf_...):");
   if (!botToken?.startsWith("bf_")) {
     console.error("Error: Bot token must start with 'bf_'.");
     process.exit(1);
   }
 
   let apiUrl = opts.apiUrl;
-  if (!apiUrl) {
-    apiUrl = await prompt("Enter API server URL:");
-  }
+  if (!apiUrl) apiUrl = await prompt("Enter API server URL:");
   if (!apiUrl) {
     console.error("Error: API URL is required.");
     process.exit(1);
@@ -290,29 +332,16 @@ async function configureDmworkAccount(opts: InstallOptions): Promise<void> {
   printAgentHint(accountId);
 }
 
-// ---------------------------------------------------------------------------
-// session.dmScope
-// ---------------------------------------------------------------------------
-
 function ensureDmScope(): void {
   const current = configGet("session.dmScope");
   if (!current) {
     configSet("session.dmScope", RECOMMENDED_DM_SCOPE);
   } else if (current !== RECOMMENDED_DM_SCOPE) {
-    console.log(
-      `Warning: session.dmScope is "${current}" (recommended: ${RECOMMENDED_DM_SCOPE})`,
-    );
+    console.log(`Warning: session.dmScope is "${current}" (recommended: ${RECOMMENDED_DM_SCOPE})`);
   }
 }
 
-// ---------------------------------------------------------------------------
-// Agent hint
-// ---------------------------------------------------------------------------
-
 function printAgentHint(accountId: string): void {
   const agentName = accountId.replace(/_bot$/, "");
-  console.log(`
-To create an independent agent for this bot (optional):
-  openclaw agents add ${agentName}
-  openclaw agents bind ${agentName} dmwork ${accountId}`);
+  console.log(`\nTo create an independent agent for this bot (optional):\n  openclaw agents add ${agentName}\n  openclaw agents bind ${agentName} dmwork ${accountId}`);
 }

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -232,10 +232,11 @@ function runDeadlockRepair(spec: string, quiet: boolean, skipConfig?: boolean): 
   const restoredCfg = readConfigFromFile();
   if (restoredCfg?.channels?.dmwork) {
     try { rmSync(backupPath, { force: true }); } catch { /* best effort */ }
+    console.log("  Deadlock repaired!");
   } else {
-    console.log("  Warning: channels.dmwork restore may not have succeeded. Keeping backup for safety.");
+    // Config restore failed — plugin is installed but bot config is missing
+    throw new Error("Deadlock repair incomplete: plugin installed but channels.dmwork could not be restored. Backup kept at " + backupPath);
   }
-  console.log("  Deadlock repaired!");
 }
 
 // ---------------------------------------------------------------------------

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -5,7 +5,7 @@
  */
 
 import { execFileSync, execSync } from "node:child_process";
-import { readFileSync, writeFileSync, copyFileSync, existsSync, rmSync, readdirSync, statSync } from "node:fs";
+import { readFileSync, writeFileSync, copyFileSync, existsSync, rmSync, readdirSync, statSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 
@@ -535,6 +535,216 @@ export function cleanupStaleStageDirectories(): string[] {
       } catch { /* skip this entry */ }
     }
   } catch { /* best effort */ }
+
+  return actions;
+}
+
+// ---------------------------------------------------------------------------
+// Atomic config write
+// ---------------------------------------------------------------------------
+
+/**
+ * Write openclaw.json atomically: write to .tmp then rename.
+ * Prevents gateway watcher from reading half-written/truncated JSON.
+ */
+export function writeConfigAtomic(cfg: Record<string, any>): void {
+  const configPath = getConfigFilePathSafe();
+  const tmpPath = configPath + ".tmp";
+  writeFileSync(tmpPath, JSON.stringify(cfg, null, 2), "utf-8");
+  renameSync(tmpPath, configPath);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario detection
+// ---------------------------------------------------------------------------
+
+export type UpgradeScenario = "legacy" | "update" | "fresh" | "deadlock" | "broken";
+
+export function detectScenario(): UpgradeScenario {
+  const cfg = readConfigFromFile();
+  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+
+  const hasLegacyDir = existsSync(resolve(extDir, "dmwork"));
+  const hasLegacyEntries = Boolean(cfg?.plugins?.entries?.["dmwork"]);
+  const hasLegacyInstalls = Boolean(cfg?.plugins?.installs?.["dmwork"]);
+  const hasLegacy = hasLegacyDir || hasLegacyEntries || hasLegacyInstalls;
+
+  const hasNewDir = existsSync(resolve(extDir, "openclaw-channel-dmwork"));
+  const hasNewEntries = Boolean(cfg?.plugins?.entries?.["openclaw-channel-dmwork"]);
+  const hasNewInstalls = Boolean(cfg?.plugins?.installs?.["openclaw-channel-dmwork"]);
+  const inspectOk = Boolean(pluginsInspect("openclaw-channel-dmwork")?.plugin);
+  const isHealthy = inspectOk || (hasNewDir && hasNewEntries && hasNewInstalls);
+  const hasNewPartial = (hasNewDir || hasNewEntries || hasNewInstalls) && !isHealthy;
+
+  const hasDmworkChannel = Boolean(cfg?.channels?.dmwork);
+
+  if (hasLegacy) return "legacy";
+  if (isHealthy) return "update";
+  if (hasNewPartial) return "broken";
+  if (hasDmworkChannel) return "deadlock";
+  return "fresh";
+}
+
+export function isHealthyInstall(): boolean {
+  const cfg = readConfigFromFile();
+  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+  const hasNewDir = existsSync(resolve(extDir, "openclaw-channel-dmwork"));
+  const hasNewEntries = Boolean(cfg?.plugins?.entries?.["openclaw-channel-dmwork"]);
+  const hasNewInstalls = Boolean(cfg?.plugins?.installs?.["openclaw-channel-dmwork"]);
+  const inspectOk = Boolean(pluginsInspect("openclaw-channel-dmwork")?.plugin);
+  return inspectOk || (hasNewDir && hasNewEntries && hasNewInstalls);
+}
+
+export function ensurePluginsAllow(): void {
+  try {
+    const cfg = readConfigFromFile();
+    if (!cfg?.plugins?.allow || !Array.isArray(cfg.plugins.allow)) return;
+    if (cfg.plugins.allow.includes("openclaw-channel-dmwork")) return;
+    cfg.plugins.allow.push("openclaw-channel-dmwork");
+    writeConfigAtomic(cfg);
+  } catch { /* best effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// pluginsUpdateCompat
+// ---------------------------------------------------------------------------
+
+export function pluginsUpdateCompat(id: string, tag: string, quiet?: boolean): void {
+  const stdioOpt: import("node:child_process").StdioOptions = quiet
+    ? ["pipe", "pipe", "pipe"]
+    : "inherit";
+  try {
+    execFileSync(OPENCLAW, ["plugins", "update", id], { stdio: stdioOpt });
+  } catch {
+    pluginsInstall(`${id}@${tag}`, quiet, true);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy migration helpers
+// ---------------------------------------------------------------------------
+
+export function renameLegacyDir(): boolean {
+  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+  const legacyDir = resolve(extDir, "dmwork");
+  const backupDir = resolve(extDir, ".dmwork-backup");
+  if (!existsSync(legacyDir)) return false;
+  try {
+    if (existsSync(backupDir)) rmSync(backupDir, { recursive: true, force: true });
+    renameSync(legacyDir, backupDir);
+    return true;
+  } catch { return false; }
+}
+
+export function restoreLegacyDir(): void {
+  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+  const legacyDir = resolve(extDir, "dmwork");
+  const backupDir = resolve(extDir, ".dmwork-backup");
+  if (!existsSync(backupDir)) return;
+  try {
+    if (existsSync(legacyDir)) rmSync(legacyDir, { recursive: true, force: true });
+    renameSync(backupDir, legacyDir);
+  } catch { /* best effort */ }
+}
+
+export function deleteLegacyBackup(): void {
+  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+  const backupDir = resolve(extDir, ".dmwork-backup");
+  if (existsSync(backupDir)) {
+    try { rmSync(backupDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+}
+
+export function removeLegacyFromConfig(): void {
+  try {
+    const cfg = readConfigFromFile();
+    if (!cfg) return;
+    if (cfg.plugins?.entries?.["dmwork"]) delete cfg.plugins.entries["dmwork"];
+    if (cfg.plugins?.installs?.["dmwork"]) delete cfg.plugins.installs["dmwork"];
+    if (Array.isArray(cfg.plugins?.allow)) {
+      cfg.plugins.allow = cfg.plugins.allow.filter((id: string) => id !== "dmwork");
+    }
+    if (cfg.channels?.dmwork) delete cfg.channels.dmwork;
+    writeConfigAtomic(cfg);
+  } catch { /* best effort */ }
+}
+
+export function saveChannelConfigToDisk(): void {
+  try {
+    const backupPath = getConfigFilePathSafe().replace(/openclaw\.json$/, "channels-dmwork-backup.json");
+    const cfg = readConfigFromFile();
+    const dmwork = cfg?.channels?.dmwork;
+    if (dmwork) {
+      writeFileSync(backupPath, JSON.stringify(dmwork, null, 2), "utf-8");
+    } else {
+      // No channels.dmwork — remove stale backup to prevent wrong restore
+      if (existsSync(backupPath)) rmSync(backupPath, { force: true });
+    }
+  } catch { /* best effort */ }
+}
+
+export function restoreChannelConfigFromDisk(): void {
+  try {
+    const backupPath = getConfigFilePathSafe().replace(/openclaw\.json$/, "channels-dmwork-backup.json");
+    if (!existsSync(backupPath)) return;
+    let dmwork = JSON.parse(readFileSync(backupPath, "utf-8"));
+
+    // Migrate flat config → accounts.default
+    if (dmwork.botToken && !dmwork.accounts) {
+      dmwork = {
+        ...dmwork,
+        accounts: { default: { botToken: dmwork.botToken, apiUrl: dmwork.apiUrl } },
+      };
+      delete dmwork.botToken;
+    }
+
+    const cfg = readConfigFromFile();
+    if (!cfg) return;
+    if (!cfg.channels) cfg.channels = {};
+    cfg.channels.dmwork = dmwork;
+    writeConfigAtomic(cfg);
+    rmSync(backupPath, { force: true });
+  } catch { /* best effort */ }
+}
+
+export function cleanupBrokenInstall(): string[] {
+  const actions: string[] = [];
+  const cfg = readConfigFromFile();
+  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+  const pluginDir = resolve(extDir, "openclaw-channel-dmwork");
+
+  const hasDir = existsSync(pluginDir);
+  const hasEntries = Boolean(cfg?.plugins?.entries?.["openclaw-channel-dmwork"]);
+  const hasInstalls = Boolean(cfg?.plugins?.installs?.["openclaw-channel-dmwork"]);
+
+  // "Healthy" requires all three (or inspect OK). Anything less is broken.
+  const inspectOk = Boolean(pluginsInspect("openclaw-channel-dmwork")?.plugin);
+  if (inspectOk) return actions; // Actually healthy, nothing to clean
+
+  // Remove directory if it exists (orphan or partial)
+  if (hasDir) {
+    try {
+      rmSync(pluginDir, { recursive: true, force: true });
+      actions.push("Removed broken/orphan plugin directory");
+    } catch { /* best effort */ }
+  }
+
+  // Remove stale config entries
+  if (cfg && (hasEntries || hasInstalls)) {
+    let changed = false;
+    if (hasEntries) {
+      delete cfg.plugins!.entries!["openclaw-channel-dmwork"];
+      changed = true;
+    }
+    if (hasInstalls) {
+      delete cfg.plugins!.installs!["openclaw-channel-dmwork"];
+      changed = true;
+    }
+    if (changed) {
+      writeConfigAtomic(cfg);
+      actions.push("Cleaned stale config entries");
+    }
+  }
 
   return actions;
 }

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -731,9 +731,10 @@ export function cleanupBrokenInstall(): string[] {
   const hasEntries = Boolean(cfg?.plugins?.entries?.["openclaw-channel-dmwork"]);
   const hasInstalls = Boolean(cfg?.plugins?.installs?.["openclaw-channel-dmwork"]);
 
-  // "Healthy" requires all three (or inspect OK). Anything less is broken.
+  // Use same healthy definition as detectScenario(): inspect OK OR all 3 artifacts present
   const inspectOk = Boolean(pluginsInspect("openclaw-channel-dmwork")?.plugin);
-  if (inspectOk) return actions; // Actually healthy, nothing to clean
+  const isHealthy = inspectOk || (hasDir && hasEntries && hasInstalls);
+  if (isHealthy) return actions; // Actually healthy, nothing to clean
 
   // Remove directory if it exists (orphan or partial)
   if (hasDir) {

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -305,7 +305,7 @@ export function restoreChannelConfigToFile(
   const cfg = JSON.parse(raw);
   if (!cfg.channels) cfg.channels = {};
   cfg.channels.dmwork = dmworkConfig;
-  writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+  writeConfigAtomic(cfg);
 }
 
 /**
@@ -330,11 +330,10 @@ export function removeChannelConfigFromFile(): void {
   try {
     const configPath = getConfigFilePathSafe();
     copyFileSync(configPath, configPath + ".bak");
-    const raw = readFileSync(configPath, "utf-8");
-    const cfg = JSON.parse(raw);
-    if (cfg.channels?.dmwork) {
+    const cfg = readConfigFromFile();
+    if (cfg?.channels?.dmwork) {
       delete cfg.channels.dmwork;
-      writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+      writeConfigAtomic(cfg);
     }
   } catch {
     // best effort
@@ -375,7 +374,7 @@ export function removeOrphanedBindingsFromFile(
       // Keep only if accountId is in valid list (or no accountId specified)
       return !b.match.accountId || validAccountIds.includes(b.match.accountId);
     });
-    writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+    writeConfigAtomic(cfg);
   } catch {
     // best effort
   }
@@ -441,7 +440,7 @@ export function cleanupLegacyPlugin(): string[] {
       if (Array.isArray(cfg.plugins?.allow)) {
         cfg.plugins.allow = cfg.plugins.allow.filter((id: string) => id !== LEGACY_PLUGIN_ID);
       }
-      writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+      writeConfigAtomic(cfg);
       actions.push(`Cleaned legacy entries from openclaw.json`);
     }
   } catch {

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -156,19 +156,34 @@ function isUnsupportedOptionError(err: unknown): boolean {
 }
 
 export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): void {
-  const args = ["plugins", "install", spec];
-  if (force) args.push("--force");
+  const baseArgs = ["plugins", "install", spec];
   const stdioOpt: import("node:child_process").StdioOptions = quiet
     ? ["pipe", "pipe", "pipe"]
     : "inherit";
 
-  // Try with --dangerously-force-unsafe-install first; fall back if unsupported
-  try {
-    execFileSync(OPENCLAW, [...args, "--dangerously-force-unsafe-install"], { stdio: stdioOpt });
-  } catch (err) {
-    if (isUnsupportedOptionError(err)) {
-      execFileSync(OPENCLAW, args, { stdio: stdioOpt });
-    } else {
+  // 3-layer degradation for old openclaw versions:
+  //   1. --force --dangerously-force-unsafe-install  (newest openclaw)
+  //   2. --force                                     (mid-age openclaw)
+  //   3. bare install                                (oldest openclaw)
+  const attempts: string[][] = force
+    ? [
+        [...baseArgs, "--force", "--dangerously-force-unsafe-install"],
+        [...baseArgs, "--force"],
+        baseArgs,
+      ]
+    : [
+        [...baseArgs, "--dangerously-force-unsafe-install"],
+        baseArgs,
+      ];
+
+  for (let i = 0; i < attempts.length; i++) {
+    try {
+      execFileSync(OPENCLAW, attempts[i], { stdio: stdioOpt });
+      return;
+    } catch (err) {
+      if (isUnsupportedOptionError(err) && i < attempts.length - 1) {
+        continue; // try next degradation level
+      }
       throw err;
     }
   }

--- a/openclaw-channel-dmwork/cli/update.ts
+++ b/openclaw-channel-dmwork/cli/update.ts
@@ -1,16 +1,21 @@
 /**
  * update command:
- * - Without --dev: always target latest (stable) version
- * - With --dev: always target @dev tag version
- * - Skip if the target version is already installed
+ * - Detects scenario and routes accordingly
+ * - For healthy installs: compare versions, update if different
+ * - For legacy/broken/deadlock: delegate to install's safe paths
  */
 
 import {
+  cleanupBrokenInstall,
+  detectScenario,
   gatewayRestart,
   pluginsInspect,
-  pluginsInstall,
+  pluginsUpdateCompat,
 } from "./openclaw-cli.js";
-import { runSafeInstall } from "./install.js";
+import {
+  runLegacyMigrationForUpdate,
+  runDeadlockRepairForUpdate,
+} from "./install.js";
 import { PLUGIN_ID, ensureOpenClawCompat } from "./utils.js";
 import { execFileSync } from "node:child_process";
 
@@ -19,9 +24,6 @@ export interface UpdateOptions {
   dev?: boolean;
 }
 
-/**
- * Query npm registry for the latest version under a given tag.
- */
 function getLatestNpmVersion(tag: string): string | null {
   try {
     return execFileSync("npm", ["view", `${PLUGIN_ID}@${tag}`, "version"], {
@@ -36,35 +38,67 @@ function getLatestNpmVersion(tag: string): string | null {
 export async function runUpdate(opts: UpdateOptions): Promise<void> {
   ensureOpenClawCompat();
 
-  const inspect = pluginsInspect(PLUGIN_ID);
-  if (!inspect?.plugin) {
-    // Plugin not found — use full safe install path (handles deadlock, stale dirs, legacy cleanup)
-    if (!opts.json) {
-      console.log("DMWork plugin not found. Attempting install...");
-    }
-    const tag = opts.dev ? "dev" : "latest";
-    runSafeInstall(`${PLUGIN_ID}@${tag}`, true, opts.json);
+  const scenario = detectScenario();
+  const tag = opts.dev ? "dev" : "latest";
+  const spec = `${PLUGIN_ID}@${tag}`;
+  const quiet = Boolean(opts.json);
 
-    if (!opts.json) {
-      console.log("Restarting gateway...");
-    }
-    if (!gatewayRestart(opts.json)) {
-      if (!opts.json) {
-        console.log("Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.");
-      }
-    }
-
-    const after = pluginsInspect(PLUGIN_ID);
+  // Non-healthy scenarios: delegate to install's safe paths
+  if (scenario === "legacy") {
+    if (!quiet) console.log("Detected legacy DMWork plugin. Running migration...");
+    runLegacyMigrationForUpdate(spec, quiet);
+    if (!quiet) console.log("Restarting gateway...");
+    gatewayRestart(quiet);
     if (opts.json) {
+      const after = pluginsInspect(PLUGIN_ID);
       console.log(JSON.stringify({ success: true, previousVersion: null, currentVersion: after?.plugin?.version ?? "unknown" }));
-    } else {
-      console.log(`Installed: v${after?.plugin?.version ?? "unknown"}`);
     }
     return;
   }
 
-  const currentVersion = inspect.plugin.version;
-  const tag = opts.dev ? "dev" : "latest";
+  if (scenario === "broken") {
+    if (!quiet) console.log("Detected broken plugin install. Cleaning up and reinstalling...");
+    cleanupBrokenInstall();
+    // After cleanup, fall through to fresh install via pluginsInstall
+    const { pluginsInstall } = await import("./openclaw-cli.js");
+    pluginsInstall(spec, quiet);
+    if (!quiet) console.log("Restarting gateway...");
+    gatewayRestart(quiet);
+    if (opts.json) {
+      const after = pluginsInspect(PLUGIN_ID);
+      console.log(JSON.stringify({ success: true, previousVersion: null, currentVersion: after?.plugin?.version ?? "unknown" }));
+    }
+    return;
+  }
+
+  if (scenario === "deadlock") {
+    if (!quiet) console.log("Detected config deadlock. Repairing...");
+    runDeadlockRepairForUpdate(spec, quiet);
+    if (!quiet) console.log("Restarting gateway...");
+    gatewayRestart(quiet);
+    if (opts.json) {
+      const after = pluginsInspect(PLUGIN_ID);
+      console.log(JSON.stringify({ success: true, previousVersion: null, currentVersion: after?.plugin?.version ?? "unknown" }));
+    }
+    return;
+  }
+
+  if (scenario === "fresh") {
+    if (!quiet) console.log("DMWork plugin not found. Installing...");
+    const { pluginsInstall } = await import("./openclaw-cli.js");
+    pluginsInstall(spec, quiet);
+    if (!quiet) console.log("Restarting gateway...");
+    gatewayRestart(quiet);
+    if (opts.json) {
+      const after = pluginsInspect(PLUGIN_ID);
+      console.log(JSON.stringify({ success: true, previousVersion: null, currentVersion: after?.plugin?.version ?? "unknown" }));
+    }
+    return;
+  }
+
+  // Scenario: update (healthy install)
+  const inspect = pluginsInspect(PLUGIN_ID);
+  const currentVersion = inspect?.plugin?.version ?? "unknown";
   const targetVersion = getLatestNpmVersion(tag);
 
   if (!targetVersion) {
@@ -76,7 +110,6 @@ export async function runUpdate(opts: UpdateOptions): Promise<void> {
     process.exit(1);
   }
 
-  // Skip if already on the target version
   if (currentVersion === targetVersion) {
     if (opts.json) {
       console.log(JSON.stringify({ success: true, previousVersion: currentVersion, currentVersion: targetVersion }));
@@ -86,22 +119,15 @@ export async function runUpdate(opts: UpdateOptions): Promise<void> {
     return;
   }
 
-  const quiet = Boolean(opts.json);
-
   if (!quiet) {
     console.log(`Updating DMWork plugin: v${currentVersion} -> v${targetVersion}${opts.dev ? " (dev)" : ""}...`);
   }
 
-  // Use --force to replace existing installation when switching versions
-  pluginsInstall(`${PLUGIN_ID}@${tag}`, quiet, true);
+  pluginsUpdateCompat(PLUGIN_ID, tag, quiet);
 
-  if (!quiet) {
-    console.log("Restarting gateway...");
-  }
+  if (!quiet) console.log("Restarting gateway...");
   if (!gatewayRestart(quiet)) {
-    if (!quiet) {
-      console.log("Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.");
-    }
+    if (!quiet) console.log("Warning: Gateway restart failed. Run 'openclaw gateway restart' manually.");
   }
 
   if (opts.json) {


### PR DESCRIPTION
## Summary

- 重写升级流程为 4 场景分支（legacy / update / fresh / deadlock / broken），每个场景有独立的安全处理路径和失败回滚
- legacy 迁移采用 rename（非 delete）旧目录，安装失败时完整恢复
- deadlock 修复（channels.dmwork 存在但插件未装）：临时移除配置 → 安装 → 恢复，失败时抛错而非静默
- `pluginsInstall()` 三层参数降级：`--force --dangerously-force-unsafe-install` → `--force` → 裸 install，兼容所有版本 openclaw
- 所有配置写入改用 `writeConfigAtomic()`（tmp + rename），防止 gateway 读到截断 JSON
- doctor `--fix` 移除旧的破坏性 `cleanupLegacyPlugin()` 调用，改用场景感知的非破坏性清理
- CI tag 发布顺序修正：先 `npm version` 再 `npm run build`，确保 dist 版本号正确

## Test plan

- [x] `npx tsc --noEmit` 编译通过
- [x] `npm test` 533 个测试全部通过
- [ ] 旧版 openclaw（无 --force）环境验证三层降级
- [ ] legacy 场景：extensions/dmwork 存在 → 迁移成功 → 旧目录被 rename
- [ ] deadlock 场景：channels.dmwork 存在但插件未装 → 自动修复
- [ ] broken 场景：stage 目录残留 → 自动清理后安装

🤖 Generated with [Claude Code](https://claude.com/claude-code)