### PR TITLE
fix: Windows 上 npx install 找不到 openclaw 的问题

### DIFF
--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -17,6 +17,8 @@ import { resolve } from "node:path";
  * causes version incompatibility crashes on older OpenClaw servers.
  */
 function findGlobalOpenclaw(): string {
+  const isWindows = process.platform === "win32";
+
   // Strategy 1: use "which -a" (Unix) or "where" (Windows) to find all openclaw paths
   // Skip: _npx (npx cache), npx-cache, node_modules (project-local devDependency)
   for (const cmd of ["which -a openclaw", "where openclaw"]) {
@@ -40,7 +42,25 @@ function findGlobalOpenclaw(): string {
     }
   }
 
-  // Strategy 2: check common global install paths
+  // Strategy 2 (Windows): npm global prefix + openclaw.cmd
+  // npm i -g openclaw 在 Windows 上生成 .ps1 和 .cmd，但 npx 子进程的 PATH
+  // 可能不包含 npm 全局目录，导致 where 找不到。直接通过 npm prefix 定位。
+  if (isWindows) {
+    try {
+      const prefix = execSync("npm config get prefix", {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      if (prefix) {
+        const cmdPath = resolve(prefix, "openclaw.cmd");
+        if (existsSync(cmdPath)) return cmdPath;
+      }
+    } catch {
+      // npm not available
+    }
+  }
+
+  // Strategy 3: check common global install paths
   const candidates = [
     "/opt/homebrew/bin/openclaw",
     "/usr/local/bin/openclaw",
@@ -56,11 +76,27 @@ function findGlobalOpenclaw(): string {
 }
 
 const OPENCLAW = findGlobalOpenclaw();
+const NEEDS_SHELL = process.platform === "win32" && /\.cmd$/i.test(OPENCLAW);
+
+/**
+ * Execute openclaw CLI command. On Windows, .cmd shims require shell: true.
+ * All openclaw invocations in this module MUST go through this function.
+ *
+ * 使用 execFileSync + shell:true 而非手动拼字符串，
+ * 让 Node.js 自动处理 cmd.exe 参数转义（包括 JSON 内的引号）。
+ */
+function runOpenclaw(args: string[], opts: Record<string, unknown> = {}): string {
+  const shellOpt = NEEDS_SHELL ? { shell: true } : {};
+  return execFileSync(OPENCLAW, args, { encoding: "utf-8", ...shellOpt, ...opts } as any) as unknown as string;
+}
 
 /** Get the resolved openclaw binary path */
 export function getOpenClawBin(): string {
   return OPENCLAW;
 }
+
+/** Execute openclaw command (exported for quickstart.ts etc.) */
+export { runOpenclaw };
 
 /** Expand ~ to home directory */
 function expandHome(p: string): string {
@@ -73,7 +109,7 @@ function expandHome(p: string): string {
 // ---------------------------------------------------------------------------
 
 export function getConfigFilePath(): string {
-  const out = execFileSync(OPENCLAW, ["config", "file"], { encoding: "utf-8" });
+  const out = runOpenclaw(["config", "file"]);
   // openclaw may prepend warnings/box-drawing to stdout; extract the actual path
   // The path is typically the last non-empty line containing openclaw.json
   const lines = out.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
@@ -105,8 +141,7 @@ function stripStdoutNoise(raw: string): string {
 
 export function configGet(path: string): string | null {
   try {
-    const raw = execFileSync(OPENCLAW, ["config", "get", path], {
-      encoding: "utf-8",
+    const raw = runOpenclaw(["config", "get", path], {
       stdio: ["pipe", "pipe", "pipe"],
     });
     const val = stripStdoutNoise(raw);
@@ -118,8 +153,7 @@ export function configGet(path: string): string | null {
 
 export function configGetJson(path: string): any {
   try {
-    const out = execFileSync(OPENCLAW, ["config", "get", path, "--json"], {
-      encoding: "utf-8",
+    const out = runOpenclaw(["config", "get", path, "--json"], {
       stdio: ["pipe", "pipe", "pipe"],
     });
     const jsonStart = out.indexOf("{");
@@ -145,7 +179,7 @@ export function configGetJson(path: string): any {
 }
 
 export function configSet(path: string, value: string): void {
-  execFileSync(OPENCLAW, ["config", "set", path, value], {
+  runOpenclaw(["config", "set", path, value], {
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
@@ -156,19 +190,19 @@ export function configSetBatch(
   const batchJson = JSON.stringify(
     operations.map((op) => ({ path: op.path, value: op.value })),
   );
-  execFileSync(OPENCLAW, ["config", "set", "--batch-json", batchJson], {
+  runOpenclaw(["config", "set", "--batch-json", batchJson], {
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
 
 export function configSetJson(path: string, value: unknown): void {
-  execFileSync(OPENCLAW, ["config", "set", path, JSON.stringify(value), "--strict-json"], {
+  runOpenclaw(["config", "set", path, JSON.stringify(value), "--strict-json"], {
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
 
 export function configUnset(path: string): void {
-  execFileSync(OPENCLAW, ["config", "unset", path], {
+  runOpenclaw(["config", "unset", path], {
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
@@ -228,7 +262,7 @@ export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): 
   // making isUnsupportedOptionError() unable to detect "unknown option".
   for (let i = 0; i < attempts.length; i++) {
     try {
-      const result = execFileSync(OPENCLAW, attempts[i], {
+      const result = runOpenclaw(attempts[i], {
         stdio: ["pipe", "pipe", "pipe"],
         encoding: "utf-8",
       });
@@ -251,7 +285,7 @@ export function pluginsInstall(spec: string, quiet?: boolean, force?: boolean): 
 }
 
 export function pluginsUpdate(id: string, quiet?: boolean): void {
-  const result = execFileSync(OPENCLAW, ["plugins", "update", id], {
+  const result = runOpenclaw(["plugins", "update", id], {
     stdio: ["pipe", "pipe", "pipe"],
     encoding: "utf-8",
   });
@@ -261,7 +295,7 @@ export function pluginsUpdate(id: string, quiet?: boolean): void {
 export function pluginsUninstall(id: string, yes?: boolean): void {
   const args = ["plugins", "uninstall", id];
   if (yes) args.push("--force");
-  execFileSync(OPENCLAW, args, { stdio: "inherit" });
+  runOpenclaw(args, { stdio: "inherit" });
 }
 
 export interface PluginInspectResult {
@@ -294,7 +328,7 @@ export interface PluginsInspectOutcome {
  */
 export function pluginsInspectDetailed(id: string): PluginsInspectOutcome {
   try {
-    const out = execFileSync(OPENCLAW, ["plugins", "inspect", id, "--json"], {
+    const out = runOpenclaw(["plugins", "inspect", id, "--json"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -406,7 +440,7 @@ export function resolvePluginState(id: string): PluginResolvedState {
 
 export function gatewayStatus(): { running: boolean } {
   try {
-    const out = execFileSync(OPENCLAW, ["gateway", "status", "--json"], {
+    const out = runOpenclaw(["gateway", "status", "--json"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -433,7 +467,7 @@ export function gatewayStatus(): { running: boolean } {
 
 export function gatewayRestart(quiet?: boolean): boolean {
   try {
-    execFileSync(OPENCLAW, ["gateway", "restart"], {
+    runOpenclaw(["gateway", "restart"], {
       stdio: quiet ? ["pipe", "pipe", "pipe"] : "inherit",
     });
     return true;
@@ -448,7 +482,7 @@ export function gatewayRestart(quiet?: boolean): boolean {
 
 export function getOpenClawVersion(): string | null {
   try {
-    const out = execFileSync(OPENCLAW, ["--version"], {
+    const out = runOpenclaw(["--version"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -604,7 +638,7 @@ export function cleanupLegacyPlugin(): string[] {
   if (existsSync(legacyDir)) {
     // Try to uninstall via openclaw CLI first (removes entries/installs/allow)
     try {
-      execFileSync(OPENCLAW, ["plugins", "uninstall", LEGACY_PLUGIN_ID, "--force", "--keep-files"], {
+      runOpenclaw(["plugins", "uninstall", LEGACY_PLUGIN_ID, "--force", "--keep-files"], {
         stdio: ["pipe", "pipe", "pipe"],
       });
       actions.push(`Unregistered legacy plugin "${LEGACY_PLUGIN_ID}"`);
@@ -805,7 +839,7 @@ export function ensurePluginsAllow(): void {
 
 export function pluginsUpdateCompat(id: string, tag: string, quiet?: boolean): void {
   try {
-    const result = execFileSync(OPENCLAW, ["plugins", "update", id], {
+    const result = runOpenclaw(["plugins", "update", id], {
       stdio: ["pipe", "pipe", "pipe"],
       encoding: "utf-8",
     });

--- a/openclaw-channel-dmwork/cli/quickstart.test.ts
+++ b/openclaw-channel-dmwork/cli/quickstart.test.ts
@@ -54,15 +54,11 @@ describe("normalizeUsername", () => {
 // ── runQuickstart error output tests ─────────────────────────────
 
 // Mock dependencies before importing runQuickstart
-vi.mock("node:child_process", () => ({
-  execFileSync: vi.fn(),
-}));
-
 vi.mock("./openclaw-cli.js", () => ({
   isHealthyInstall: vi.fn(() => true),
   readConfigFromFile: vi.fn(() => ({})),
   writeConfigAtomic: vi.fn(),
-  getOpenClawBin: vi.fn(() => "openclaw"),
+  runOpenclaw: vi.fn(),
 }));
 
 vi.mock("./utils.js", () => ({
@@ -71,9 +67,8 @@ vi.mock("./utils.js", () => ({
   ensureOpenClawCompat: vi.fn(),
 }));
 
-import { execFileSync } from "node:child_process";
-
-const mockExecFileSync = vi.mocked(execFileSync);
+import { runOpenclaw } from "./openclaw-cli.js";
+const mockRunOpenclaw = vi.mocked(runOpenclaw);
 
 function makeResponse(status: number, body: string): Response {
   return {
@@ -87,15 +82,11 @@ function makeResponse(status: number, body: string): Response {
 async function loadAndRun(opts: { apiKey: string; apiUrl: string }) {
   vi.resetModules();
 
-  // Re-apply mocks after resetModules
-  vi.doMock("node:child_process", () => ({
-    execFileSync: mockExecFileSync,
-  }));
   vi.doMock("./openclaw-cli.js", () => ({
     isHealthyInstall: vi.fn(() => true),
     readConfigFromFile: vi.fn(() => ({})),
     writeConfigAtomic: vi.fn(),
-    getOpenClawBin: vi.fn(() => "openclaw"),
+    runOpenclaw: vi.fn(() => mockRunOpenclaw()),
   }));
   vi.doMock("./utils.js", () => ({
     PLUGIN_ID: "openclaw-channel-dmwork",
@@ -128,7 +119,7 @@ describe("runQuickstart error output", () => {
     }) as any;
 
     // Default: agents list returns one agent "main"
-    mockExecFileSync.mockReturnValue('[{"id":"main","name":"main"}]');
+    mockRunOpenclaw.mockReturnValue('[{"id":"main","name":"main"}]');
   });
 
   afterEach(() => {

--- a/openclaw-channel-dmwork/cli/quickstart.ts
+++ b/openclaw-channel-dmwork/cli/quickstart.ts
@@ -9,12 +9,11 @@
  * - NOT idempotent — designed for first-time setup only
  */
 
-import { execFileSync } from "node:child_process";
 import {
   isHealthyInstall,
   readConfigFromFile,
   writeConfigAtomic,
-  getOpenClawBin,
+  runOpenclaw,
 } from "./openclaw-cli.js";
 import {
   RECOMMENDED_DM_SCOPE,
@@ -64,9 +63,7 @@ export async function runQuickstart(opts: QuickstartOptions): Promise<void> {
   console.log("Fetching agent list...");
   let agents: AgentInfo[];
   try {
-    const OPENCLAW = getOpenClawBin();
-    const raw = execFileSync(OPENCLAW, ["agents", "list", "--json"], {
-      encoding: "utf-8",
+    const raw = runOpenclaw(["agents", "list", "--json"], {
       stdio: ["pipe", "pipe", "pipe"],
     });
     // OpenClaw stdout may contain plugin log noise before JSON (e.g. [dmwork], [plugins]).


### PR DESCRIPTION
## 问题

Windows 用户通过 `npm i -g openclaw` 安装后，执行 `npx -y openclaw-channel-dmwork install` 报 `Error: openclaw not found`。

**根因**：npm 全局安装在 Windows 上生成 `.ps1` 和 `.cmd` shim 到 `AppData\Roaming\npm\`，但 npx 子进程的 PATH 不包含该目录，导致 `where openclaw` 找不到。且 `execFileSync` 不能直接执行 `.cmd` 文件（报 EINVAL）。

## 修复

- `findGlobalOpenclaw()`: 新增 Windows 专用 Strategy，通过 `npm config get prefix` 获取 npm 全局目录，直接检查 `openclaw.cmd`
- 新增 `runOpenclaw(args, opts)` 统一执行封装：Windows `.cmd` 走 `execFileSync + shell:true`（Node.js 自动处理参数转义），其他平台走原 `execFileSync` 路径
- `NEEDS_SHELL` 仅匹配 `.cmd`（不含 `.ps1`）
- 替换所有 `execFileSync(OPENCLAW, ...)` 调用为 `runOpenclaw(...)`（17 处）

## 影响范围

- macOS/Linux：不受影响，`NEEDS_SHELL = false`，走原路径
- Windows：解决 `openclaw not found` + `.cmd` 执行失败

## 测试

604 tests passing