### PR TITLE
fix: doctor 兼容老版本 OpenClaw stdout 噪音误判

### DIFF
--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -76,12 +76,35 @@ export function getConfigFilePath(): string {
   return pathLine ?? out.trim();
 }
 
+/**
+ * Strip OpenClaw stdout noise (banner, plugin log lines, timestamps).
+ * Old OpenClaw versions mix these into stdout alongside the actual value.
+ */
+function stripStdoutNoise(raw: string): string {
+  return raw
+    .split("\n")
+    .filter((line) => {
+      const t = line.trim();
+      if (!t) return false;
+      // Banner: 🦞 OpenClaw ...
+      if (/^[\u{1F980}\u{1F600}-\u{1FAFF}]/u.test(t)) return false;
+      // Plugin log: [plugins] ..., [dmwork] ...
+      if (/^\[[\w-]+\]/.test(t)) return false;
+      // Timestamped log: 17:37:26 [plugins] ...
+      if (/^\d{1,2}:\d{2}(:\d{2})?\s*\[/.test(t)) return false;
+      return true;
+    })
+    .join("\n")
+    .trim();
+}
+
 export function configGet(path: string): string | null {
   try {
-    const val = execFileSync(OPENCLAW, ["config", "get", path], {
+    const raw = execFileSync(OPENCLAW, ["config", "get", path], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
+    });
+    const val = stripStdoutNoise(raw);
     return val === "" ? null : val;
   } catch {
     return null;
@@ -100,7 +123,17 @@ export function configGetJson(path: string): any {
       ? Math.min(jsonStart, arrStart)
       : Math.max(jsonStart, arrStart);
     if (start < 0) return null;
-    return JSON.parse(out.slice(start));
+    // Find matching end bracket to avoid trailing log noise breaking JSON.parse
+    const openChar = out[start];
+    const closeChar = openChar === "{" ? "}" : "]";
+    let depth = 0;
+    let end = -1;
+    for (let i = start; i < out.length; i++) {
+      if (out[i] === openChar) depth++;
+      else if (out[i] === closeChar) { depth--; if (depth === 0) { end = i; break; } }
+    }
+    if (end < 0) return null;
+    return JSON.parse(out.slice(start, end + 1));
   } catch {
     return null;
   }
@@ -374,11 +407,20 @@ export function gatewayStatus(): { running: boolean } {
     });
     const jsonStart = out.indexOf("{");
     if (jsonStart < 0) return { running: false };
-    const data = JSON.parse(out.slice(jsonStart));
-    // Real structure: { service.runtime.status: "running", health.healthy: true }
+    // Find matching } to avoid trailing log noise
+    let depth = 0;
+    let end = -1;
+    for (let i = jsonStart; i < out.length; i++) {
+      if (out[i] === "{") depth++;
+      else if (out[i] === "}") { depth--; if (depth === 0) { end = i; break; } }
+    }
+    if (end < 0) return { running: false };
+    const data = JSON.parse(out.slice(jsonStart, end + 1));
     const runtimeRunning = data.service?.runtime?.status === "running";
     const healthy = data.health?.healthy === true;
-    return { running: runtimeRunning || healthy };
+    // Fallback: port is busy with an openclaw-gateway process = gateway is running
+    const portBusy = data.port?.status === "busy";
+    return { running: runtimeRunning || healthy || portBusy };
   } catch {
     return { running: false };
   }


### PR DESCRIPTION
## Summary

OpenClaw 2026.3.13 把插件日志（`[plugins]`、`[dmwork]`）和横幅（`🦞 OpenClaw ...`）混入 stdout，导致 doctor 误判：

- **Plugin enabled: FAIL** — `configGet` 拿到 `"🦞...\ntrue\n[plugins]..."` 而非 `"true"`
- **Accounts configured: FAIL** — `configGetJson` 的 `JSON.parse` 因尾部日志噪音抛异常
- **Gateway running: FAIL** — `runtime.status` 为 `"unknown"`（systemctl 不可用），但端口实际在跑

修复：
1. `configGet`: 新增 `stripStdoutNoise()` 过滤横幅/日志行
2. `configGetJson`: 用括号深度匹配找 JSON 边界，不再 `slice` 到末尾
3. `gatewayStatus`: 同样括号匹配解析 JSON；增加 `port.status === "busy"` 判定

高版本 OpenClaw 输出干净，改动无感。

## Test plan

- [x] `npx tsc --noEmit` 通过
- [x] `npm test` 547 全绿
- [ ] OpenClaw 2026.3.13 线上验证 `npx doctor` 全 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)