### PR TITLE
fix: install 已是最新时不重启 gateway，优化文案

### DIFF
--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -83,11 +83,12 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       }
 
       if (currentVersion === latestVersion && !opts.force) {
-        console.log(`DMWork plugin is already up to date (v${currentVersion}).`);
+        console.log(`DMWork plugin v${currentVersion} is already the latest version. No update needed.`);
+        return; // Skip gateway restart — nothing changed
       } else {
         console.log(`Updating DMWork plugin: v${currentVersion} → v${latestVersion}${opts.dev ? " (dev)" : ""}...`);
         pluginsUpdateCompat(PLUGIN_ID, tag, quiet);
-        console.log("Plugin updated successfully.");
+        console.log(`DMWork plugin updated from v${currentVersion} to v${latestVersion}.`);
       }
       break;
     }


### PR DESCRIPTION
- 已是最新版时：`DMWork plugin v0.6.0 is already the latest version. No update needed.` + return early 不重启
- 更新完成时：`DMWork plugin updated from v0.5.x to v0.6.0.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)