### PR TITLE
fix: Windows .cmd 执行改为 cmd /d /v:off /c call + 参数转义闭环

### DIFF
--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -15,7 +15,7 @@ import {
 import { runUninstall } from "./uninstall.js";
 import { runRemoveAccount } from "./remove-account.js";
 import { ensureOpenClawCompat, PLUGIN_ID } from "./utils.js";
-import { getOpenClawVersion, resolvePluginState } from "./openclaw-cli.js";
+import { getOpenClawVersionStrict, resolvePluginState } from "./openclaw-cli.js";
 import { createRequire } from "node:module";
 
 const program = new Command();
@@ -33,7 +33,12 @@ program
   .command("info")
   .description("Show CLI and plugin version info")
   .action(() => {
-    const openclawVersion = getOpenClawVersion() ?? "not found";
+    let openclawVersion: string;
+    try {
+      openclawVersion = getOpenClawVersionStrict() ?? "not found";
+    } catch (err) {
+      openclawVersion = `error: ${err instanceof Error ? err.message : String(err)}`;
+    }
     const state = resolvePluginState(PLUGIN_ID);
     let installedVersion = "not installed";
     if (state.installed && state.version) {

--- a/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.test.ts
@@ -101,13 +101,33 @@ describe("getOpenClawVersion", () => {
     expect(getOpenClawVersion()).toBe("2026.4.11");
   });
 
-  it("should return null when openclaw is not installed", async () => {
+  it("should return null when openclaw is not installed (ENOENT)", async () => {
     const { getOpenClawVersion } = await loadModule();
     mockExecFileSync.mockImplementation(() => {
-      throw new Error("ENOENT");
+      const err = new Error("spawn openclaw ENOENT") as any;
+      err.code = "ENOENT";
+      throw err;
     });
 
     expect(getOpenClawVersion()).toBeNull();
+  });
+
+  it("should return null on non-ENOENT errors (getOpenClawVersion)", async () => {
+    const { getOpenClawVersion } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    expect(getOpenClawVersion()).toBeNull();
+  });
+
+  it("should throw on non-ENOENT errors (getOpenClawVersionStrict)", async () => {
+    const { getOpenClawVersionStrict } = await loadModule();
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    expect(() => getOpenClawVersionStrict()).toThrow("Failed to execute openclaw");
   });
 });
 
@@ -184,7 +204,7 @@ describe("findGlobalOpenclaw (via module load)", () => {
       // Windows .cmd files are executed via cmd.exe /d /s /c
       expect(mockExecFileSync).toHaveBeenCalledWith(
         expect.stringContaining("cmd.exe"),
-        expect.arrayContaining(["/d", "/s", "/v:off", "/c"]),
+        expect.arrayContaining(["/d", "/v:off", "/c", "call"]),
         expect.any(Object),
       );
     } finally {
@@ -215,8 +235,8 @@ describe("findGlobalOpenclaw (via module load)", () => {
       mockExecFileSync.mockClear();
       mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
         const argsArr = args as string[];
-        // cmd.exe /d /s /v:off /c "npm.cmd" config get prefix
-        if (argsArr?.some?.((a: string) => String(a).includes("config get prefix"))) {
+        // cmd.exe /d /v:off /c call npm.cmd config get prefix
+        if (argsArr?.includes?.("prefix")) {
           return "C:\\Users\\mLamp\\AppData\\Roaming\\npm\n";
         }
         // openclaw --version via cmd.exe

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -61,7 +61,7 @@ function findGlobalOpenclaw(): string {
       let prefix: string;
       if (/\.cmd$/i.test(npmResolved)) {
         const comspec = process.env.ComSpec || "C:\\Windows\\System32\\cmd.exe";
-        prefix = execFileSync(comspec, ["/d", "/s", "/v:off", "/c", `"${npmResolved}" config get prefix`], {
+        prefix = execFileSync(comspec, ["/d", "/v:off", "/c", "call", npmResolved, "config", "get", "prefix"], {
           encoding: "utf-8",
           stdio: ["pipe", "pipe", "pipe"],
         }).trim();
@@ -123,16 +123,23 @@ function resolveCommand(name: string): string {
  * On Windows, .cmd files are executed via cmd.exe /d /s /c explicitly.
  * All external command invocations (openclaw, npm, etc.) should use this.
  */
+function escapeCmdArg(a: string): string {
+  let s = a.replace(/%/g, "%%");
+  if (/[&|<>^()"\s]/.test(s)) {
+    s = `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function escapeCmdArgs(args: string[]): string[] {
+  return args.map(escapeCmdArg);
+}
+
 export function runCmd(command: string, args: string[], opts: Record<string, unknown> = {}): string {
   const resolved = resolveCommand(command);
   if (IS_WINDOWS && /\.cmd$/i.test(resolved)) {
     const comspec = process.env.ComSpec || "C:\\Windows\\System32\\cmd.exe";
-    const escaped = args.map((a) => {
-      if (!/[\s"&|<>^%!]/.test(a)) return a;
-      return `"${a.replace(/%/g, "%%").replace(/"/g, '""')}"`;
-    });
-    const cmdline = `"${resolved}" ${escaped.join(" ")}`;
-    return execFileSync(comspec, ["/d", "/s", "/v:off", "/c", cmdline], { encoding: "utf-8", ...opts } as any) as unknown as string;
+    return execFileSync(comspec, ["/d", "/v:off", "/c", "call", resolved, ...escapeCmdArgs(args)], { encoding: "utf-8", ...opts } as any) as unknown as string;
   }
   return execFileSync(resolved, args, { encoding: "utf-8", ...opts } as any) as unknown as string;
 }
@@ -146,12 +153,7 @@ const NEEDS_SHELL = IS_WINDOWS && /\.cmd$/i.test(OPENCLAW);
 function runOpenclaw(args: string[], opts: Record<string, unknown> = {}): string {
   if (NEEDS_SHELL) {
     const comspec = process.env.ComSpec || "C:\\Windows\\System32\\cmd.exe";
-    const escaped = args.map((a) => {
-      if (!/[\s"&|<>^%!]/.test(a)) return a;
-      return `"${a.replace(/%/g, "%%").replace(/"/g, '""')}"`;
-    });
-    const cmdline = `"${OPENCLAW}" ${escaped.join(" ")}`;
-    return execFileSync(comspec, ["/d", "/s", "/v:off", "/c", cmdline], { encoding: "utf-8", ...opts } as any) as unknown as string;
+    return execFileSync(comspec, ["/d", "/v:off", "/c", "call", OPENCLAW, ...escapeCmdArgs(args)], { encoding: "utf-8", ...opts } as any) as unknown as string;
   }
   return execFileSync(OPENCLAW, args, { encoding: "utf-8", ...opts } as any) as unknown as string;
 }
@@ -554,8 +556,28 @@ export function getOpenClawVersion(): string | null {
     });
     const match = out.match(/(\d{4}\.\d+\.\d+)/);
     return match?.[1] ?? null;
-  } catch {
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return null;
+    }
+    console.error(`Failed to execute openclaw --version: ${err?.message ?? err}`);
     return null;
+  }
+}
+
+export function getOpenClawVersionStrict(): string | null {
+  try {
+    const out = runOpenclaw(["--version"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const match = out.match(/(\d{4}\.\d+\.\d+)/);
+    return match?.[1] ?? null;
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return null;
+    }
+    throw new Error(`Failed to execute openclaw: ${err?.message ?? err}`);
   }
 }
 

--- a/openclaw-channel-dmwork/cli/utils.ts
+++ b/openclaw-channel-dmwork/cli/utils.ts
@@ -3,7 +3,7 @@
  */
 
 import { createInterface } from "node:readline";
-import { getOpenClawVersion } from "./openclaw-cli.js";
+import { getOpenClawVersion, getOpenClawVersionStrict } from "./openclaw-cli.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -35,7 +35,13 @@ function compareVersions(a: string, b: string): number {
  * Warns (but continues) if version is below recommended minimum.
  */
 export function ensureOpenClawCompat(): void {
-  const version = getOpenClawVersion();
+  let version: string | null = null;
+  try {
+    version = getOpenClawVersionStrict();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
   if (!version) {
     console.error(
       "Error: openclaw not found. Install it first: npm i -g openclaw",


### PR DESCRIPTION
## 问题

Windows 上 .cmd 文件执行不稳定：
- `cmd.exe /d /s /c "\"path\" args"` 在路径带空格时失败
- `shell: true` 对 npm.cmd 不可靠
- 参数中 `%`、`"`、`&|<>^()` 等元字符未转义
- getOpenClawVersion 吞异常导致误报 "openclaw not found"

## 修复

- `.cmd` 执行改为 `cmd.exe /d /v:off /c call <resolved> ...args`
- `escapeCmdArg()`：`%` → `%%`，`"` → `""`，元字符用双引号包裹
- `findGlobalOpenclaw` npm prefix 查找也走兼容层
- `getOpenClawVersionStrict()`：非 ENOENT 向上 throw 真实错误
- `ensureOpenClawCompat` 和 `info` 都用 strict 版，不再误报
- macOS/Linux 不受影响

## 测试

597 tests passing