### PR TITLE
fix: include name and size in image message payload

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.test.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.test.ts
@@ -646,7 +646,7 @@ describe("sendMediaMessage", () => {
     global.fetch = originalFetch;
   });
 
-  it("Image type should include width/height and exclude name/size", async () => {
+  it("Image type should include width/height and name/size", async () => {
     let sentBody: any = null;
     global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
       sentBody = JSON.parse(init?.body as string);
@@ -666,8 +666,8 @@ describe("sendMediaMessage", () => {
       url: "https://cdn.example.com/img.png",
       width: 800,
       height: 600,
-      name: "img.png",   // should be ignored for Image
-      size: 12345,        // should be ignored for Image
+      name: "img.png",
+      size: 12345,
     });
 
     expect(sentBody).not.toBeNull();
@@ -676,9 +676,9 @@ describe("sendMediaMessage", () => {
     expect(payload.url).toBe("https://cdn.example.com/img.png");
     expect(payload.width).toBe(800);
     expect(payload.height).toBe(600);
-    // Image type must NOT include name/size
-    expect(payload.name).toBeUndefined();
-    expect(payload.size).toBeUndefined();
+    // Image type must include name/size
+    expect(payload.name).toBe("img.png");
+    expect(payload.size).toBe(12345);
   });
 
   it("File type should include name/size and exclude width/height", async () => {

--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -71,10 +71,12 @@ export async function sendMediaMessage(params: {
     url: params.url,
   };
 
-  // Image (type=2) needs width/height; File (type=8) needs name/size
+  // Image (type=2) needs width/height/name/size; File (type=8) needs name/size
   if (params.type === MessageType.Image) {
     if (params.width) payload.width = params.width;
     if (params.height) payload.height = params.height;
+    if (params.name) payload.name = params.name;
+    if (params.size != null) payload.size = params.size;
   } else {
     if (params.name) payload.name = params.name;
     if (params.size != null) payload.size = params.size;

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -602,6 +602,8 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
             url: cdnUrl,
             width: dims?.width,
             height: dims?.height,
+            name: filename,
+            size: fileSize,
           });
         } else {
           await sendMediaMessage({

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -195,8 +195,8 @@ export async function uploadAndSendMedia(params: {
       channelType,
       type: msgType,
       url: uploadedUrl,
-      name: isImage ? undefined : filename,
-      size: isImage ? undefined : fileSize,
+      name: filename,
+      size: fileSize,
       width,
       height,
     });


### PR DESCRIPTION
## Summary

Bot-sent image messages now include original filename and file size in the payload.

### Problem

When a bot sends an image via the adapter, the message payload only contained `{type, url, width, height}` — no `name` or `size`. The web frontend would fallback to `"image.png"` for downloads.

### Changes

| File | Change |
|------|--------|
| `api-fetch.ts` | Image branch now includes `name` and `size` in payload |
| `channel.ts` | Image `sendMediaMessage` call passes `name: filename` and `size: fileSize` |
| `inbound.ts` | Removed `isImage ? undefined :` conditional — always pass `name` and `size` |
| `api-fetch.test.ts` | Updated test assertions: Image payload now includes name/size |

### Payload Before/After

**Before:**
```json
{"type": 2, "url": "https://cdn.../uuid.jpg", "width": 800, "height": 600}
```

**After:**
```json
{"type": 2, "url": "https://cdn.../uuid.jpg", "width": 800, "height": 600, "name": "photo.jpg", "size": 123456}
```

### Backward Compatibility

- `name` and `size` remain optional params — no breaking changes
- Old messages without `name` continue to fallback as before

### Tests
604 tests passed ✅

Refs: dmwork-org/dmwork-PM#225