### PR TITLE
fix: route deliver by kind — buffer blocks/final, send tool immediately

### DIFF
--- a/openclaw-channel-dmwork/src/__tests__/deliver-buffer.test.ts
+++ b/openclaw-channel-dmwork/src/__tests__/deliver-buffer.test.ts
@@ -3,14 +3,14 @@ import { describe, it, expect, vi } from "vitest";
 /**
  * Unit tests for the deliver buffer pattern used in handleInboundMessage.
  *
- * The deliver callback is a closure inside handleInboundMessage, so we
- * extract and test the core logic via pure helper functions that mirror
- * the production behavior:
+ * The deliver callback uses info.kind to decide behavior:
+ * - "tool"  → send immediately via resolveAndSendText (verbose output)
+ * - "block" / "final" / other → buffer text (overwrite), send once in finally
  *
- * - Text payloads are buffered (each deliver call overwrites the previous)
- * - Media payloads are sent immediately with dedup via sentMediaUrls
- * - After the dispatcher finishes, the finally block sends the last buffered text
- * - If onError fires, it clears the buffer to prevent stale text from being sent
+ * - isReasoning payloads are skipped entirely
+ * - Media payloads are always sent immediately with dedup
+ * - The finally block sends the last buffered text after dispatcher finishes
+ * - onError clears the buffer to prevent stale text
  */
 
 // ---- helpers that mirror the production logic in inbound.ts ----
@@ -26,12 +26,22 @@ function makeDeliver(
   deliverBuffer: ReturnType<typeof createDeliverBuffer>,
   sentMediaUrls: Set<string>,
   sendMediaFn: (url: string) => Promise<void>,
+  sendTextFn: (text: string) => Promise<void>,
 ) {
-  return async (payload: {
-    text?: string;
-    mediaUrls?: string[];
-    mediaUrl?: string;
-  }) => {
+  return async (
+    payload: {
+      text?: string;
+      mediaUrls?: string[];
+      mediaUrl?: string;
+      isReasoning?: boolean;
+    },
+    info?: { kind?: string },
+  ) => {
+    // Skip reasoning blocks
+    if (payload.isReasoning) return;
+
+    const kind = info?.kind ?? "final";
+
     // Media: send immediately with dedup
     const outboundMediaUrls = [
       ...(payload.mediaUrls ?? []),
@@ -48,10 +58,18 @@ function makeDeliver(
       }
     }
 
-    // Text: buffer only
+    // Text handling based on kind
     const content = payload.text?.trim() ?? "";
     if (!content && outboundMediaUrls.length > 0) return;
     if (!content) return;
+
+    if (kind === "tool") {
+      // Verbose tool call output: send immediately
+      await sendTextFn(content);
+      return;
+    }
+
+    // kind === "block" / "final" / anything else: buffer, send once after dispatcher finishes
     deliverBuffer.lastText = content;
   };
 }
@@ -62,6 +80,7 @@ function makeOnError(
 ) {
   return async (_err: unknown) => {
     deliverBuffer.lastText = null;
+    deliverBuffer.textSent = true;
     await sendErrorFn();
   };
 }
@@ -79,28 +98,144 @@ async function runFinally(
 // ---- tests ----
 
 describe("deliver buffer pattern", () => {
-  it("normal flow: multiple deliver calls buffer text, finally sends only the last", async () => {
+  it("block kind: buffers text without sending", async () => {
     const deliverBuffer = createDeliverBuffer();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
 
-    // Simulate dispatcher calling deliver multiple times with progressive text
-    await deliver({ text: "Hello" });
-    await deliver({ text: "Hello, how are you" });
-    await deliver({ text: "Hello, how are you? I'm here to help." });
+    await deliver({ text: "Hello" }, { kind: "block" });
+    await deliver({ text: "Hello, how are you" }, { kind: "block" });
+    await deliver({ text: "Hello, how are you? I'm here to help." }, { kind: "block" });
 
-    // Text should NOT have been sent yet
+    // Text should NOT have been sent
     expect(sendText).not.toHaveBeenCalled();
+    // Buffer should have the latest text
     expect(deliverBuffer.lastText).toBe("Hello, how are you? I'm here to help.");
+    expect(deliverBuffer.textSent).toBe(false);
 
-    // Simulate finally block
+    // finally block sends the buffered text
     await runFinally(deliverBuffer, sendText);
-
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(sendText).toHaveBeenCalledWith("Hello, how are you? I'm here to help.");
     expect(deliverBuffer.textSent).toBe(true);
+  });
+
+  it("final kind: buffers text, sends via finally", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+
+    await deliver({ text: "Final answer" }, { kind: "final" });
+
+    // final is buffered, NOT sent immediately
+    expect(sendText).not.toHaveBeenCalled();
+    expect(deliverBuffer.lastText).toBe("Final answer");
+
+    // finally block sends it
+    await runFinally(deliverBuffer, sendText);
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith("Final answer");
+  });
+
+  it("tool kind: sends text immediately, does not affect buffer", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+
+    await deliver({ text: "Tool output: file listing..." }, { kind: "tool" });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith("Tool output: file listing...");
+    // tool does NOT set textSent — final text should still be sent via finally
+    expect(deliverBuffer.textSent).toBe(false);
+    expect(deliverBuffer.lastText).toBeNull();
+  });
+
+  it("tool then final: tool sent immediately, final sent via finally", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+
+    // Tool output sent immediately
+    await deliver({ text: "🔧 exec: ls" }, { kind: "tool" });
+    expect(sendText).toHaveBeenCalledTimes(1);
+
+    // Block and final buffered
+    await deliver({ text: "Checking files..." }, { kind: "block" });
+    await deliver({ text: "Here are your files: ..." }, { kind: "final" });
+    expect(sendText).toHaveBeenCalledTimes(1); // still 1, final buffered
+
+    // finally sends the last buffered text
+    await runFinally(deliverBuffer, sendText);
+    expect(sendText).toHaveBeenCalledTimes(2);
+    expect(sendText).toHaveBeenLastCalledWith("Here are your files: ...");
+  });
+
+  it("undefined kind falls back to buffer (sends via finally)", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+
+    // No info parameter at all
+    await deliver({ text: "Fallback text" });
+
+    expect(sendText).not.toHaveBeenCalled();
+    expect(deliverBuffer.lastText).toBe("Fallback text");
+
+    await runFinally(deliverBuffer, sendText);
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith("Fallback text");
+  });
+
+  it("isReasoning: skips entirely", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+
+    await deliver({ text: "Internal reasoning...", isReasoning: true }, { kind: "block" });
+    await deliver({ text: "More reasoning", isReasoning: true }, { kind: "final" });
+
+    expect(sendText).not.toHaveBeenCalled();
+    expect(deliverBuffer.lastText).toBeNull();
+
+    await runFinally(deliverBuffer, sendText);
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("blocks then final: all buffered, finally sends last final", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+
+    // Streaming blocks
+    await deliver({ text: "Part 1" }, { kind: "block" });
+    await deliver({ text: "Part 1 Part 2" }, { kind: "block" });
+    expect(sendText).not.toHaveBeenCalled();
+    expect(deliverBuffer.lastText).toBe("Part 1 Part 2");
+
+    // Final arrives — also buffered (overwrites block buffer)
+    await deliver({ text: "Complete response" }, { kind: "final" });
+    expect(sendText).not.toHaveBeenCalled();
+    expect(deliverBuffer.lastText).toBe("Complete response");
+
+    // finally block sends the last buffered text
+    await runFinally(deliverBuffer, sendText);
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith("Complete response");
   });
 
   it("onError clears buffer so finally does not send stale text", async () => {
@@ -109,17 +244,18 @@ describe("deliver buffer pattern", () => {
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
     const sendError = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
     const onError = makeOnError(deliverBuffer, sendError);
 
     // Partial text buffered before error
-    await deliver({ text: "Partial response from AI..." });
+    await deliver({ text: "Partial response from AI..." }, { kind: "block" });
     expect(deliverBuffer.lastText).toBe("Partial response from AI...");
 
     // onError fires
     await onError(new Error("AI generation failed"));
 
     expect(deliverBuffer.lastText).toBeNull();
+    expect(deliverBuffer.textSent).toBe(true);
     expect(sendError).toHaveBeenCalledTimes(1);
 
     // finally block — should NOT send anything
@@ -132,15 +268,15 @@ describe("deliver buffer pattern", () => {
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
 
-    await deliver({ mediaUrl: "https://example.com/img1.png" });
+    await deliver({ mediaUrl: "https://example.com/img1.png" }, { kind: "final" });
     await deliver({
       mediaUrls: [
         "https://example.com/img2.png",
         "https://example.com/img3.png",
       ],
-    });
+    }, { kind: "tool" });
 
     // Media sent immediately — three calls total
     expect(sendMedia).toHaveBeenCalledTimes(3);
@@ -160,10 +296,11 @@ describe("deliver buffer pattern", () => {
     const deliverBuffer = createDeliverBuffer();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
 
-    await deliver({ mediaUrl: "https://example.com/img.png" });
-    await deliver({ mediaUrl: "https://example.com/img.png" });
+    await deliver({ mediaUrl: "https://example.com/img.png" }, { kind: "block" });
+    await deliver({ mediaUrl: "https://example.com/img.png" }, { kind: "final" });
 
     // Only one call — second was deduped
     expect(sendMedia).toHaveBeenCalledTimes(1);

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1499,21 +1499,138 @@ export async function handleInboundMessage(params: {
   };
   const sentMediaUrls = new Set<string>();
 
+  // --- Shared helper: resolve mentions and send text ---
+  const resolveAndSendText = async (content: string) => {
+    let replyMentionUids: string[] = [];
+    let replyMentionEntities: MentionEntity[] = [];
+    let finalContent = content;
+
+    if (isGroup) {
+      const structuredMentions = parseStructuredMentions(content);
+
+      if (structuredMentions.length > 0) {
+        // v2 path: LLM used @[uid:name] format
+        const validUids = new Set(uidToNameMap.keys());
+        const converted = convertStructuredMentions(
+          content,
+          structuredMentions,
+          validUids,
+        );
+        finalContent = converted.content;
+        replyMentionEntities = [...converted.entities];
+
+        // Mixed scenario: check for remaining @name in converted content
+        const remaining = buildEntitiesFromFallback(finalContent, memberMap);
+        const existingOffsets = new Set(replyMentionEntities.map((e) => e.offset));
+        for (const rm of remaining.entities) {
+          if (!existingOffsets.has(rm.offset)) {
+            replyMentionEntities.push(rm);
+          }
+        }
+
+        log?.debug?.(
+          `dmwork: [REPLY] structured mentions: ${structuredMentions.length}, fallback: ${remaining.entities.length}`,
+        );
+      } else {
+        // v1 fallback path: LLM used @name format
+        const contentMentions = extractMentionMatches(content);
+
+        const unresolvedNames: { name: string; index: number }[] = [];
+
+        const resolveMention = (name: string): { uid: string | null; newContent: string } => {
+          const uid = findUidByName(name, memberMap);
+          let newContent = finalContent;
+
+          if (uid) {
+            return { uid, newContent };
+          } else if (/^[a-f0-9]{32}$/i.test(name)) {
+            const displayName = uidToNameMap.get(name);
+            if (displayName) {
+              newContent = newContent.replace(`@${name}`, `@${displayName}`);
+              return { uid: name, newContent };
+            }
+            return { uid: name, newContent };
+          } else if (/^[a-zA-Z0-9_]+$/.test(name)) {
+            const displayName = uidToNameMap.get(name);
+            if (displayName) {
+              newContent = newContent.replace(`@${name}`, `@${displayName}`);
+              return { uid: name, newContent };
+            }
+            return { uid: name, newContent };
+          }
+          return { uid: null, newContent };
+        };
+
+        const resolvedUids: (string | null)[] = [];
+        for (const mention of contentMentions) {
+          const name = mention.slice(1);
+          const result = resolveMention(name);
+          finalContent = result.newContent;
+          resolvedUids.push(result.uid);
+          if (!result.uid) {
+            unresolvedNames.push({ name, index: resolvedUids.length - 1 });
+          }
+        }
+
+        if (unresolvedNames.length > 0) {
+          log?.info?.(`dmwork: [REPLY] ${unresolvedNames.length} unresolved names, force refreshing cache...`);
+          const refreshed = await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", forceRefresh: true, log });
+          if (refreshed) {
+            for (const { name, index } of unresolvedNames) {
+              const uid = findUidByName(name, memberMap);
+              if (uid) {
+                resolvedUids[index] = uid;
+              }
+            }
+          }
+        }
+
+        replyMentionUids = resolvedUids.filter((uid): uid is string => uid !== null);
+        const fallbackResult = buildEntitiesFromFallback(finalContent, memberMap);
+        replyMentionEntities = fallbackResult.entities;
+      }
+
+      // Sort entities by offset and rebuild uids from sorted entities
+      if (replyMentionEntities.length > 0) {
+        replyMentionEntities.sort((a, b) => a.offset - b.offset);
+        replyMentionUids = replyMentionEntities.map((e) => e.uid);
+      }
+    }
+
+    // Detect @all/@所有人 in final content
+    const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalContent);
+
+    await sendMessage({
+      apiUrl: account.config.apiUrl,
+      botToken: account.config.botToken ?? "",
+      channelId: replyChannelId,
+      channelType: replyChannelType,
+      content: finalContent,
+      ...(replyMentionUids.length > 0 ? { mentionUids: replyMentionUids } : {}),
+      ...(replyMentionEntities.length > 0 ? { mentionEntities: replyMentionEntities } : {}),
+      mentionAll: hasAtAll || undefined,
+    });
+    statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
+  };
+
   try {
     await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
       cfg: config,
       replyOptions: {},
       dispatcherOptions: {
-        // Note: core's createNormalizedOutboundDeliverer currently swallows the
-        // `info` argument (kind, etc.) before calling this deliver callback.
-        // If that changes upstream, re-add the second parameter here.
         deliver: async (payload: {
           text?: string;
           mediaUrls?: string[];
           mediaUrl?: string;
           replyToId?: string | null;
-        }) => {
+          isReasoning?: boolean;
+        }, info?: { kind?: string }) => {
+          // Skip reasoning blocks
+          if (payload.isReasoning) return;
+
+          const kind = info?.kind ?? "final";
+
           // --- Media: send immediately (no edit/forward issue) with dedup ---
           const outboundMediaUrls = resolveOutboundMediaUrls(payload);
           for (const mediaUrl of outboundMediaUrls) {
@@ -1533,7 +1650,7 @@ export async function handleInboundMessage(params: {
             }
           }
 
-          // --- Text: buffer only, will be sent once after dispatcher finishes ---
+          // --- Text handling based on kind ---
           const content = payload.text?.trim() ?? "";
           if (!content && outboundMediaUrls.length > 0) {
             statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
@@ -1541,9 +1658,16 @@ export async function handleInboundMessage(params: {
           }
           if (!content) return;
 
-          // Overwrite buffer with latest cumulative text
+          if (kind === "tool") {
+            // Verbose tool call output: send immediately
+            await resolveAndSendText(content);
+            log?.info?.(`dmwork: [deliver] tool text sent (${content.length} chars)`);
+            return;
+          }
+
+          // kind === "block" / "final" / anything else: buffer, send only once after dispatcher finishes
           deliverBuffer.lastText = content;
-          log?.debug?.(`dmwork: [deliver-buffer] text buffered (${content.length} chars)`);
+          log?.debug?.(`dmwork: [deliver-buffer] ${kind} text buffered (${content.length} chars)`);
         },
         onError: async (err: unknown, info: { kind: string }) => {
           clearInterval(typingInterval);
@@ -1566,125 +1690,12 @@ export async function handleInboundMessage(params: {
       },
     });
   } finally {
-    // --- Final send: deliver buffered text even if dispatcher threw ---
+    // --- Final send: deliver buffered text if only blocks arrived (no final/tool) ---
     if (deliverBuffer.lastText && !deliverBuffer.textSent) {
       deliverBuffer.textSent = true;
       try {
-        const content = deliverBuffer.lastText;
-
-        // Build mentionUids + entities from @mentions in content
-        // Supports both @[uid:name] (v2 structured) and @name (v1 fallback)
-        let replyMentionUids: string[] = [];
-        let replyMentionEntities: MentionEntity[] = [];
-        let finalContent = content;
-
-        if (isGroup) {
-          const structuredMentions = parseStructuredMentions(content);
-
-          if (structuredMentions.length > 0) {
-            // v2 path: LLM used @[uid:name] format
-            const validUids = new Set(uidToNameMap.keys());
-            const converted = convertStructuredMentions(
-              content,
-              structuredMentions,
-              validUids,
-            );
-            finalContent = converted.content;
-            replyMentionEntities = [...converted.entities];
-
-            // Mixed scenario: check for remaining @name in converted content
-            const remaining = buildEntitiesFromFallback(finalContent, memberMap);
-            const existingOffsets = new Set(replyMentionEntities.map((e) => e.offset));
-            for (const rm of remaining.entities) {
-              if (!existingOffsets.has(rm.offset)) {
-                replyMentionEntities.push(rm);
-              }
-            }
-
-            log?.debug?.(
-              `dmwork: [REPLY] structured mentions: ${structuredMentions.length}, fallback: ${remaining.entities.length}`,
-            );
-          } else {
-            // v1 fallback path: LLM used @name format
-            const contentMentions = extractMentionMatches(content);
-
-            const unresolvedNames: { name: string; index: number }[] = [];
-
-            const resolveMention = (name: string): { uid: string | null; newContent: string } => {
-              const uid = findUidByName(name, memberMap);
-              let newContent = finalContent;
-
-              if (uid) {
-                return { uid, newContent };
-              } else if (/^[a-f0-9]{32}$/i.test(name)) {
-                const displayName = uidToNameMap.get(name);
-                if (displayName) {
-                  newContent = newContent.replace(`@${name}`, `@${displayName}`);
-                  return { uid: name, newContent };
-                }
-                return { uid: name, newContent };
-              } else if (/^[a-zA-Z0-9_]+$/.test(name)) {
-                const displayName = uidToNameMap.get(name);
-                if (displayName) {
-                  newContent = newContent.replace(`@${name}`, `@${displayName}`);
-                  return { uid: name, newContent };
-                }
-                return { uid: name, newContent };
-              }
-              return { uid: null, newContent };
-            };
-
-            const resolvedUids: (string | null)[] = [];
-            for (const mention of contentMentions) {
-              const name = mention.slice(1);
-              const result = resolveMention(name);
-              finalContent = result.newContent;
-              resolvedUids.push(result.uid);
-              if (!result.uid) {
-                unresolvedNames.push({ name, index: resolvedUids.length - 1 });
-              }
-            }
-
-            if (unresolvedNames.length > 0) {
-              log?.info?.(`dmwork: [REPLY] ${unresolvedNames.length} unresolved names, force refreshing cache...`);
-              const refreshed = await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", forceRefresh: true, log });
-              if (refreshed) {
-                for (const { name, index } of unresolvedNames) {
-                  const uid = findUidByName(name, memberMap);
-                  if (uid) {
-                    resolvedUids[index] = uid;
-                  }
-                }
-              }
-            }
-
-            replyMentionUids = resolvedUids.filter((uid): uid is string => uid !== null);
-            const fallbackResult = buildEntitiesFromFallback(finalContent, memberMap);
-            replyMentionEntities = fallbackResult.entities;
-          }
-
-          // Sort entities by offset and rebuild uids from sorted entities
-          if (replyMentionEntities.length > 0) {
-            replyMentionEntities.sort((a, b) => a.offset - b.offset);
-            replyMentionUids = replyMentionEntities.map((e) => e.uid);
-          }
-        }
-
-        // Detect @all/@所有人 in final content
-        const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalContent);
-
-        await sendMessage({
-          apiUrl: account.config.apiUrl,
-          botToken: account.config.botToken ?? "",
-          channelId: replyChannelId,
-          channelType: replyChannelType,
-          content: finalContent,
-          ...(replyMentionUids.length > 0 ? { mentionUids: replyMentionUids } : {}),
-          ...(replyMentionEntities.length > 0 ? { mentionEntities: replyMentionEntities } : {}),
-          mentionAll: hasAtAll || undefined,
-        });
-        log?.info?.(`dmwork: [deliver-buffer] final text sent (${finalContent.length} chars)`);
-        statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
+        await resolveAndSendText(deliverBuffer.lastText);
+        log?.info?.(`dmwork: [deliver-buffer] fallback text sent (${deliverBuffer.lastText.length} chars)`);
       } catch (finalSendErr) {
         log?.error?.(`dmwork: [deliver-buffer] final text send failed: ${String(finalSendErr)}`);
       }


### PR DESCRIPTION
## Problem
1. PR #214 fixed the editMessage forward bug by buffering all deliver text, but broke verbose mode — tool call outputs were silently discarded.
2. First fix (send tool+final immediately) caused multiple text messages per reply because core's `dispatchReplyWithBufferedBlockDispatcher` emits multiple `final` kind deliveries (one per tool-call boundary).

## Root Cause
Core's BufferedBlockDispatcher flushes accumulated text as independent `final` deliveries at each tool boundary. With 5 tool calls, there are 5+1 `final` deliveries. Only `tool` kind should be sent immediately (verbose output); all text (`block`/`final`) should be buffered and sent once.

## Solution
Route deliver by `info.kind`:
- **`tool`** → send immediately via `resolveAndSendText()` (verbose tool output)
- **`block` / `final` / other** → buffer text (overwrite), send once in `finally` after dispatcher finishes
- **`isReasoning`** → skip

This gives:
- ✅ Verbose mode: tool call info sent as individual messages
- ✅ Final reply: single message with complete text
- ✅ Forward/copy: correct content (no editMessage)
- ✅ Non-verbose mode: single message, no intermediate output

## Changes
- `inbound.ts`: kind-based routing, `resolveAndSendText()` extraction
- `deliver-buffer.test.ts`: 11 tests covering kind routing, tool+final flow, reasoning skip, media dedup, error handling

## Testing
- 609/609 tests passing
- `npx tsc --noEmit` clean
- Deployed and verified on Thomas node (verbose on + off)

Fixes #213