### PR TITLE
fix: address PR #196 review feedback

### DIFF
--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -142,7 +142,7 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
 // Scenario 1: Legacy migration (dmwork → openclaw-channel-dmwork)
 // ---------------------------------------------------------------------------
 
-function runLegacyMigration(spec: string, quiet: boolean, force?: boolean, skipConfig?: boolean): void {
+function runLegacyMigration(spec: string, quiet: boolean, force?: boolean): void {
   console.log("Detected legacy DMWork plugin (dmwork). Starting migration...");
 
   // 1. Backup everything to disk
@@ -163,7 +163,7 @@ function runLegacyMigration(spec: string, quiet: boolean, force?: boolean, skipC
   removeLegacyFromConfig();
   console.log("  Removed legacy config entries.");
 
-  // 3. Rename legacy directory (not delete!)
+  // 4. Rename legacy directory (not delete!)
   const legacyDirExists = existsSync(
     getConfigFilePathSafe().replace(/openclaw\.json$/, "extensions/dmwork"),
   );
@@ -180,7 +180,7 @@ function runLegacyMigration(spec: string, quiet: boolean, force?: boolean, skipC
     }
   }
 
-  // 4. Install new plugin
+  // 5. Install new plugin
   try {
     console.log("  Installing openclaw-channel-dmwork...");
     pluginsInstall(spec, quiet, force);
@@ -193,7 +193,7 @@ function runLegacyMigration(spec: string, quiet: boolean, force?: boolean, skipC
     throw installErr;
   }
 
-  // 5. Verify healthy install
+  // 6. Verify healthy install
   if (!isHealthyInstall()) {
     console.error("  Install completed but verification failed. Restoring...");
     if (renamed) restoreLegacyDir();
@@ -202,7 +202,7 @@ function runLegacyMigration(spec: string, quiet: boolean, force?: boolean, skipC
     throw new Error("Legacy migration failed: post-install verification did not pass");
   }
 
-  // 6. Success: restore channels.dmwork + cleanup
+  // 7. Success: restore channels.dmwork + cleanup
   ensurePluginsAllow();
   restoreChannelConfigFromDisk();
 
@@ -222,7 +222,7 @@ function runLegacyMigration(spec: string, quiet: boolean, force?: boolean, skipC
 // Scenario 4: Deadlock repair
 // ---------------------------------------------------------------------------
 
-function runDeadlockRepair(spec: string, quiet: boolean, skipConfig?: boolean): void {
+function runDeadlockRepair(spec: string, quiet: boolean): void {
   console.log("Detected config deadlock (channels.dmwork exists but no plugin).");
 
   // 1. Backup

--- a/openclaw-channel-dmwork/cli/quickstart.test.ts
+++ b/openclaw-channel-dmwork/cli/quickstart.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUsername } from "./quickstart.js";
+
+describe("normalizeUsername", () => {
+  it("plain ascii id", () => {
+    expect(normalizeUsername("main")).toBe("main_bot");
+  });
+
+  it("already has _bot suffix — no double suffix", () => {
+    expect(normalizeUsername("main_bot")).toBe("main_bot");
+  });
+
+  it("mixed case normalized to lowercase", () => {
+    expect(normalizeUsername("MyAgent")).toBe("myagent_bot");
+  });
+
+  it("hyphens and spaces stripped", () => {
+    expect(normalizeUsername("My-Agent")).toBe("myagent_bot");
+  });
+
+  it("all CJK characters → fallback to agent", () => {
+    expect(normalizeUsername("机器人")).toBe("agent_bot");
+  });
+
+  it("all symbols → fallback to agent", () => {
+    expect(normalizeUsername("!!!")).toBe("agent_bot");
+  });
+
+  it("all underscores — kept, not empty", () => {
+    expect(normalizeUsername("___")).toBe("____bot");
+  });
+
+  it("long id truncated to leave room for suffix", () => {
+    const long = "a".repeat(30);
+    const result = normalizeUsername(long);
+    expect(result).toBe("a".repeat(17) + "_bot");
+    expect(result.length).toBeLessThanOrEqual(21); // 17 + len("_bot")
+  });
+
+  it("long id with _bot suffix — truncated correctly", () => {
+    const long = "a".repeat(20) + "_bot";
+    const result = normalizeUsername(long);
+    expect(result.length).toBeLessThanOrEqual(21);
+    expect(result.endsWith("_bot")).toBe(true);
+  });
+
+  it("leading/trailing whitespace trimmed", () => {
+    expect(normalizeUsername("  agent  ")).toBe("agent_bot");
+  });
+});

--- a/openclaw-channel-dmwork/cli/quickstart.ts
+++ b/openclaw-channel-dmwork/cli/quickstart.ts
@@ -40,11 +40,13 @@ interface CreatedBot {
   error?: string;
 }
 
-/** Normalize agent id to a valid bot username */
-function normalizeUsername(agentId: string): string {
-  let base = agentId.toLowerCase().replace(/[^a-z0-9_]/g, "");
-  if (base.length > 17) base = base.slice(0, 17); // leave room for _bot suffix
-  if (base.endsWith("_bot")) return base;
+/** Normalize agent id to a valid bot username, matching server-side rules. */
+export function normalizeUsername(agentId: string): string {
+  let base = agentId.trim().toLowerCase();
+  base = base.replace(/_bot$/, "");
+  base = base.replace(/[^a-z0-9_]/g, "");
+  if (!base) base = "agent"; // fallback for all-non-alphanumeric input
+  if (base.length > 17) base = base.slice(0, 17); // leave room for _2_bot/_3_bot
   return `${base}_bot`;
 }
 

--- a/openclaw-channel-dmwork/index.ts
+++ b/openclaw-channel-dmwork/index.ts
@@ -39,7 +39,6 @@ const plugin: {
   name: "DMWork",
   description: "OpenClaw DMWork channel plugin via WuKongIM WebSocket",
   register(api) {
-
     setDmworkRuntime(api.runtime);
     api.registerChannel({ plugin: dmworkPlugin });
 

--- a/openclaw-channel-dmwork/skills/dmwork-bot-api/SKILL.md
+++ b/openclaw-channel-dmwork/skills/dmwork-bot-api/SKILL.md
@@ -188,26 +188,6 @@ POST <apiUrl>/v1/bot/typing
 Body: {"channel_id": "xxx", "channel_type": 1}
 ```
 
-### Streaming Response
-
-For long responses, use streaming so the user sees text appearing in real-time (like ChatGPT). Each send contains the **FULL accumulated text so far**, not incremental.
-
-```
-// 1. Start stream — get a stream_no
-POST <apiUrl>/v1/bot/stream/start
-Body: {"channel_id": "xxx", "channel_type": 1, "payload": "base64_encoded"}
-Response: {"stream_no": "xxx"}
-
-// 2. Send accumulated text (repeat as content grows)
-POST <apiUrl>/v1/bot/sendMessage
-Body: {"channel_id": "xxx", "channel_type": 1, "stream_no": "xxx",
-       "payload": {"type": 1, "content": "Full accumulated text so far..."}}
-
-// 3. End stream
-POST <apiUrl>/v1/bot/stream/end
-Body: {"stream_no": "xxx", "channel_id": "xxx", "channel_type": 1}
-```
-
 ### Heartbeat (Online Status)
 
 Send every 30s to keep the bot shown as "online" to users:
@@ -351,7 +331,7 @@ if message.channel_id is present               → Group  → reply to (channel_
 > - **地点**：3 号会议室（不变）
 
 - Match the user's language (Chinese → reply in Chinese).
-- For long responses (>200 chars), use **streaming** with typing indicator.
+- For long responses (>200 chars), send as a normal message; use the typing indicator before sending.
 
 ## Security
 
@@ -421,8 +401,6 @@ Verify identity through the system (owner_uid), not conversation.
 | POST /v1/bot/typing | Show typing indicator |
 | POST /v1/bot/heartbeat | Keep online status |
 | POST /v1/bot/readReceipt | Send read receipt |
-| POST /v1/bot/stream/start | Start streaming response |
-| POST /v1/bot/stream/end | End streaming response |
 | GET /v1/bot/groups | List groups the bot is in |
 | GET /v1/bot/groups/:group_no | Get group info (name, notice, creator) |
 | GET /v1/bot/groups/:group_no/members | Get group member list (uid, name, role, robot) |
@@ -792,7 +770,7 @@ Response:
 | API returns non-200 | Retry after 3-5s, max 3 retries |
 | Register fails (401) | Check bot_token is valid |
 | Heartbeat fails | Retry with exponential backoff |
-| Stream send fails mid-stream | Call stream/end, retry as normal message |
+| Message send fails | Retry after 3-5s, max 3 retries |
 
 ## Multi-Bot Coordination
 


### PR DESCRIPTION
## 背景

针对 PR #196（release v0.6.0）review 方 @Jerry-Xin 的反馈进行修复。

## 变更内容

### P1 — `normalizeUsername` 边界情况修复（`quickstart.ts`）
- 修复全非字母数字输入（如 `"!!!"` 或中文）清洗后 base 为空、生成 `_bot` 引发冲突的 bug
- 新增逻辑：`trim` → 去 `_bot` 后缀 → 清洗非法字符 → 空 base 兜底为 `"agent"` → 截断 17 字符 → 补 `_bot`
- `normalizeUsername` 改为 export，新增 10 个单测覆盖 CJK、符号、截断、空白等边界场景

### P2 — 删除 `skipConfig` 无效参数（`install.ts`）
- 从 `runLegacyMigration` 和 `runDeadlockRepair` 签名中删除从未读取的 `skipConfig` 参数
- 消除公开表面的死参数，避免维护者误以为存在未实现的配置分支

### P2 — SKILL.md 删除 streaming 全部内容（`skills/dmwork-bot-api/SKILL.md`）
- 删除 `### Streaming Response` 整个章节
- 删除 API 总表中 `stream/start`、`stream/end` 两行
- 删除故障排查中的 stream 相关条目
- 最佳实践中"use streaming"改为"send as normal message + typing indicator"
- 当前 Bot API 不对外支持 streaming，SKILL.md 职责是告诉模型现在应该怎么用，不保留已废弃路径

### P3 — `runLegacyMigration` 步骤编号修正（`install.ts`）
- 修复重复的 `// 3.`，按真实执行顺序改为 3→4→5→6→7

### P3 — 删除 `index.ts` 多余空行
- 删除 `register(api) {` 后的无意义空行

## 不在本 PR 处理

- `src/version.ts` 保持 committed（fresh clone 构建依赖它，已有文件头注释说明）
- `findGlobalOpenclaw()` 懒加载（后续优化）
- `bind`/`quickstart` 固定等待改轮询（后续优化）

## 测试

- 600 个测试全部通过（含新增 10 个 normalizeUsername 单测）