### PR TITLE
fix: install 命令逻辑重构 — 支持 @dev tag / 精准重启 / --force 语义

### DIFF
--- a/openclaw-channel-dmwork/cli/install.test.ts
+++ b/openclaw-channel-dmwork/cli/install.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execFileSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+  execSync: vi.fn(() => ""),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => "{}"),
+    writeFileSync: vi.fn(),
+    copyFileSync: vi.fn(),
+    renameSync: vi.fn(),
+  };
+});
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+// Helpers to mock module internals via execFileSync dispatch
+function mockOpenClawVersion(version: string) {
+  // openclaw --version returns version string
+  return version;
+}
+
+async function loadInstall() {
+  vi.resetModules();
+  return await import("./install.js");
+}
+
+// We test by observing which commands are executed via execFileSync
+function getCalledArgs(): string[][] {
+  return mockExecFileSync.mock.calls.map((c) => c[1] as string[]);
+}
+
+function didCallPluginsInstall(calls: string[][]): boolean {
+  return calls.some((args) => args[0] === "plugins" && args[1] === "install");
+}
+
+function didCallGatewayRestart(calls: string[][]): boolean {
+  return calls.some((args) => args[0] === "gateway" && args[1] === "restart");
+}
+
+function pluginsInstallSpec(calls: string[][]): string | undefined {
+  const call = calls.find((args) => args[0] === "plugins" && args[1] === "install");
+  return call?.[2];
+}
+
+describe("runInstall — update scenario", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("already target version: no install, no restart", async () => {
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      // openclaw config file
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      // openclaw --version
+      if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
+      // plugins inspect
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        return JSON.stringify({ plugin: { id: "openclaw-channel-dmwork", version: "0.6.0", enabled: true } });
+      }
+      // npm view (targetVersion)
+      if (a[0] === "view") return "0.6.0\n";
+      return "";
+    });
+
+    await runInstall({ force: false, dev: false });
+
+    const calls = getCalledArgs();
+    expect(didCallPluginsInstall(calls)).toBe(false);
+    expect(didCallGatewayRestart(calls)).toBe(false);
+  });
+
+  it("--force: installs without checking version, then restarts", async () => {
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        return JSON.stringify({ plugin: { id: "openclaw-channel-dmwork", version: "0.6.0", enabled: true } });
+      }
+      // npm view should NOT be called for --force
+      if (a[0] === "view") throw new Error("npm view should not be called with --force");
+      // gateway restart
+      if (a[0] === "gateway" && a[1] === "restart") return "";
+      // plugins install
+      if (a[0] === "plugins" && a[1] === "install") return "";
+      return "";
+    });
+
+    await runInstall({ force: true, dev: false });
+
+    const calls = getCalledArgs();
+    expect(didCallPluginsInstall(calls)).toBe(true);
+    expect(pluginsInstallSpec(calls)).toBe("openclaw-channel-dmwork");
+    expect(didCallGatewayRestart(calls)).toBe(true);
+  });
+
+  it("npm view fails: no install, no restart", async () => {
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        return JSON.stringify({ plugin: { id: "openclaw-channel-dmwork", version: "0.6.0", enabled: true } });
+      }
+      if (a[0] === "view") throw new Error("ENOTFOUND registry.npmjs.org");
+      return "";
+    });
+
+    await runInstall({ force: false, dev: false });
+
+    const calls = getCalledArgs();
+    expect(didCallPluginsInstall(calls)).toBe(false);
+    expect(didCallGatewayRestart(calls)).toBe(false);
+  });
+
+  it("--dev: uses openclaw-channel-dmwork@dev spec", async () => {
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        return JSON.stringify({ plugin: { id: "openclaw-channel-dmwork", version: "0.6.0", enabled: true } });
+      }
+      // npm view openclaw-channel-dmwork@dev
+      if (a[0] === "view" && a[1]?.includes("@dev")) return "0.6.0-dev.abc123\n";
+      if (a[0] === "plugins" && a[1] === "install") return "";
+      if (a[0] === "gateway" && a[1] === "restart") return "";
+      return "";
+    });
+
+    await runInstall({ force: false, dev: true });
+
+    const calls = getCalledArgs();
+    expect(didCallPluginsInstall(calls)).toBe(true);
+    expect(pluginsInstallSpec(calls)).toBe("openclaw-channel-dmwork@dev");
+    expect(didCallGatewayRestart(calls)).toBe(true);
+  });
+
+  it("new version available: installs and restarts", async () => {
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        return JSON.stringify({ plugin: { id: "openclaw-channel-dmwork", version: "0.5.21", enabled: true } });
+      }
+      if (a[0] === "view") return "0.6.0\n";
+      if (a[0] === "plugins" && a[1] === "install") return "";
+      if (a[0] === "gateway" && a[1] === "restart") return "";
+      return "";
+    });
+
+    await runInstall({ force: false, dev: false });
+
+    const calls = getCalledArgs();
+    expect(didCallPluginsInstall(calls)).toBe(true);
+    expect(pluginsInstallSpec(calls)).toBe("openclaw-channel-dmwork");
+    expect(didCallGatewayRestart(calls)).toBe(true);
+  });
+});

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -83,11 +83,12 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       }
 
       if (currentVersion === latestVersion && !opts.force) {
-        console.log(`DMWork plugin is already up to date (v${currentVersion}).`);
+        console.log(`DMWork plugin v${currentVersion} is already the latest version. No update needed.`);
+        return; // Skip gateway restart — nothing changed
       } else {
         console.log(`Updating DMWork plugin: v${currentVersion} → v${latestVersion}${opts.dev ? " (dev)" : ""}...`);
         pluginsUpdateCompat(PLUGIN_ID, tag, quiet);
-        console.log("Plugin updated successfully.");
+        console.log(`DMWork plugin updated from v${currentVersion} to v${latestVersion}.`);
       }
       break;
     }

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -65,31 +65,35 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
   const tag = opts.dev ? "dev" : "latest";
   const spec = opts.dev ? `${PLUGIN_ID}@dev` : PLUGIN_ID;
   const quiet = false;
+  let didChange = false;
 
   switch (scenario) {
     case "legacy":
       runLegacyMigration(spec, quiet, opts.force);
+      didChange = true;
       break;
     case "update": {
-      // Already installed — check for updates
+      // Already installed — compare against target version
       const inspect = pluginsInspect(PLUGIN_ID);
       const currentVersion = inspect?.plugin?.version ?? "unknown";
-      const latestVersion = getLatestNpmVersion(tag);
+      const targetVersion = getLatestNpmVersion(tag);
 
-      if (!latestVersion) {
+      if (!targetVersion) {
+        // Cannot determine target — skip install and restart
         console.log(`Cannot reach npm registry to check ${tag} version.`);
         console.log(`Current version: v${currentVersion}`);
-        break;
+        return;
       }
 
-      if (currentVersion === latestVersion && !opts.force) {
-        console.log(`DMWork plugin v${currentVersion} is already the latest version. No update needed.`);
-        return; // Skip gateway restart — nothing changed
-      } else {
-        console.log(`Updating DMWork plugin: v${currentVersion} → v${latestVersion}${opts.dev ? " (dev)" : ""}...`);
-        pluginsUpdateCompat(PLUGIN_ID, tag, quiet);
-        console.log(`DMWork plugin updated from v${currentVersion} to v${latestVersion}.`);
+      if (currentVersion === targetVersion && !opts.force) {
+        console.log(`DMWork plugin v${currentVersion} is already the target version${opts.dev ? " (dev)" : ""}. No update needed.`);
+        return; // Nothing changed — skip gateway restart
       }
+
+      console.log(`Updating DMWork plugin: v${currentVersion} → v${targetVersion}${opts.dev ? " (dev)" : ""}...`);
+      pluginsInstall(spec, quiet, true); // Always use spec with tag so @dev is respected
+      console.log(`DMWork plugin updated from v${currentVersion} to v${targetVersion}${opts.dev ? " (dev)" : ""}.`);
+      didChange = true;
       break;
     }
     case "broken": {
@@ -99,17 +103,22 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       console.log(`Installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
       pluginsInstall(spec, quiet, opts.force);
       console.log("Plugin installed successfully.");
+      didChange = true;
       break;
     }
     case "deadlock":
       runDeadlockRepair(spec, quiet);
+      didChange = true;
       break;
     case "fresh":
       console.log(`Installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
       pluginsInstall(spec, quiet, opts.force);
       console.log("Plugin installed successfully.");
+      didChange = true;
       break;
   }
+
+  if (!didChange) return;
 
   // Gateway restart (plugin lifecycle requires restart)
   console.log("Restarting gateway...");

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -23,7 +23,6 @@ import {
   isHealthyInstall,
   pluginsInspect,
   pluginsInstall,
-  pluginsUpdateCompat,
   readConfigFromFile,
   removeLegacyFromConfig,
   renameLegacyDir,
@@ -76,6 +75,16 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       // Already installed — compare against target version
       const inspect = pluginsInspect(PLUGIN_ID);
       const currentVersion = inspect?.plugin?.version ?? "unknown";
+
+      if (opts.force) {
+        // --force: skip version check, always install target spec
+        console.log(`Force installing DMWork plugin${opts.dev ? " (dev)" : ""}...`);
+        pluginsInstall(spec, quiet, true);
+        console.log("Plugin installed successfully.");
+        didChange = true;
+        break;
+      }
+
       const targetVersion = getLatestNpmVersion(tag);
 
       if (!targetVersion) {
@@ -85,7 +94,7 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
         return;
       }
 
-      if (currentVersion === targetVersion && !opts.force) {
+      if (currentVersion === targetVersion) {
         console.log(`DMWork plugin v${currentVersion} is already the target version${opts.dev ? " (dev)" : ""}. No update needed.`);
         return; // Nothing changed — skip gateway restart
       }


### PR DESCRIPTION
## Summary

- **已是目标版本时不重启**：`install` 检测到当前版本等于目标版本时直接返回，跳过 gateway restart
- **`--dev` 正确装 dev 版**：update 分支改用 `pluginsInstall(spec, ..., true)`（spec 含 `@dev`），不再走 `pluginsUpdateCompat`（底层 `plugins update` 不支持 tag）
- **`--force` 跳过版本查询**：registry 不可达时 `--force` 仍然有效，直接执行安装
- **`npm view` 失败时不重启**：无法确定目标版本时直接返回
- **`didChange` 控制重启时机**：只有真正发生安装/更新时才重启 gateway
- 删掉未使用的 `pluginsUpdateCompat` import

## 文案

- 已是最新：`DMWork plugin v0.6.0 is already the target version. No update needed.`
- 更新完成：`DMWork plugin updated from v0.5.x to v0.6.0.`

## Test plan

- [x] `npm test` 552 个测试全部通过（新增 5 条 install 单测）
- [x] `npx tsc --noEmit` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)