### PR TITLE
fix: 安装兼容层修复 — pipe 捕获 + 三层降级 + 精准 fallback

### DIFF
--- a/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
@@ -189,3 +189,153 @@ describe("findGlobalOpenclaw (via module load)", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// pluginsInstall degradation
+// ---------------------------------------------------------------------------
+
+describe("pluginsInstall 3-layer degradation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should succeed on first attempt (newest openclaw)", async () => {
+    const { pluginsInstall } = await loadModule();
+    mockExecFileSync.mockReturnValue("");
+    pluginsInstall("test-plugin", true, true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFileSync.mock.calls[0][1]).toContain("--dangerously-force-unsafe-install");
+    expect(mockExecFileSync.mock.calls[0][1]).toContain("--force");
+  });
+
+  it("should degrade from --dangerously-force-unsafe-install to --force", async () => {
+    const { pluginsInstall } = await loadModule();
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        const err = new Error("error: unknown option '--dangerously-force-unsafe-install'");
+        (err as any).stderr = Buffer.from("error: unknown option '--dangerously-force-unsafe-install'");
+        throw err;
+      })
+      .mockReturnValue("");
+    pluginsInstall("test-plugin", true, true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    expect(mockExecFileSync.mock.calls[1][1]).toContain("--force");
+    expect(mockExecFileSync.mock.calls[1][1]).not.toContain("--dangerously-force-unsafe-install");
+  });
+
+  it("should degrade to bare install when --force also unsupported", async () => {
+    const { pluginsInstall } = await loadModule();
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        const err = new Error("unknown option");
+        (err as any).stderr = Buffer.from("error: unknown option '--dangerously-force-unsafe-install'");
+        throw err;
+      })
+      .mockImplementationOnce(() => {
+        const err = new Error("unknown option");
+        (err as any).stderr = Buffer.from("error: unknown option '--force'");
+        throw err;
+      })
+      .mockReturnValue("");
+    pluginsInstall("test-plugin", true, true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+    const lastArgs = mockExecFileSync.mock.calls[2][1] as string[];
+    expect(lastArgs).not.toContain("--force");
+    expect(lastArgs).not.toContain("--dangerously-force-unsafe-install");
+    expect(lastArgs).toContain("test-plugin");
+  });
+
+  it("should throw non-option errors without degrading", async () => {
+    const { pluginsInstall } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      const err = new Error("network error");
+      (err as any).stderr = Buffer.from("ECONNREFUSED");
+      throw err;
+    });
+    expect(() => pluginsInstall("test-plugin", true)).toThrow("network error");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("should work without force (2-layer degradation)", async () => {
+    const { pluginsInstall } = await loadModule();
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        const err = new Error("unknown option");
+        (err as any).stderr = Buffer.from("error: unknown option '--dangerously-force-unsafe-install'");
+        throw err;
+      })
+      .mockReturnValue("");
+    pluginsInstall("test-plugin", true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    const lastArgs = mockExecFileSync.mock.calls[1][1] as string[];
+    expect(lastArgs).not.toContain("--force");
+    expect(lastArgs).not.toContain("--dangerously-force-unsafe-install");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pluginsUpdateCompat precise fallback
+// ---------------------------------------------------------------------------
+
+describe("pluginsUpdateCompat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should succeed when plugins update works", async () => {
+    const { pluginsUpdateCompat } = await loadModule();
+    mockExecFileSync.mockReturnValue("");
+    pluginsUpdateCompat("test-plugin", "latest", true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFileSync.mock.calls[0][1]).toContain("update");
+  });
+
+  it("should fallback to install when update reports not installed", async () => {
+    const { pluginsUpdateCompat } = await loadModule();
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        const err = new Error("plugin not found");
+        (err as any).stderr = Buffer.from("plugin not found");
+        throw err;
+      })
+      .mockReturnValue(""); // install succeeds
+    pluginsUpdateCompat("test-plugin", "latest", true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    expect(mockExecFileSync.mock.calls[1][1]).toContain("install");
+  });
+
+  it("should fallback to install when update command is unsupported", async () => {
+    const { pluginsUpdateCompat } = await loadModule();
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        const err = new Error("unknown option");
+        (err as any).stderr = Buffer.from("error: unknown option 'update'");
+        throw err;
+      })
+      .mockReturnValue("");
+    pluginsUpdateCompat("test-plugin", "latest", true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("should throw network errors without fallback", async () => {
+    const { pluginsUpdateCompat } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      const err = new Error("ECONNREFUSED");
+      (err as any).stderr = Buffer.from("connect ECONNREFUSED 127.0.0.1:443");
+      throw err;
+    });
+    expect(() => pluginsUpdateCompat("test-plugin", "latest", true)).toThrow("ECONNREFUSED");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw permission errors without fallback", async () => {
+    const { pluginsUpdateCompat } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      const err = new Error("EACCES");
+      (err as any).stderr = Buffer.from("EACCES: permission denied");
+      throw err;
+    });
+    expect(() => pluginsUpdateCompat("test-plugin", "latest", true)).toThrow("EACCES");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -155,11 +155,20 @@ function isUnsupportedOptionError(err: unknown): boolean {
   );
 }
 
+function isPluginNotInstalledError(err: unknown): boolean {
+  const sources = [
+    (err as any)?.stderr?.toString?.(),
+    (err as any)?.stdout?.toString?.(),
+    (err as any)?.message,
+    String(err),
+  ];
+  return sources.some(
+    (s) => s && (/not installed|no such plugin|plugin not found/i.test(s)),
+  );
+}
+
 export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): void {
   const baseArgs = ["plugins", "install", spec];
-  const stdioOpt: import("node:child_process").StdioOptions = quiet
-    ? ["pipe", "pipe", "pipe"]
-    : "inherit";
 
   // 3-layer degradation for old openclaw versions:
   //   1. --force --dangerously-force-unsafe-install  (newest openclaw)
@@ -176,13 +185,27 @@ export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): 
         baseArgs,
       ];
 
+  // Always pipe to capture stderr for degradation detection.
+  // stdio: "inherit" causes Node to omit stderr from the error object,
+  // making isUnsupportedOptionError() unable to detect "unknown option".
   for (let i = 0; i < attempts.length; i++) {
     try {
-      execFileSync(OPENCLAW, attempts[i], { stdio: stdioOpt });
+      const result = execFileSync(OPENCLAW, attempts[i], {
+        stdio: ["pipe", "pipe", "pipe"],
+        encoding: "utf-8",
+      });
+      if (!quiet && result) process.stdout.write(result);
       return;
     } catch (err) {
       if (isUnsupportedOptionError(err) && i < attempts.length - 1) {
         continue; // try next degradation level
+      }
+      // Final attempt failed: replay captured output, then throw
+      if (!quiet) {
+        const stdout = (err as any)?.stdout?.toString?.();
+        const stderr = (err as any)?.stderr?.toString?.();
+        if (stdout) process.stdout.write(stdout);
+        if (stderr) process.stderr.write(stderr);
       }
       throw err;
     }
@@ -190,9 +213,11 @@ export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): 
 }
 
 export function pluginsUpdate(id: string, quiet?: boolean): void {
-  execFileSync(OPENCLAW, ["plugins", "update", id], {
-    stdio: quiet ? ["pipe", "pipe", "pipe"] : "inherit",
+  const result = execFileSync(OPENCLAW, ["plugins", "update", id], {
+    stdio: ["pipe", "pipe", "pipe"],
+    encoding: "utf-8",
   });
+  if (!quiet && result) process.stdout.write(result);
 }
 
 export function pluginsUninstall(id: string, yes?: boolean): void {
@@ -624,13 +649,26 @@ export function ensurePluginsAllow(): void {
 // ---------------------------------------------------------------------------
 
 export function pluginsUpdateCompat(id: string, tag: string, quiet?: boolean): void {
-  const stdioOpt: import("node:child_process").StdioOptions = quiet
-    ? ["pipe", "pipe", "pipe"]
-    : "inherit";
   try {
-    execFileSync(OPENCLAW, ["plugins", "update", id], { stdio: stdioOpt });
-  } catch {
-    pluginsInstall(`${id}@${tag}`, quiet, true);
+    const result = execFileSync(OPENCLAW, ["plugins", "update", id], {
+      stdio: ["pipe", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    if (!quiet && result) process.stdout.write(result);
+  } catch (err) {
+    // Only fallback to install when update is unsupported or plugin not installed.
+    // Other errors (network, permissions, etc.) should propagate.
+    if (isUnsupportedOptionError(err) || isPluginNotInstalledError(err)) {
+      pluginsInstall(`${id}@${tag}`, quiet, true);
+      return;
+    }
+    if (!quiet) {
+      const stdout = (err as any)?.stdout?.toString?.();
+      const stderr = (err as any)?.stderr?.toString?.();
+      if (stdout) process.stdout.write(stdout);
+      if (stderr) process.stderr.write(stderr);
+    }
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary

- **pluginsInstall() 始终 pipe 捕获输出**：`stdio: "inherit"` 导致 Node 错误对象没有 stderr，`isUnsupportedOptionError()` 无法识别 "unknown option"，三层降级链断裂。改为始终 pipe，成功后回放 stdout，失败时回放 stdout+stderr 后抛出
- **三层参数降级**：`--force --dangerously-force-unsafe-install` → `--force` → 裸 install，兼容所有版本 openclaw（包括 2026.3.13）
- **pluginsUpdateCompat() 精准 fallback**：只在 "update 不支持" 或 "插件未安装" 时才降级到 install，网络/权限等真实错误不再被吞
- **cleanupBrokenInstall() 健康判定统一**：与 detectScenario() 使用相同定义，避免 inspectOk 临时失败时误删健康安装
- **doctor.ts hasDmworkChannel 变量修复**：补回被移除的变量定义
- **所有配置写入使用 writeConfigAtomic()**：防止 gateway 读到截断 JSON
- **deadlock repair 失败时抛错**：不再静默返回

线上验证发现的问题：OpenClaw 2026.3.13 不支持 `--force` 也不支持 `--dangerously-force-unsafe-install`，旧代码用 `stdio: "inherit"` 导致降级检测失败。

## Test plan

- [x] `npx tsc --noEmit` 编译通过
- [x] `npm test` 543 个测试全部通过（新增 10 个降级测试）
- [x] 三层降级测试：不支持 `--dangerously-force-unsafe-install` 也不支持 `--force` → 裸 install 成功
- [x] pluginsUpdateCompat 网络错误 → 不 fallback，直接抛出
- [x] pluginsUpdateCompat "not installed" → fallback 到 install
- [ ] OpenClaw 2026.3.13 线上验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)