### PR TITLE
fix: Windows where openclaw 返回无扩展名 shim 导致 ENOENT

### DIFF
--- a/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
@@ -150,18 +150,45 @@ describe("findGlobalOpenclaw (via module load)", () => {
   });
 
   it("should handle CRLF output from Windows", async () => {
-    const { execSync } = await import("node:child_process");
-    vi.mocked(execSync).mockReturnValue(
-      "C:\\npm\\_npx\\openclaw.cmd\r\nC:\\Program Files\\openclaw\\openclaw.exe\r\n",
-    );
-    const mod = await loadModule();
-    mockExecFileSync.mockReturnValue("test\n");
-    mod.configGet("test.path");
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      "C:\\Program Files\\openclaw\\openclaw.exe",
-      expect.any(Array),
-      expect.any(Object),
-    );
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      const { execSync } = await import("node:child_process");
+      vi.mocked(execSync).mockReturnValue(
+        "C:\\npm\\_npx\\openclaw.cmd\r\nC:\\Program Files\\openclaw\\openclaw.exe\r\n",
+      );
+      const mod = await loadModule();
+      mockExecFileSync.mockReturnValue("test\n");
+      mod.configGet("test.path");
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "C:\\Program Files\\openclaw\\openclaw.exe",
+        expect.any(Array),
+        expect.any(Object),
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("should prefer .cmd when where returns both shim variants on Windows", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      const { execSync } = await import("node:child_process");
+      vi.mocked(execSync).mockReturnValue(
+        "C:\\Users\\mLamp\\AppData\\Roaming\\npm\\openclaw\r\nC:\\Users\\mLamp\\AppData\\Roaming\\npm\\openclaw.cmd\r\n",
+      );
+      const mod = await loadModule();
+      mockExecFileSync.mockReturnValue("OpenClaw 2026.4.21\n");
+      mod.getOpenClawVersion();
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "C:\\Users\\mLamp\\AppData\\Roaming\\npm\\openclaw.cmd",
+        expect.any(Array),
+        expect.objectContaining({ shell: true }),
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
   });
 
   it("should fallback to candidate paths when which/where fails", async () => {

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -36,7 +36,16 @@ function findGlobalOpenclaw(): string {
           !p.includes("npx-cache") &&
           !p.includes("node_modules"),
         );
-      if (paths.length > 0) return paths[0];
+      if (paths.length > 0) {
+        // On Windows, `where openclaw` may return both the extensionless shim
+        // and `openclaw.cmd`. Prefer `.cmd`, otherwise execFileSync may hit
+        // ENOENT for the extensionless path.
+        if (isWindows) {
+          const cmdShim = paths.find((p) => /\.cmd$/i.test(p));
+          if (cmdShim) return cmdShim;
+        }
+        return paths[0];
+      }
     } catch {
       // command not available on this platform
     }


### PR DESCRIPTION
## 问题

PR #201 合并后，Windows 上 `npx install` 仍然报 `openclaw not found`。

**根因**：`where openclaw` 在 Windows 上返回两个结果：
- `C:\Users\mLamp\AppData\Roaming\npm\openclaw`（无扩展名 shim）
- `C:\Users\mLamp\AppData\Roaming\npm\openclaw.cmd`

代码取了第一个（无扩展名），`execFileSync` 执行时报 ENOENT。

## 修复

- Windows 下解析 `where` 结果时，优先选 `.cmd` 结尾的路径
- 补充回归测试：覆盖"无扩展名 + .cmd 共存"的真实复现场景

## 测试

605 tests passing（含新增 Windows .cmd 优先选择测试）