### PR TITLE
fix: Windows cmd.exe /v:off + npm prefix fallback 闭环 + 回归测试

### DIFF
--- a/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
@@ -184,7 +184,7 @@ describe("findGlobalOpenclaw (via module load)", () => {
       // Windows .cmd files are executed via cmd.exe /d /s /c
       expect(mockExecFileSync).toHaveBeenCalledWith(
         expect.stringContaining("cmd.exe"),
-        expect.arrayContaining(["/d", "/s", "/c"]),
+        expect.arrayContaining(["/d", "/s", "/v:off", "/c"]),
         expect.any(Object),
       );
     } finally {

--- a/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
@@ -192,6 +192,57 @@ describe("findGlobalOpenclaw (via module load)", () => {
     }
   });
 
+  it("should fallback to npm prefix when where openclaw fails on Windows", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      const { execSync } = await import("node:child_process");
+      const { existsSync } = await import("node:fs");
+
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        const cmdStr = String(cmd);
+        // where openclaw / where openclaw.exe → fail
+        if (cmdStr.includes("where") && cmdStr.includes("openclaw") && !cmdStr.includes("npm")) {
+          throw new Error("not found");
+        }
+        // where.exe npm → return npm.cmd (for resolveCommand)
+        if (cmdStr.includes("where") && cmdStr.includes("npm")) {
+          return "C:\\Users\\mLamp\\AppData\\Roaming\\npm\\npm.cmd\r\n";
+        }
+        return "";
+      });
+
+      mockExecFileSync.mockClear();
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        const argsArr = args as string[];
+        // cmd.exe /d /s /v:off /c "npm.cmd" config get prefix
+        if (argsArr?.some?.((a: string) => String(a).includes("config get prefix"))) {
+          return "C:\\Users\\mLamp\\AppData\\Roaming\\npm\n";
+        }
+        // openclaw --version via cmd.exe
+        return "OpenClaw 2026.4.21\n";
+      });
+
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        return String(p).endsWith("openclaw.cmd");
+      });
+
+      const mod = await loadModule();
+      mod.getOpenClawVersion();
+
+      // Verify: openclaw.cmd found via npm prefix, executed via cmd.exe
+      const cmdExeCalls = mockExecFileSync.mock.calls.filter(
+        (call) => String(call[0]).includes("cmd.exe"),
+      );
+      expect(cmdExeCalls.length).toBeGreaterThanOrEqual(2); // npm prefix + openclaw --version
+      expect(cmdExeCalls.some(
+        (call) => (call[1] as string[]).some((a) => a.includes("openclaw.cmd")),
+      )).toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
   it("should fallback to candidate paths when which/where fails", async () => {
     const { execSync } = await import("node:child_process");
     const { existsSync } = await import("node:fs");

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -61,7 +61,7 @@ function findGlobalOpenclaw(): string {
       let prefix: string;
       if (/\.cmd$/i.test(npmResolved)) {
         const comspec = process.env.ComSpec || "C:\\Windows\\System32\\cmd.exe";
-        prefix = execFileSync(comspec, ["/d", "/s", "/c", `"${npmResolved}" config get prefix`], {
+        prefix = execFileSync(comspec, ["/d", "/s", "/v:off", "/c", `"${npmResolved}" config get prefix`], {
           encoding: "utf-8",
           stdio: ["pipe", "pipe", "pipe"],
         }).trim();
@@ -132,7 +132,7 @@ export function runCmd(command: string, args: string[], opts: Record<string, unk
       return `"${a.replace(/%/g, "%%").replace(/"/g, '""')}"`;
     });
     const cmdline = `"${resolved}" ${escaped.join(" ")}`;
-    return execFileSync(comspec, ["/d", "/s", "/c", cmdline], { encoding: "utf-8", ...opts } as any) as unknown as string;
+    return execFileSync(comspec, ["/d", "/s", "/v:off", "/c", cmdline], { encoding: "utf-8", ...opts } as any) as unknown as string;
   }
   return execFileSync(resolved, args, { encoding: "utf-8", ...opts } as any) as unknown as string;
 }
@@ -151,7 +151,7 @@ function runOpenclaw(args: string[], opts: Record<string, unknown> = {}): string
       return `"${a.replace(/%/g, "%%").replace(/"/g, '""')}"`;
     });
     const cmdline = `"${OPENCLAW}" ${escaped.join(" ")}`;
-    return execFileSync(comspec, ["/d", "/s", "/c", cmdline], { encoding: "utf-8", ...opts } as any) as unknown as string;
+    return execFileSync(comspec, ["/d", "/s", "/v:off", "/c", cmdline], { encoding: "utf-8", ...opts } as any) as unknown as string;
   }
   return execFileSync(OPENCLAW, args, { encoding: "utf-8", ...opts } as any) as unknown as string;
 }

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -127,7 +127,10 @@ export function runCmd(command: string, args: string[], opts: Record<string, unk
   const resolved = resolveCommand(command);
   if (IS_WINDOWS && /\.cmd$/i.test(resolved)) {
     const comspec = process.env.ComSpec || "C:\\Windows\\System32\\cmd.exe";
-    const escaped = args.map((a) => /[\s"&|<>^%]/.test(a) ? `"${a.replace(/"/g, '""')}"` : a);
+    const escaped = args.map((a) => {
+      if (!/[\s"&|<>^%!]/.test(a)) return a;
+      return `"${a.replace(/%/g, "%%").replace(/"/g, '""')}"`;
+    });
     const cmdline = `"${resolved}" ${escaped.join(" ")}`;
     return execFileSync(comspec, ["/d", "/s", "/c", cmdline], { encoding: "utf-8", ...opts } as any) as unknown as string;
   }
@@ -143,7 +146,10 @@ const NEEDS_SHELL = IS_WINDOWS && /\.cmd$/i.test(OPENCLAW);
 function runOpenclaw(args: string[], opts: Record<string, unknown> = {}): string {
   if (NEEDS_SHELL) {
     const comspec = process.env.ComSpec || "C:\\Windows\\System32\\cmd.exe";
-    const escaped = args.map((a) => /[\s"&|<>^%]/.test(a) ? `"${a.replace(/"/g, '""')}"` : a);
+    const escaped = args.map((a) => {
+      if (!/[\s"&|<>^%!]/.test(a)) return a;
+      return `"${a.replace(/%/g, "%%").replace(/"/g, '""')}"`;
+    });
     const cmdline = `"${OPENCLAW}" ${escaped.join(" ")}`;
     return execFileSync(comspec, ["/d", "/s", "/c", cmdline], { encoding: "utf-8", ...opts } as any) as unknown as string;
   }

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -53,13 +53,24 @@ function findGlobalOpenclaw(): string {
 
   // Strategy 2 (Windows): npm global prefix + openclaw.cmd
   // npm i -g openclaw 在 Windows 上生成 .ps1 和 .cmd，但 npx 子进程的 PATH
-  // 可能不包含 npm 全局目录，导致 where 找不到。直接通过 npm prefix 定位。
+  // 可能不包含 npm 全局目录，导致 where 找不到。通过 npm prefix 定位。
+  // 注意：npm 本身也是 .cmd，必须通过 resolveCommand 找到再用 cmd.exe 执行。
   if (isWindows) {
     try {
-      const prefix = execSync("npm config get prefix", {
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      }).trim();
+      const npmResolved = resolveCommand("npm");
+      let prefix: string;
+      if (/\.cmd$/i.test(npmResolved)) {
+        const comspec = process.env.ComSpec || "C:\\Windows\\System32\\cmd.exe";
+        prefix = execFileSync(comspec, ["/d", "/s", "/c", `"${npmResolved}" config get prefix`], {
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }).trim();
+      } else {
+        prefix = execSync("npm config get prefix", {
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }).trim();
+      }
       if (prefix) {
         const cmdPath = resolve(prefix, "openclaw.cmd");
         if (existsSync(cmdPath)) return cmdPath;


### PR DESCRIPTION
## 接续 PR #207

- cmd.exe 调用统一加 `/v:off` 禁止 delayed expansion，防止 `!` 被吞
- 参数转义补 `%` → `%%`
- 补 Windows npm prefix fallback 回归测试（where openclaw 失败 → npm prefix → openclaw.cmd）

## 测试

595 tests passing（含新增 fallback 回归测试，单跑也通过）