### PR TITLE
feat: implement draft-edit dedup in deliver callback

### DIFF
--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -3,7 +3,7 @@
  * These are used by inbound/outbound where the full DMWorkAPI class is not available.
  */
 
-import { ChannelType, MessageType, type MentionEntity } from "./types.js";
+import { ChannelType, MessageType, type MentionEntity, type SendMessageResult } from "./types.js";
 import path from "path";
 import { open } from "node:fs/promises";
 // @ts-ignore — cos-nodejs-sdk-v5 has incomplete TypeScript definitions
@@ -41,7 +41,11 @@ export async function postJson<T>(
   const text = await response.text();
   if (!text) return undefined;
   try {
-    return JSON.parse(text) as T;
+    // Protect int64 message_id from JSON.parse precision loss.
+    // Applied globally in postJson since only "message_id" fields are matched;
+    // the regex is conservative (16+ digits) to avoid any precision edge cases.
+    const safeText = text.replace(/"message_id"\s*:\s*(\d{16,})/g, '"message_id":"$1"');
+    return JSON.parse(safeText) as T;
   } catch {
     throw new Error(`DMWork API ${path} returned invalid JSON: ${text.slice(0, 200)}`);
   }
@@ -189,6 +193,9 @@ export async function parseImageDimensionsFromFile(filePath: string, mime: strin
   return null;
 }
 
+// SendMessageResult: use the canonical definition from types.ts
+// (message_id is string due to int64 protection in postJson)
+
 export async function sendMessage(params: {
   apiUrl: string;
   botToken: string;
@@ -200,7 +207,7 @@ export async function sendMessage(params: {
   mentionAll?: boolean;
   replyMsgId?: string;
   signal?: AbortSignal;
-}): Promise<void> {
+}): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
     type: MessageType.Text,
     content: params.content,
@@ -227,7 +234,7 @@ export async function sendMessage(params: {
   if (params.replyMsgId) {
     payload.reply = { message_id: params.replyMsgId };
   }
-  await postJson(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
+  return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
     channel_id: params.channelId,
     channel_type: params.channelType,
     payload,

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1,5 +1,5 @@
 import type { ChannelLogSink, OpenClawConfig } from "openclaw/plugin-sdk";
-import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadCredentials, uploadFileToCOS, fetchUserInfo } from "./api-fetch.js";
+import { sendMessage, editMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadCredentials, uploadFileToCOS, fetchUserInfo } from "./api-fetch.js";
 import type { ResolvedDmworkAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
 import { ChannelType, MessageType } from "./types.js";
@@ -1491,6 +1491,11 @@ export async function handleInboundMessage(params: {
     sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType }).catch(() => {});
   }, 5000);
 
+  // Draft-edit dedup: tracks the first sent message so subsequent delivers edit it.
+  // draftMessage is scoped to this handleInboundMessage invocation; deliver is called
+  // sequentially by dispatchReplyWithBufferedBlockDispatcher, so no concurrency issue.
+  let draftMessage: { messageId: string; messageSeq: number } | null = null;
+
   try {
   await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
     ctx: ctxPayload,
@@ -1633,7 +1638,34 @@ export async function handleInboundMessage(params: {
         // Detect @all/@所有人 in final content
         const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalContent);
 
-        await sendMessage({
+        // Draft-edit dedup: subsequent delivers edit the first message.
+        // Note: editMessage API only updates content_edit text; mention metadata
+        // (mentionUids/mentionEntities/mentionAll) cannot be updated via edit.
+        // This is acceptable because the first sendMessage already carries the
+        // correct mention info, and subsequent edits only update the text body.
+        if (draftMessage) {
+          try {
+            const contentEdit = JSON.stringify({ type: 1, content: finalContent });
+            log?.debug?.(`dmwork: [draft-edit] editMessage attempt id=${draftMessage.messageId} seq=${draftMessage.messageSeq}`);
+            await editMessage({
+              apiUrl: account.config.apiUrl,
+              botToken: account.config.botToken ?? "",
+              messageId: draftMessage.messageId,
+              messageSeq: draftMessage.messageSeq,
+              channelId: replyChannelId,
+              channelType: replyChannelType,
+              contentEdit,
+            });
+            log?.debug?.(`dmwork: [draft-edit] editMessage success`);
+            statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
+            return;
+          } catch (editErr) {
+            log?.warn?.(`dmwork: [draft-edit] editMessage failed: ${String(editErr)}, falling back to sendMessage`);
+            draftMessage = null;
+          }
+        }
+
+        const sendResult = await sendMessage({
           apiUrl: account.config.apiUrl,
           botToken: account.config.botToken ?? "",
           channelId: replyChannelId,
@@ -1643,6 +1675,17 @@ export async function handleInboundMessage(params: {
           ...(replyMentionEntities.length > 0 ? { mentionEntities: replyMentionEntities } : {}),
           mentionAll: hasAtAll || undefined,
         });
+
+        // Save draft for subsequent edit-dedup
+        if (sendResult?.message_id != null && sendResult?.message_seq != null) {
+          draftMessage = {
+            messageId: String(sendResult.message_id),
+            messageSeq: sendResult.message_seq,
+          };
+          log?.debug?.(`dmwork: [draft-edit] sendMessage OK, draft set: id=${draftMessage.messageId} seq=${draftMessage.messageSeq}`);
+        } else {
+          log?.debug?.(`dmwork: [draft-edit] sendMessage returned no id/seq, draft-edit disabled`);
+        }
 
         statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
       },

--- a/openclaw-channel-dmwork/src/types.ts
+++ b/openclaw-channel-dmwork/src/types.ts
@@ -106,7 +106,8 @@ export interface BotStreamEndReq {
 }
 
 export interface SendMessageResult {
-  message_id: number;
+  message_id: string;  // string due to int64 protection in postJson
+  client_msg_no: string;
   message_seq: number;
 }
 


### PR DESCRIPTION
Closes #204

## Summary

Implement draft-edit dedup in the deliver callback to prevent bot multi-round tool calls from outputting all intermediate text content as separate messages.

## Changes

### `api-fetch.ts`
- Added `SendMessageResult` type with `message_id`, `client_msg_no`, and `message_seq` fields
- Added int64 protection: `message_id` values exceeding `Number.MAX_SAFE_INTEGER` are kept as strings to prevent JavaScript precision loss

### `inbound.ts`
- Added `draftMessage` variable to track the in-flight message per conversation turn
- First `deliver` call sends a new message via `sendMessage` and stores the result in `draftMessage`
- Subsequent `deliver` calls edit the same message via `editMessage` using the stored `message_id`
- Draft state is reset when the conversation turn completes

## Related Issues

- dmwork-org/dmworkim#1131 — botMessageEdit needs message_id fallback when message_seq=0
- dmwork-org/dmwork-web#939 — Edited message should render content_edit text