### PR TITLE
fix: resolvePluginState 兼容老版本 OpenClaw 无 plugins inspect

### DIFF
--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -160,21 +160,30 @@ export async function runDoctorChecks(params: {
   // =========================================================================
   const reader = params.reader ?? cliConfigReader;
 
-  // 1. Plugin installed (using unified resolvePluginState for inspect + fallback)
+  // 1. Plugin installed
+  //    Uses resolvePluginState (inspect + fallback) but cross-checks with
+  //    detectScenario() when fallback says not-installed, to avoid hiding
+  //    broken/partial states behind "not installed".
   let pluginState: import("./openclaw-cli.js").PluginResolvedState | null = null;
   if (!params.inProcess) {
     pluginState = resolvePluginState(PLUGIN_ID);
+
     if (pluginState.installed) {
+      // Healthy via inspect or fallback (all 3 artifacts present)
       const versionLabel = pluginState.version ? `v${pluginState.version}` : "version unknown";
-      const sourceNote = pluginState.source === "fallback"
-        ? " (fallback; plugins inspect unsupported on this OpenClaw version)"
-        : "";
+      let sourceNote = "";
+      if (pluginState.source === "fallback" && pluginState.inspectFailReason === "unsupported") {
+        sourceNote = " (fallback; plugins inspect unsupported on this OpenClaw version)";
+      } else if (pluginState.source === "fallback") {
+        sourceNote = " (fallback; plugins inspect failed)";
+      }
       checks.push({
         name: "Plugin installed",
         status: "PASS",
         detail: `${versionLabel}${sourceNote}`,
       });
     } else if (fix) {
+      // Not installed (or broken/partial). Use detectScenario() for precise fix.
       try {
         const scenario = detectScenario();
         if (scenario === "legacy") {

--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -25,6 +25,7 @@ import {
   removeChannelConfigFromFile,
   removeOrphanedBindingsFromFile,
   readConfigFromFile,
+  resolvePluginState,
 } from "./openclaw-cli.js";
 import { PLUGIN_ID, RECOMMENDED_DM_SCOPE } from "./utils.js";
 
@@ -159,72 +160,56 @@ export async function runDoctorChecks(params: {
   // =========================================================================
   const reader = params.reader ?? cliConfigReader;
 
-  // 1. Plugin installed (with fallback for inspect failures)
+  // 1. Plugin installed (using unified resolvePluginState for inspect + fallback)
+  let pluginState: import("./openclaw-cli.js").PluginResolvedState | null = null;
   if (!params.inProcess) {
-    const inspect = pluginsInspect(PLUGIN_ID);
-    if (inspect?.plugin) {
+    pluginState = resolvePluginState(PLUGIN_ID);
+    if (pluginState.installed) {
+      const versionLabel = pluginState.version ? `v${pluginState.version}` : "version unknown";
+      const sourceNote = pluginState.source === "fallback"
+        ? " (fallback; plugins inspect unsupported on this OpenClaw version)"
+        : "";
       checks.push({
         name: "Plugin installed",
         status: "PASS",
-        detail: `v${inspect.plugin.version}`,
+        detail: `${versionLabel}${sourceNote}`,
       });
-    } else {
-      // Fallback: inspect failed, check if plugin directory exists on disk
-      const extensionsDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
-      const pluginDir = resolve(extensionsDir, "openclaw-channel-dmwork");
-      let fallbackVersion: string | null = null;
-      if (existsSync(pluginDir)) {
-        try {
-          const pkg = JSON.parse(readFileSync(resolve(pluginDir, "package.json"), "utf-8"));
-          fallbackVersion = pkg.version ?? null;
-        } catch { /* no package.json */ }
-      }
-
-      if (fallbackVersion) {
-        // Plugin exists on disk but inspect can't see it
+    } else if (fix) {
+      try {
+        const scenario = detectScenario();
+        if (scenario === "legacy") {
+          const { runLegacyMigrationForUpdate } = await import("./install.js");
+          runLegacyMigrationForUpdate(PLUGIN_ID, true);
+        } else if (scenario === "deadlock") {
+          const { runDeadlockRepairForUpdate } = await import("./install.js");
+          runDeadlockRepairForUpdate(PLUGIN_ID, true);
+        } else if (scenario === "broken") {
+          cleanupBrokenInstall();
+          pluginsInstall(PLUGIN_ID, true);
+        } else {
+          pluginsInstall(PLUGIN_ID, true);
+        }
+        pluginState = resolvePluginState(PLUGIN_ID);
         checks.push({
           name: "Plugin installed",
-          status: "WARN",
-          detail: `v${fallbackVersion} (directory exists but openclaw inspect failed — try: openclaw gateway restart)`,
+          status: "FIXED",
+          detail: `Installed v${pluginState.version ?? "unknown"}`,
         });
-      } else if (fix) {
-        try {
-          // Use scenario-aware install (handles legacy, deadlock, broken)
-          const scenario = detectScenario();
-          if (scenario === "legacy") {
-            const { runLegacyMigrationForUpdate } = await import("./install.js");
-            runLegacyMigrationForUpdate(PLUGIN_ID, true);
-          } else if (scenario === "deadlock") {
-            const { runDeadlockRepairForUpdate } = await import("./install.js");
-            runDeadlockRepairForUpdate(PLUGIN_ID, true);
-          } else if (scenario === "broken") {
-            cleanupBrokenInstall();
-            pluginsInstall(PLUGIN_ID, true);
-          } else {
-            pluginsInstall(PLUGIN_ID, true);
-          }
-          const after = pluginsInspect(PLUGIN_ID);
-          checks.push({
-            name: "Plugin installed",
-            status: "FIXED",
-            detail: `Installed v${after?.plugin?.version ?? "unknown"}`,
-          });
-        } catch {
-          checks.push({
-            name: "Plugin installed",
-            status: "FAIL",
-            detail: "Not installed (auto-install failed)",
-          });
-          return summarize(checks);
-        }
-      } else {
+      } catch {
         checks.push({
           name: "Plugin installed",
           status: "FAIL",
-          detail: "Not installed",
+          detail: "Not installed (auto-install failed)",
         });
         return summarize(checks);
       }
+    } else {
+      checks.push({
+        name: "Plugin installed",
+        status: "FAIL",
+        detail: "Not installed",
+      });
+      return summarize(checks);
     }
   }
 
@@ -247,18 +232,18 @@ export async function runDoctorChecks(params: {
     }
   }
 
-  // 3. node_modules check
+  // 3. node_modules check (uses installPath from resolvePluginState)
   if (!params.inProcess) {
-    const inspect = pluginsInspect(PLUGIN_ID);
-    const installPath = inspect?.install?.installPath;
+    const installPath = pluginState?.installPath;
     if (installPath) {
-      const nmPath = installPath.replace(/^~/, process.env.HOME ?? "") + "/node_modules";
+      const resolvedPath = installPath.replace(/^~/, process.env.HOME ?? "");
+      const nmPath = resolvedPath + "/node_modules";
       if (existsSync(nmPath)) {
         checks.push({ name: "Dependencies", status: "PASS", detail: "node_modules exists" });
       } else if (fix) {
         try {
           execFileSync("npm", ["install", "--production", "--ignore-scripts"], {
-            cwd: installPath.replace(/^~/, process.env.HOME ?? ""),
+            cwd: resolvedPath,
             stdio: ["pipe", "pipe", "pipe"],
           });
           checks.push({ name: "Dependencies", status: "FIXED", detail: "npm install completed" });

--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -36,8 +36,10 @@ program
     let installedVersion = "not installed";
     if (state.installed && state.version) {
       installedVersion = state.version;
-      if (state.source === "fallback") {
+      if (state.source === "fallback" && state.inspectFailReason === "unsupported") {
         installedVersion += " (fallback; plugins inspect unsupported on this OpenClaw version)";
+      } else if (state.source === "fallback") {
+        installedVersion += " (fallback; plugins inspect failed)";
       }
     } else if (state.installed) {
       installedVersion = "installed (version unknown)";

--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -13,7 +13,7 @@ import {
 import { runUninstall } from "./uninstall.js";
 import { runRemoveAccount } from "./remove-account.js";
 import { ensureOpenClawCompat, PLUGIN_ID } from "./utils.js";
-import { getOpenClawVersion, pluginsInspect } from "./openclaw-cli.js";
+import { getOpenClawVersion, resolvePluginState } from "./openclaw-cli.js";
 import { createRequire } from "node:module";
 
 const program = new Command();
@@ -32,14 +32,20 @@ program
   .description("Show CLI and plugin version info")
   .action(() => {
     const openclawVersion = getOpenClawVersion() ?? "not found";
-    const inspect = pluginsInspect(PLUGIN_ID);
-    const installedVersion = inspect?.plugin?.version ?? "not installed";
+    const state = resolvePluginState(PLUGIN_ID);
+    let installedVersion = "not installed";
+    if (state.installed && state.version) {
+      installedVersion = state.version;
+      if (state.source === "fallback") {
+        installedVersion += " (fallback; plugins inspect unsupported on this OpenClaw version)";
+      }
+    } else if (state.installed) {
+      installedVersion = "installed (version unknown)";
+    }
 
-    // ANSI: \x1b[1m = bold, \x1b[32m = green, \x1b[4m = underline, \x1b[0m = reset
-    const b = "\x1b[1m";   // bold
-    const g = "\x1b[32m";  // green
-    const u = "\x1b[4m";   // underline
-    const r = "\x1b[0m";   // reset
+    const b = "\x1b[1m";
+    const g = "\x1b[32m";
+    const r = "\x1b[0m";
 
     console.log(`${b}openclaw-channel-dmwork-cli:${r} ${g}${_pkg.version}${r}`);
     console.log(`${b}openclaw:${r} ${g}${openclawVersion}${r}`);

--- a/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
@@ -8,7 +8,14 @@ vi.mock("node:child_process", () => ({
 }));
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
-  return { ...actual, existsSync: vi.fn(() => false) };
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => "{}"),
+    writeFileSync: vi.fn(),
+    copyFileSync: vi.fn(),
+    renameSync: vi.fn(),
+  };
 });
 
 const mockExecFileSync = vi.mocked(execFileSync);
@@ -337,5 +344,113 @@ describe("pluginsUpdateCompat", () => {
     });
     expect(() => pluginsUpdateCompat("test-plugin", "latest", true)).toThrow("EACCES");
     expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePluginState (inspect + fallback)
+// ---------------------------------------------------------------------------
+
+describe("resolvePluginState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return inspect data when plugins inspect succeeds", async () => {
+    const { resolvePluginState } = await loadModule();
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
+        return JSON.stringify({
+          plugin: { id: "openclaw-channel-dmwork", version: "0.5.21", enabled: true },
+          install: { source: "npm", version: "0.5.21", installPath: "~/.openclaw/extensions/openclaw-channel-dmwork" },
+        });
+      }
+      return "";
+    });
+    const state = resolvePluginState("openclaw-channel-dmwork");
+    expect(state.installed).toBe(true);
+    expect(state.version).toBe("0.5.21");
+    expect(state.source).toBe("inspect");
+    expect(state.enabled).toBe(true);
+  });
+
+  it("should fallback to config+dir when inspect fails (old OpenClaw)", async () => {
+    const { resolvePluginState } = await loadModule();
+    const { existsSync, readFileSync } = await import("node:fs");
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (argsArr[0] === "plugins" && argsArr[1] === "inspect") {
+        throw new Error("error: unknown command 'inspect'");
+      }
+      return "";
+    });
+    // readConfigFromFile reads the config file
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      plugins: {
+        entries: { "openclaw-channel-dmwork": { enabled: true } },
+        installs: { "openclaw-channel-dmwork": { version: "0.5.21", installPath: "~/.openclaw/extensions/openclaw-channel-dmwork" } },
+      },
+    }));
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const state = resolvePluginState("openclaw-channel-dmwork");
+    expect(state.installed).toBe(true);
+    expect(state.version).toBe("0.5.21");
+    expect(state.source).toBe("fallback");
+    expect(state.enabled).toBe(true);
+    expect(state.installPath).toBe("~/.openclaw/extensions/openclaw-channel-dmwork");
+  });
+
+  it("should read version from package.json when installs record has no version", async () => {
+    const { resolvePluginState } = await loadModule();
+    const { existsSync, readFileSync } = await import("node:fs");
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (argsArr[0] === "plugins") throw new Error("unknown command");
+      return "";
+    });
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path.endsWith("openclaw.json")) {
+        return JSON.stringify({
+          plugins: {
+            entries: { "openclaw-channel-dmwork": { enabled: true } },
+            installs: { "openclaw-channel-dmwork": { installPath: "~/.openclaw/extensions/openclaw-channel-dmwork" } },
+          },
+        });
+      }
+      if (path.endsWith("package.json")) {
+        return JSON.stringify({ version: "0.5.20" });
+      }
+      return "{}";
+    });
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const state = resolvePluginState("openclaw-channel-dmwork");
+    expect(state.installed).toBe(true);
+    expect(state.version).toBe("0.5.20");
+    expect(state.source).toBe("fallback");
+  });
+
+  it("should return not installed when nothing exists", async () => {
+    const { resolvePluginState } = await loadModule();
+    const { existsSync, readFileSync } = await import("node:fs");
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === "config" && argsArr[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (argsArr[0] === "plugins") throw new Error("unknown command");
+      return "";
+    });
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({}));
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const state = resolvePluginState("openclaw-channel-dmwork");
+    expect(state.installed).toBe(false);
+    expect(state.version).toBeNull();
+    expect(state.source).toBe("fallback");
   });
 });

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -239,19 +239,53 @@ export interface PluginInspectResult {
   };
 }
 
-export function pluginsInspect(id: string): PluginInspectResult | null {
+export type InspectFailReason = "unsupported" | "not_found" | "error";
+
+export interface PluginsInspectOutcome {
+  ok: boolean;
+  data: PluginInspectResult | null;
+  failReason: InspectFailReason | null;
+}
+
+/**
+ * Inspect a plugin. Returns structured outcome distinguishing:
+ * - ok + data: inspect succeeded
+ * - unsupported: old OpenClaw without `plugins inspect`
+ * - not_found: plugin genuinely not found
+ * - error: other failure (config corruption, plugin load crash, etc.)
+ */
+export function pluginsInspectDetailed(id: string): PluginsInspectOutcome {
   try {
     const out = execFileSync(OPENCLAW, ["plugins", "inspect", id, "--json"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
-    // stdout may contain plugin log noise before JSON — find the JSON object
     const jsonStart = out.indexOf("{");
-    if (jsonStart < 0) return null;
-    return JSON.parse(out.slice(jsonStart));
-  } catch {
-    return null;
+    if (jsonStart < 0) return { ok: false, data: null, failReason: "error" };
+    const data = JSON.parse(out.slice(jsonStart));
+    return { ok: true, data, failReason: null };
+  } catch (err) {
+    const sources = [
+      (err as any)?.stderr?.toString?.(),
+      (err as any)?.stdout?.toString?.(),
+      (err as any)?.message,
+      String(err),
+    ];
+    const text = sources.filter(Boolean).join(" ");
+    if (/unknown command|unrecognized command/i.test(text)) {
+      return { ok: false, data: null, failReason: "unsupported" };
+    }
+    if (/not found|not installed|no such plugin/i.test(text)) {
+      return { ok: false, data: null, failReason: "not_found" };
+    }
+    return { ok: false, data: null, failReason: "error" };
   }
+}
+
+/** Backward-compatible wrapper: returns data or null. */
+export function pluginsInspect(id: string): PluginInspectResult | null {
+  const outcome = pluginsInspectDetailed(id);
+  return outcome.ok ? outcome.data : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -264,23 +298,30 @@ export interface PluginResolvedState {
   version: string | null;
   installPath: string | null;
   source: "inspect" | "fallback";
+  /** Why inspect failed. null when source === "inspect". */
+  inspectFailReason: InspectFailReason | null;
 }
 
 /**
  * Resolve plugin install state. Uses `plugins inspect` when available,
  * falls back to config entries + directory + package.json for old OpenClaw
  * versions that don't support `plugins inspect`.
+ *
+ * Fallback installed = all 3 artifacts present (entries + installs + dir),
+ * matching detectScenario()'s healthy definition. Partial presence is NOT
+ * considered installed — that's a broken state for doctor --fix to handle.
  */
 export function resolvePluginState(id: string): PluginResolvedState {
   // Try inspect first
-  const inspect = pluginsInspect(id);
-  if (inspect?.plugin) {
+  const outcome = pluginsInspectDetailed(id);
+  if (outcome.ok && outcome.data?.plugin) {
     return {
       installed: true,
-      enabled: inspect.plugin.enabled,
-      version: inspect.plugin.version,
-      installPath: inspect.install?.installPath ?? null,
+      enabled: outcome.data.plugin.enabled,
+      version: outcome.data.plugin.version,
+      installPath: outcome.data.install?.installPath ?? null,
       source: "inspect",
+      inspectFailReason: null,
     };
   }
 
@@ -294,10 +335,16 @@ export function resolvePluginState(id: string): PluginResolvedState {
   const installs = cfg?.plugins?.installs?.[id];
   const hasEntry = Boolean(entries);
   const hasInstall = Boolean(installs);
-  const installed = hasEntry || hasInstall || hasDir;
+
+  // Healthy install requires all 3 artifacts, same as detectScenario().
+  // Partial presence (e.g. dir exists but no entries/installs) is broken, not installed.
+  const installed = hasDir && hasEntry && hasInstall;
 
   if (!installed) {
-    return { installed: false, enabled: null, version: null, installPath: null, source: "fallback" };
+    return {
+      installed: false, enabled: null, version: null, installPath: null,
+      source: "fallback", inspectFailReason: outcome.failReason,
+    };
   }
 
   // Resolve version: installs record > package.json on disk
@@ -312,7 +359,7 @@ export function resolvePluginState(id: string): PluginResolvedState {
   const enabled = entries?.enabled ?? null;
   const installPath = installs?.installPath ?? (hasDir ? `~/.openclaw/extensions/${id}` : null);
 
-  return { installed, enabled, version, installPath, source: "fallback" };
+  return { installed, enabled, version, installPath, source: "fallback", inspectFailReason: outcome.failReason };
 }
 
 // ---------------------------------------------------------------------------

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -255,6 +255,67 @@ export function pluginsInspect(id: string): PluginInspectResult | null {
 }
 
 // ---------------------------------------------------------------------------
+// Unified plugin state detection (inspect + fallback)
+// ---------------------------------------------------------------------------
+
+export interface PluginResolvedState {
+  installed: boolean;
+  enabled: boolean | null;
+  version: string | null;
+  installPath: string | null;
+  source: "inspect" | "fallback";
+}
+
+/**
+ * Resolve plugin install state. Uses `plugins inspect` when available,
+ * falls back to config entries + directory + package.json for old OpenClaw
+ * versions that don't support `plugins inspect`.
+ */
+export function resolvePluginState(id: string): PluginResolvedState {
+  // Try inspect first
+  const inspect = pluginsInspect(id);
+  if (inspect?.plugin) {
+    return {
+      installed: true,
+      enabled: inspect.plugin.enabled,
+      version: inspect.plugin.version,
+      installPath: inspect.install?.installPath ?? null,
+      source: "inspect",
+    };
+  }
+
+  // Fallback: check config + filesystem
+  const cfg = readConfigFromFile();
+  const extDir = getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions");
+  const pluginDir = resolve(extDir, id);
+
+  const hasDir = existsSync(pluginDir);
+  const entries = cfg?.plugins?.entries?.[id];
+  const installs = cfg?.plugins?.installs?.[id];
+  const hasEntry = Boolean(entries);
+  const hasInstall = Boolean(installs);
+  const installed = hasEntry || hasInstall || hasDir;
+
+  if (!installed) {
+    return { installed: false, enabled: null, version: null, installPath: null, source: "fallback" };
+  }
+
+  // Resolve version: installs record > package.json on disk
+  let version: string | null = installs?.version ?? null;
+  if (!version && hasDir) {
+    try {
+      const pkg = JSON.parse(readFileSync(resolve(pluginDir, "package.json"), "utf-8"));
+      version = pkg.version ?? null;
+    } catch { /* no package.json */ }
+  }
+
+  const enabled = entries?.enabled ?? null;
+  const installPath = installs?.installPath ?? (hasDir ? `~/.openclaw/extensions/${id}` : null);
+
+  return { installed, enabled, version, installPath, source: "fallback" };
+}
+
+// ---------------------------------------------------------------------------
 // Gateway helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- 老版本 OpenClaw（如 2026.3.13）不支持 `plugins inspect` 命令，导致 `info` 显示 "not installed"、`doctor` 报 FAIL，即使插件实际已安装可用
- 新增 `resolvePluginState()` 统一检测函数：优先用 inspect，fallback 到 config entries + installs + 目录 package.json
- `info` 命令改用 `resolvePluginState()`，不再误报 "not installed"
- `doctor` Plugin installed 检查：fallback installed → PASS 而非 WARN
- `doctor` 依赖检查用 `pluginState.installPath` 而非再次调 inspect

## Test plan

- [x] `npx tsc --noEmit` 编译通过
- [x] `npm test` 547 个测试全部通过（新增 4 个 resolvePluginState 测试）
- [x] inspect 成功 → source: "inspect"，直接显示版本
- [x] inspect 失败（老版本）→ source: "fallback"，从 config + 目录获取版本
- [x] 完全未安装 → installed: false
- [ ] OpenClaw 2026.3.13 线上验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)