### PR TITLE
fix: quickstart 失败时输出详细错误信息

### DIFF
--- a/openclaw-channel-dmwork/cli/quickstart.test.ts
+++ b/openclaw-channel-dmwork/cli/quickstart.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { normalizeUsername } from "./quickstart.js";
+
+// ── normalizeUsername unit tests ──────────────────────────────────
 
 describe("normalizeUsername", () => {
   it("plain ascii id", () => {
@@ -46,5 +48,158 @@ describe("normalizeUsername", () => {
 
   it("leading/trailing whitespace trimmed", () => {
     expect(normalizeUsername("  agent  ")).toBe("agent_bot");
+  });
+});
+
+// ── runQuickstart error output tests ─────────────────────────────
+
+// Mock dependencies before importing runQuickstart
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("./openclaw-cli.js", () => ({
+  isHealthyInstall: vi.fn(() => true),
+  readConfigFromFile: vi.fn(() => ({})),
+  writeConfigAtomic: vi.fn(),
+  getOpenClawBin: vi.fn(() => "openclaw"),
+}));
+
+vi.mock("./utils.js", () => ({
+  PLUGIN_ID: "openclaw-channel-dmwork",
+  RECOMMENDED_DM_SCOPE: "dmwork",
+  ensureOpenClawCompat: vi.fn(),
+}));
+
+import { execFileSync } from "node:child_process";
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+function makeResponse(status: number, body: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(body),
+    json: () => Promise.resolve(JSON.parse(body)),
+  } as Response;
+}
+
+async function loadAndRun(opts: { apiKey: string; apiUrl: string }) {
+  vi.resetModules();
+
+  // Re-apply mocks after resetModules
+  vi.doMock("node:child_process", () => ({
+    execFileSync: mockExecFileSync,
+  }));
+  vi.doMock("./openclaw-cli.js", () => ({
+    isHealthyInstall: vi.fn(() => true),
+    readConfigFromFile: vi.fn(() => ({})),
+    writeConfigAtomic: vi.fn(),
+    getOpenClawBin: vi.fn(() => "openclaw"),
+  }));
+  vi.doMock("./utils.js", () => ({
+    PLUGIN_ID: "openclaw-channel-dmwork",
+    RECOMMENDED_DM_SCOPE: "dmwork",
+    ensureOpenClawCompat: vi.fn(),
+  }));
+
+  const mod = await import("./quickstart.js");
+  return mod.runQuickstart(opts);
+}
+
+describe("runQuickstart error output", () => {
+  let logs: string[];
+  let errors: string[];
+  let exitCode: number | undefined;
+  const origLog = console.log;
+  const origError = console.error;
+  const origExit = process.exit;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logs = [];
+    errors = [];
+    exitCode = undefined;
+    console.log = (...args: any[]) => logs.push(args.join(" "));
+    console.error = (...args: any[]) => errors.push(args.join(" "));
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as any;
+
+    // Default: agents list returns one agent "main"
+    mockExecFileSync.mockReturnValue('[{"id":"main","name":"main"}]');
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    console.error = origError;
+    process.exit = origExit;
+    vi.restoreAllMocks();
+  });
+
+  it("all 3 candidates 409: prints each conflict + final summary", async () => {
+    const fetchMock = vi.fn<typeof globalThis.fetch>()
+      .mockResolvedValue(makeResponse(409, "username occupied"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadAndRun({ apiKey: "uk_test", apiUrl: "http://api" }))
+      .rejects.toThrow("process.exit(1)");
+
+    const allOutput = [...logs, ...errors].join("\n");
+    expect(allOutput).toContain("main_bot already occupied");
+    expect(allOutput).toContain("main_2_bot already occupied");
+    expect(allOutput).toContain("main_3_bot already occupied");
+    expect(allOutput).toContain("all username variants conflicted");
+    expect(allOutput).toContain("main_bot, main_2_bot, main_3_bot");
+    expect(allOutput).toContain("Suggestion:");
+    expect(exitCode).toBe(1);
+  });
+
+  it("first candidate 409, second succeeds: shows retry then success", async () => {
+    const fetchMock = vi.fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(makeResponse(409, "occupied"))
+      .mockResolvedValueOnce(makeResponse(200, JSON.stringify({
+        robot_id: "main_2_bot", bot_token: "bf_xxx", name: "main",
+      })))
+      // register + sendMessage for greeting
+      .mockResolvedValue(makeResponse(200, JSON.stringify({ owner_uid: "u1" })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await loadAndRun({ apiKey: "uk_test", apiUrl: "http://api" });
+
+    const allOutput = [...logs, ...errors].join("\n");
+    expect(allOutput).toContain("main_bot already occupied");
+    expect(allOutput).toContain("Created bot: main_2_bot");
+    expect(exitCode).toBeUndefined(); // no exit(1)
+  });
+
+  it("401 API key error: prints HTTP status and response", async () => {
+    const fetchMock = vi.fn<typeof globalThis.fetch>()
+      .mockResolvedValue(makeResponse(401, "Unauthorized: invalid api key"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadAndRun({ apiKey: "uk_bad", apiUrl: "http://api" }))
+      .rejects.toThrow("process.exit(1)");
+
+    const allOutput = [...logs, ...errors].join("\n");
+    expect(allOutput).toContain("HTTP 401");
+    expect(allOutput).toContain("Unauthorized");
+    expect(allOutput).toContain("1 agent(s) failed");
+    expect(exitCode).toBe(1);
+  });
+
+  it("network error: prints error message", async () => {
+    const fetchMock = vi.fn<typeof globalThis.fetch>()
+      .mockRejectedValue(new Error("fetch failed: ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadAndRun({ apiKey: "uk_test", apiUrl: "http://api" }))
+      .rejects.toThrow("process.exit(1)");
+
+    const allOutput = [...logs, ...errors].join("\n");
+    expect(allOutput).toContain("ECONNREFUSED");
+    expect(allOutput).toContain("1 agent(s) failed");
+    expect(exitCode).toBe(1);
   });
 });

--- a/openclaw-channel-dmwork/cli/quickstart.test.ts
+++ b/openclaw-channel-dmwork/cli/quickstart.test.ts
@@ -34,7 +34,7 @@ describe("normalizeUsername", () => {
     const long = "a".repeat(30);
     const result = normalizeUsername(long);
     expect(result).toBe("a".repeat(17) + "_bot");
-    expect(result.length).toBeLessThanOrEqual(21); // 17 + len("_bot")
+    expect(result.length).toBeLessThanOrEqual(21);
   });
 
   it("long id with _bot suffix — truncated correctly", () => {

--- a/openclaw-channel-dmwork/cli/quickstart.ts
+++ b/openclaw-channel-dmwork/cli/quickstart.ts
@@ -141,27 +141,32 @@ export async function runQuickstart(opts: QuickstartOptions): Promise<void> {
           (resp.status === 400 && /已被占用|occupied/i.test(text));
 
         if (isUsernameConflict) {
+          console.log(`  ${username} already occupied, trying next...`);
           continue;
         }
 
+        const errMsg = `HTTP ${resp.status}: ${text.slice(0, 200)}`;
+        console.error(`  ${agent.id}: ${errMsg}`);
         results.push({
           agentId: agent.id,
           robotId: username,
           botToken: "",
           name: agent.name || agent.id,
           status: "failed",
-          error: `HTTP ${resp.status}: ${text}`,
+          error: errMsg,
         });
         created = true;
         break;
       } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.error(`  ${agent.id}: ${errMsg}`);
         results.push({
           agentId: agent.id,
           robotId: username,
           botToken: "",
           name: agent.name || agent.id,
           status: "failed",
-          error: err instanceof Error ? err.message : String(err),
+          error: errMsg,
         });
         created = true;
         break;
@@ -169,13 +174,15 @@ export async function runQuickstart(opts: QuickstartOptions): Promise<void> {
     }
 
     if (!created) {
+      const tried = candidates.join(", ");
+      console.error(`  ${agent.id}: all username variants conflicted (${tried})`);
       results.push({
         agentId: agent.id,
         robotId: baseName,
         botToken: "",
         name: agent.name || agent.id,
         status: "failed",
-        error: "All username variants conflicted",
+        error: `All username variants conflicted: ${tried}`,
       });
     }
   }
@@ -184,7 +191,11 @@ export async function runQuickstart(opts: QuickstartOptions): Promise<void> {
   const failed = results.filter((r) => r.status === "failed");
 
   if (successful.length === 0) {
-    console.error("\nNo bots were created. Please check the errors above.");
+    console.error(`\n${failed.length} agent(s) failed:`);
+    for (const f of failed) {
+      console.error(`  ${f.agentId} → ${f.error}`);
+    }
+    console.error("\nSuggestion: create manually with /newbot, or retry with a different agent name.");
     process.exit(1);
   }
 


### PR DESCRIPTION
## 问题

`quickstart` 创建 bot 失败时，错误信息被吞掉。用户只看到：
```
Found 1 agent(s): main
No bots were created. Please check the errors above.
```
但 "above" 什么都没有。

**根因**：失败结果存到 `results` 数组但 `process.exit(1)` 在打印明细之前就退出了。

## 修复内容

### 错误输出（`quickstart.ts`）
- 用户名冲突时输出 `main_bot already occupied, trying next...`（不再静默 continue）
- 非冲突 HTTP 错误（401 等）立即输出状态码和响应
- 网络异常立即输出异常消息
- 全部候选名冲突时输出完整尝试列表
- `successful.length === 0` 退出前逐条打印每个 agent 的失败原因 + 建议

### 测试（`quickstart.test.ts`）
- 3 个候选名全部 409：验证逐次冲突提示 + 最终汇总 + `process.exit(1)`
- 第 1 个冲突第 2 个成功：验证 retry 输出 + 创建成功
- 401 API key 错误：验证 HTTP 状态和响应打印
- 网络异常：验证异常消息打印

## 测试

604 tests passing（含新增 4 个错误输出路径测试 + 10 个 normalizeUsername 测试）