### PR TITLE
fix: trust structured mention uids without cache validation

### DIFF
--- a/openclaw-channel-dmwork/src/actions.test.ts
+++ b/openclaw-channel-dmwork/src/actions.test.ts
@@ -307,7 +307,7 @@ describe("handleDmworkMessageAction", () => {
   });
 
   describe("send — invalid uid in v2 (uid not in uidToNameMap)", () => {
-    it("should convert format but not create entity for unknown uid", async () => {
+    it("should create entities for all structured mentions including unknown uids", async () => {
       let sentPayload: any = null;
       globalThis.fetch = mockFetch({
         "/v1/bot/sendMessage": async (_url, init) => {
@@ -333,10 +333,11 @@ describe("handleDmworkMessageAction", () => {
       expect(result.ok).toBe(true);
       // Format is still converted for both
       expect(sentPayload.payload.content).toBe("Hello @Ghost and @bob!");
-      // Only valid uid gets an entity
+      // All structured mentions get entities (uid trusted from LLM)
       const entities = sentPayload.payload.mention.entities;
-      expect(entities).toHaveLength(1);
-      expect(entities[0]).toMatchObject({ uid: "uid_bob" });
+      expect(entities).toHaveLength(2);
+      expect(entities[0]).toMatchObject({ uid: "uid_unknown" });
+      expect(entities[1]).toMatchObject({ uid: "uid_bob" });
     });
   });
 

--- a/openclaw-channel-dmwork/src/actions.ts
+++ b/openclaw-channel-dmwork/src/actions.ts
@@ -189,8 +189,7 @@ async function handleSend(params: {
       if (uidToNameMap) {
         const structuredMentions = parseStructuredMentions(finalMessage);
         if (structuredMentions.length > 0) {
-          const validUids = new Set(uidToNameMap.keys());
-          const converted = convertStructuredMentions(finalMessage, structuredMentions, validUids);
+          const converted = convertStructuredMentions(finalMessage, structuredMentions);
           finalMessage = converted.content;
           mentionEntities = [...converted.entities];
           mentionUids = [...converted.uids];

--- a/openclaw-channel-dmwork/src/channel.test.ts
+++ b/openclaw-channel-dmwork/src/channel.test.ts
@@ -292,15 +292,13 @@ describe("sendText v2 mention processing logic", () => {
     const { parseStructuredMentions, convertStructuredMentions, buildEntitiesFromFallback } = await import("./mention-utils.js");
 
     const content = "请 @[abc123:张三] 确认";
-    const uidToNameMap = new Map([["abc123", "张三"]]);
     const memberMap = new Map([["张三", "abc123"]]);
-    const validUids = new Set(uidToNameMap.keys());
 
     // v2 path
     const structuredMentions = parseStructuredMentions(content);
     expect(structuredMentions).toHaveLength(1);
 
-    const converted = convertStructuredMentions(content, structuredMentions, validUids);
+    const converted = convertStructuredMentions(content, structuredMentions);
     expect(converted.content).toBe("请 @张三 确认");
     expect(converted.entities).toHaveLength(1);
     expect(converted.entities[0]).toEqual({ uid: "abc123", offset: 2, length: 3 });
@@ -315,15 +313,13 @@ describe("sendText v2 mention processing logic", () => {
     const { parseStructuredMentions, convertStructuredMentions, buildEntitiesFromFallback } = await import("./mention-utils.js");
 
     const content = "@[abc:张三] 和 @李四";
-    const uidToNameMap = new Map([["abc", "张三"]]);
     const memberMap = new Map([["张三", "abc"], ["李四", "def"]]);
-    const validUids = new Set(uidToNameMap.keys());
 
     // v2 path
     const structuredMentions = parseStructuredMentions(content);
     expect(structuredMentions).toHaveLength(1);
 
-    const converted = convertStructuredMentions(content, structuredMentions, validUids);
+    const converted = convertStructuredMentions(content, structuredMentions);
     expect(converted.content).toBe("@张三 和 @李四");
 
     // v1 fallback resolves @李四
@@ -359,11 +355,10 @@ describe("sendText v2 mention processing logic", () => {
     const { parseStructuredMentions, convertStructuredMentions, buildEntitiesFromFallback } = await import("./mention-utils.js");
 
     const content = "@[abc:张三] @所有人";
-    const validUids = new Set(["abc"]);
     const memberMap = new Map([["张三", "abc"]]);
 
     const structured = parseStructuredMentions(content);
-    const converted = convertStructuredMentions(content, structured, validUids);
+    const converted = convertStructuredMentions(content, structured);
     expect(converted.content).toBe("@张三 @所有人");
 
     const fallback = buildEntitiesFromFallback(converted.content, memberMap);

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -424,8 +424,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         // v2 path: convert @[uid:name] → @name + entities
         const structuredMentions = parseStructuredMentions(finalContent);
         if (structuredMentions.length > 0) {
-          const validUids = new Set(uidToNameMap.keys());
-          const converted = convertStructuredMentions(finalContent, structuredMentions, validUids);
+          const converted = convertStructuredMentions(finalContent, structuredMentions);
           finalContent = converted.content;
           mentionEntities = [...converted.entities];
           for (const uid of converted.uids) {

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1226,7 +1226,9 @@ export async function handleInboundMessage(params: {
       const botName = uidToNameMap.get(botUid);
       if (botName) {
         const escaped = botName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const re = new RegExp(`(?<=^|[^\\w])@${escaped}(?![\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F.\\-])`);
+        // Lookbehind: exclude ASCII word chars AND Unicode letters/CJK — consistent with MENTION_PATTERN.
+        // Without CJK exclusion, '你好@BotName' would be a false positive (CJK is not \w).
+        const re = new RegExp(`(?<=^|[^\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F])@${escaped}(?![\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F.\\-])`);
         if (re.test(rawBody)) {
           isMentioned = true;
           isExplicitBotMention = true;

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1224,10 +1224,13 @@ export async function handleInboundMessage(params: {
     // that don't populate the mention payload (e.g. bot-to-bot messages).
     if (!isMentioned && rawBody && message.payload?.type === MessageType.Text) {
       const botName = uidToNameMap.get(botUid);
-      if (botName) {
+      if (botName?.trim()) {
         const escaped = botName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        // Lookbehind: exclude ASCII word chars AND Unicode letters/CJK — consistent with MENTION_PATTERN.
-        // Without CJK exclusion, '你好@BotName' would be a false positive (CJK is not \w).
+        // Lookbehind: more conservative than MENTION_PATTERN — also excludes CJK and extended
+        // Latin ranges so that adjacent Chinese text (e.g. '你好@BotName') is not a false
+        // positive.  Trade-off: '你好@BotName' without payload.mention is treated as non-mention;
+        // this is intentional — a false positive (spurious bot activation) is worse than a false
+        // negative (user simply re-sends with a space before @).
         const re = new RegExp(`(?<=^|[^\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F])@${escaped}(?![\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F.\\-])`);
         if (re.test(rawBody)) {
           isMentioned = true;

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1218,6 +1218,22 @@ export async function handleInboundMessage(params: {
     const mentionAll: boolean = mentionAllRaw === true || mentionAllRaw === 1;
     isMentioned = mentionAll || mentionUids.includes(botUid);
     isExplicitBotMention = mentionUids.includes(botUid);
+
+    // Defensive fallback: if payload.mention is missing/empty but the message
+    // text contains @botName, treat it as a mention.  This covers old senders
+    // that don't populate the mention payload (e.g. bot-to-bot messages).
+    if (!isMentioned && rawBody && message.payload?.type === MessageType.Text) {
+      const botName = uidToNameMap.get(botUid);
+      if (botName) {
+        const escaped = botName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const re = new RegExp(`(?<=^|[^\\w])@${escaped}(?![\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F.\\-])`);
+        if (re.test(rawBody)) {
+          isMentioned = true;
+          isExplicitBotMention = true;
+          log?.debug?.(`dmwork: [RECV] isMentioned set by text fallback (@${botName})`);
+        }
+      }
+    }
   }
 
   if (isGroup && requireMention) {
@@ -1541,11 +1557,9 @@ export async function handleInboundMessage(params: {
 
       if (structuredMentions.length > 0) {
         // v2 path: LLM used @[uid:name] format
-        const validUids = new Set(uidToNameMap.keys());
         const converted = convertStructuredMentions(
           content,
           structuredMentions,
-          validUids,
         );
         finalContent = converted.content;
         replyMentionEntities = [...converted.entities];

--- a/openclaw-channel-dmwork/src/mention-utils.test.ts
+++ b/openclaw-channel-dmwork/src/mention-utils.test.ts
@@ -751,3 +751,42 @@ describe("convertContentForLLM — 空格昵称支持", () => {
     expect(result).toBe("@[uid_anyang:Anyang Su] 你好");
   });
 });
+
+describe("inbound text fallback regex — CJK boundary fix", () => {
+  // Mirrors the regex in inbound.ts text fallback block.
+  // Lookbehind must exclude CJK so that "你好@BotName" is NOT a false positive.
+  function buildFallbackRegex(botName: string): RegExp {
+    const escaped = botName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(
+      `(?<=^|[^\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F])@${escaped}(?![\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F.\\-])`
+    );
+  }
+
+  it("matches @BotName at start of message", () => {
+    expect(buildFallbackRegex("Jeff").test("@Jeff 你好")).toBe(true);
+  });
+
+  it("matches @BotName after whitespace", () => {
+    expect(buildFallbackRegex("Jeff").test("嗨 @Jeff 能帮我吗")).toBe(true);
+  });
+
+  it("does NOT match when CJK char immediately precedes @", () => {
+    expect(buildFallbackRegex("Jeff").test("你好@Jeff")).toBe(false);
+  });
+
+  it("does NOT match when underscore precedes @ (consistent with \\w exclusion)", () => {
+    expect(buildFallbackRegex("Jeff").test("foo_@Jeff")).toBe(false);
+  });
+
+  it("does NOT match when @BotName is followed by word char (no false positive for @Jefferson)", () => {
+    expect(buildFallbackRegex("Jeff").test("@Jefferson")).toBe(false);
+  });
+
+  it("matches @BotName followed by punctuation", () => {
+    expect(buildFallbackRegex("Jeff").test("@Jeff，帮我看一下")).toBe(true);
+  });
+
+  it("matches with CJK bot name (bot name itself may be CJK)", () => {
+    expect(buildFallbackRegex("张三").test("@张三 你好")).toBe(true);
+  });
+});

--- a/openclaw-channel-dmwork/src/mention-utils.test.ts
+++ b/openclaw-channel-dmwork/src/mention-utils.test.ts
@@ -168,8 +168,7 @@ describe("convertStructuredMentions", () => {
   it("应正确转换单个 mention", () => {
     const text = "Hi @[uid_bob:Bob]!";
     const mentions = parseStructuredMentions(text);
-    const validUids = new Set(["uid_bob"]);
-    const result = convertStructuredMentions(text, mentions, validUids);
+    const result = convertStructuredMentions(text, mentions);
 
     expect(result.content).toBe("Hi @Bob!");
     expect(result.entities).toEqual([
@@ -182,8 +181,7 @@ describe("convertStructuredMentions", () => {
   it("应处理多个 mention", () => {
     const text = "@[uid_a:Alice] and @[uid_b:Bob]";
     const mentions = parseStructuredMentions(text);
-    const validUids = new Set(["uid_a", "uid_b"]);
-    const result = convertStructuredMentions(text, mentions, validUids);
+    const result = convertStructuredMentions(text, mentions);
 
     expect(result.content).toBe("@Alice and @Bob");
     expect(result.entities).toHaveLength(2);
@@ -193,24 +191,35 @@ describe("convertStructuredMentions", () => {
     expect(result.content.substring(11, 15)).toBe("@Bob");
   });
 
-  it("应处理无效 uid（不加入 entities 但保留 @name 文本）", () => {
+  it("should generate entities for all structured mentions including unknown uids", () => {
     const text = "@[fake:Bob] and @[uid_bob:Bob]";
     const mentions = parseStructuredMentions(text);
-    const validUids = new Set(["uid_bob"]);
-    const result = convertStructuredMentions(text, mentions, validUids);
+    const result = convertStructuredMentions(text, mentions);
 
     expect(result.content).toBe("@Bob and @Bob");
     expect(result.entities).toEqual([
+      { uid: "fake", offset: 0, length: 4 },
       { uid: "uid_bob", offset: 9, length: 4 },
     ]);
-    expect(result.content.substring(9, 13)).toBe("@Bob");
+    expect(result.uids).toEqual(["fake", "uid_bob"]);
+  });
+
+  it("should generate entities for known uid", () => {
+    const text = "Hi @[uid_bob:Bob]!";
+    const mentions = parseStructuredMentions(text);
+    const result = convertStructuredMentions(text, mentions);
+
+    expect(result.content).toBe("Hi @Bob!");
+    expect(result.entities).toEqual([
+      { uid: "uid_bob", offset: 3, length: 4 },
+    ]);
+    expect(result.uids).toEqual(["uid_bob"]);
   });
 
   it("应处理中文用户名", () => {
     const text = "你好 @[uid_chen:陈皮皮] 和 @[uid_bob:Bob]";
     const mentions = parseStructuredMentions(text);
-    const validUids = new Set(["uid_chen", "uid_bob"]);
-    const result = convertStructuredMentions(text, mentions, validUids);
+    const result = convertStructuredMentions(text, mentions);
 
     expect(result.content).toBe("你好 @陈皮皮 和 @Bob");
     expect(result.entities).toHaveLength(2);
@@ -398,6 +407,63 @@ describe("convertContentForLLM", () => {
   });
 });
 
+describe("inbound text fallback regex", () => {
+  function makeFallbackRegex(botName: string): RegExp {
+    const escaped = botName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(?<=^|[^\\w])@${escaped}(?![\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F.\\-])`);
+  }
+
+  it("@BotName at start of string → should match", () => {
+    const re = makeFallbackRegex("BotName");
+    expect(re.test("@BotName")).toBe(true);
+  });
+
+  it("Hello @BotName (after space) → should match", () => {
+    const re = makeFallbackRegex("BotName");
+    expect(re.test("Hello @BotName")).toBe(true);
+  });
+
+  it("Hello @BotName! (followed by punctuation) → should match", () => {
+    const re = makeFallbackRegex("BotName");
+    expect(re.test("Hello @BotName!")).toBe(true);
+  });
+
+  it("@BotName at end → should match", () => {
+    const re = makeFallbackRegex("BotName");
+    expect(re.test("@BotName at end")).toBe(true);
+  });
+
+  it("foo@BotName (no space before @) → should NOT match (email-like)", () => {
+    const re = makeFallbackRegex("BotName");
+    expect(re.test("foo@BotName")).toBe(false);
+  });
+
+  it("word@BotName.com → should NOT match", () => {
+    const re = makeFallbackRegex("BotName");
+    expect(re.test("word@BotName.com")).toBe(false);
+  });
+
+  it("@BotNameExtra (name is prefix of longer word) → should NOT match", () => {
+    const re = makeFallbackRegex("BotName");
+    expect(re.test("@BotNameExtra")).toBe(false);
+  });
+
+  it("@BotName followed by CJK character → should NOT match", () => {
+    const re = makeFallbackRegex("BotName");
+    expect(re.test("@BotName你好")).toBe(false);
+  });
+
+  it("Chinese bot name like @小助手 → should match", () => {
+    const re = makeFallbackRegex("小助手");
+    expect(re.test("@小助手")).toBe(true);
+  });
+
+  it("@小助手好 (followed by CJK) → should NOT match", () => {
+    const re = makeFallbackRegex("小助手");
+    expect(re.test("@小助手好")).toBe(false);
+  });
+});
+
 describe("buildSenderPrefix", () => {
   it("should return name(uid) when name is found", () => {
     const map = new Map([["uid1", "Alice"]]);
@@ -472,8 +538,7 @@ describe("边界情况", () => {
   it("混合 v2 + fallback 后 uids 顺序", () => {
     const text = "Hi @[uid_chen:Chen] and @Bob";
     const structured = parseStructuredMentions(text);
-    const validUids = new Set(["uid_chen"]);
-    const converted = convertStructuredMentions(text, structured, validUids);
+    const converted = convertStructuredMentions(text, structured);
 
     const memberMap = new Map([["Bob", "uid_bob"]]);
     const remaining = buildEntitiesFromFallback(converted.content, memberMap);

--- a/openclaw-channel-dmwork/src/mention-utils.test.ts
+++ b/openclaw-channel-dmwork/src/mention-utils.test.ts
@@ -204,18 +204,6 @@ describe("convertStructuredMentions", () => {
     expect(result.uids).toEqual(["fake", "uid_bob"]);
   });
 
-  it("should generate entities for known uid", () => {
-    const text = "Hi @[uid_bob:Bob]!";
-    const mentions = parseStructuredMentions(text);
-    const result = convertStructuredMentions(text, mentions);
-
-    expect(result.content).toBe("Hi @Bob!");
-    expect(result.entities).toEqual([
-      { uid: "uid_bob", offset: 3, length: 4 },
-    ]);
-    expect(result.uids).toEqual(["uid_bob"]);
-  });
-
   it("应处理中文用户名", () => {
     const text = "你好 @[uid_chen:陈皮皮] 和 @[uid_bob:Bob]";
     const mentions = parseStructuredMentions(text);
@@ -404,63 +392,6 @@ describe("convertContentForLLM", () => {
     const mention: MentionPayload = { uids: [] };
     const result = convertContentForLLM(content, mention);
     expect(result).toBe("@Alice @Bob");
-  });
-});
-
-describe("inbound text fallback regex", () => {
-  function makeFallbackRegex(botName: string): RegExp {
-    const escaped = botName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    return new RegExp(`(?<=^|[^\\w])@${escaped}(?![\\w\\u4e00-\\u9fff\\u3040-\\u30FF\\uAC00-\\uD7AF\\u00C0-\\u024F.\\-])`);
-  }
-
-  it("@BotName at start of string → should match", () => {
-    const re = makeFallbackRegex("BotName");
-    expect(re.test("@BotName")).toBe(true);
-  });
-
-  it("Hello @BotName (after space) → should match", () => {
-    const re = makeFallbackRegex("BotName");
-    expect(re.test("Hello @BotName")).toBe(true);
-  });
-
-  it("Hello @BotName! (followed by punctuation) → should match", () => {
-    const re = makeFallbackRegex("BotName");
-    expect(re.test("Hello @BotName!")).toBe(true);
-  });
-
-  it("@BotName at end → should match", () => {
-    const re = makeFallbackRegex("BotName");
-    expect(re.test("@BotName at end")).toBe(true);
-  });
-
-  it("foo@BotName (no space before @) → should NOT match (email-like)", () => {
-    const re = makeFallbackRegex("BotName");
-    expect(re.test("foo@BotName")).toBe(false);
-  });
-
-  it("word@BotName.com → should NOT match", () => {
-    const re = makeFallbackRegex("BotName");
-    expect(re.test("word@BotName.com")).toBe(false);
-  });
-
-  it("@BotNameExtra (name is prefix of longer word) → should NOT match", () => {
-    const re = makeFallbackRegex("BotName");
-    expect(re.test("@BotNameExtra")).toBe(false);
-  });
-
-  it("@BotName followed by CJK character → should NOT match", () => {
-    const re = makeFallbackRegex("BotName");
-    expect(re.test("@BotName你好")).toBe(false);
-  });
-
-  it("Chinese bot name like @小助手 → should match", () => {
-    const re = makeFallbackRegex("小助手");
-    expect(re.test("@小助手")).toBe(true);
-  });
-
-  it("@小助手好 (followed by CJK) → should NOT match", () => {
-    const re = makeFallbackRegex("小助手");
-    expect(re.test("@小助手好")).toBe(false);
   });
 });
 
@@ -752,9 +683,10 @@ describe("convertContentForLLM — 空格昵称支持", () => {
   });
 });
 
-describe("inbound text fallback regex — CJK boundary fix", () => {
-  // Mirrors the regex in inbound.ts text fallback block.
-  // Lookbehind must exclude CJK so that "你好@BotName" is NOT a false positive.
+describe("inbound text fallback regex", () => {
+  // Must mirror the regex in inbound.ts text fallback block exactly.
+  // Lookbehind: more conservative than MENTION_PATTERN — also excludes CJK
+  // and extended Latin to avoid false-positive bot activations.
   function buildFallbackRegex(botName: string): RegExp {
     const escaped = botName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     return new RegExp(
@@ -762,6 +694,7 @@ describe("inbound text fallback regex — CJK boundary fix", () => {
     );
   }
 
+  // --- positive cases ---
   it("matches @BotName at start of message", () => {
     expect(buildFallbackRegex("Jeff").test("@Jeff 你好")).toBe(true);
   });
@@ -770,23 +703,49 @@ describe("inbound text fallback regex — CJK boundary fix", () => {
     expect(buildFallbackRegex("Jeff").test("嗨 @Jeff 能帮我吗")).toBe(true);
   });
 
-  it("does NOT match when CJK char immediately precedes @", () => {
-    expect(buildFallbackRegex("Jeff").test("你好@Jeff")).toBe(false);
-  });
-
-  it("does NOT match when underscore precedes @ (consistent with \\w exclusion)", () => {
-    expect(buildFallbackRegex("Jeff").test("foo_@Jeff")).toBe(false);
-  });
-
-  it("does NOT match when @BotName is followed by word char (no false positive for @Jefferson)", () => {
-    expect(buildFallbackRegex("Jeff").test("@Jefferson")).toBe(false);
-  });
-
   it("matches @BotName followed by punctuation", () => {
     expect(buildFallbackRegex("Jeff").test("@Jeff，帮我看一下")).toBe(true);
   });
 
-  it("matches with CJK bot name (bot name itself may be CJK)", () => {
+  it("matches @BotName followed by !", () => {
+    expect(buildFallbackRegex("Jeff").test("Hello @Jeff!")).toBe(true);
+  });
+
+  it("matches CJK bot name", () => {
     expect(buildFallbackRegex("张三").test("@张三 你好")).toBe(true);
+  });
+
+  it("matches @BotName at end of string", () => {
+    expect(buildFallbackRegex("Jeff").test("hey @Jeff")).toBe(true);
+  });
+
+  // --- negative: lookbehind ---
+  it("does NOT match when CJK char immediately precedes @ (intentional conservative)", () => {
+    expect(buildFallbackRegex("Jeff").test("你好@Jeff")).toBe(false);
+  });
+
+  it("does NOT match when underscore precedes @", () => {
+    expect(buildFallbackRegex("Jeff").test("foo_@Jeff")).toBe(false);
+  });
+
+  it("does NOT match email-like foo@BotName", () => {
+    expect(buildFallbackRegex("Jeff").test("foo@Jeff")).toBe(false);
+  });
+
+  // --- negative: lookahead ---
+  it("does NOT match @BotName followed by word char (@Jefferson)", () => {
+    expect(buildFallbackRegex("Jeff").test("@Jefferson")).toBe(false);
+  });
+
+  it("does NOT match @BotName followed by CJK", () => {
+    expect(buildFallbackRegex("Jeff").test("@Jeff你好")).toBe(false);
+  });
+
+  it("does NOT match @BotName followed by dot (domain-like)", () => {
+    expect(buildFallbackRegex("Jeff").test("@Jeff.com")).toBe(false);
+  });
+
+  it("does NOT match CJK bot name followed by CJK", () => {
+    expect(buildFallbackRegex("小助手").test("@小助手好")).toBe(false);
   });
 });

--- a/openclaw-channel-dmwork/src/mention-utils.ts
+++ b/openclaw-channel-dmwork/src/mention-utils.ts
@@ -131,6 +131,9 @@ export function convertStructuredMentions(
     // While the LLM could theoretically hallucinate a uid, the server will
     // reject unknown uids, and filtering here causes cache-miss false
     // negatives that are worse than the low risk of hallucinated uids.
+    // Note: if the LLM hallucinates a uid that happens to be a real (but
+    // unintended) user, that user receives one unexpected notification.
+    // This risk is negligible given dmwork uids are random 32-char hex hashes.
     entities.push({
       uid: m.uid,
       offset: newOffset,

--- a/openclaw-channel-dmwork/src/mention-utils.ts
+++ b/openclaw-channel-dmwork/src/mention-utils.ts
@@ -111,7 +111,6 @@ export interface ConvertResult {
 export function convertStructuredMentions(
   text: string,
   mentions: StructuredMention[],
-  validUids: Set<string>,
 ): ConvertResult {
   const sorted = [...mentions].sort((a, b) => a.offset - b.offset);
 
@@ -127,14 +126,17 @@ export function convertStructuredMentions(
     const newOffset = content.length;
     content += replacement;
 
-    if (validUids.has(m.uid)) {
-      entities.push({
-        uid: m.uid,
-        offset: newOffset,
-        length: replacement.length,
-      });
-      uids.push(m.uid);
-    }
+    // Always generate entity for structured mentions — Structured mentions
+    // are generated from the member list injected into the system prompt.
+    // While the LLM could theoretically hallucinate a uid, the server will
+    // reject unknown uids, and filtering here causes cache-miss false
+    // negatives that are worse than the low risk of hallucinated uids.
+    entities.push({
+      uid: m.uid,
+      offset: newOffset,
+      length: replacement.length,
+    });
+    uids.push(m.uid);
 
     cursor = m.offset + m.length;
   }


### PR DESCRIPTION
## Summary
- remove cache-based `validUids` filtering from structured mention conversion
- add defensive inbound text fallback for missing mention payloads
- add / update tests for structured mentions and fallback boundaries

## Problem
Bot-to-bot `@[uid:Name]` mentions in groups could fail on the first attempt when member cache was not warmed. The message text was converted to `@name`, but `payload.mention` was omitted, so the receiving bot was not triggered.

Closes #217

## Testing
- npx vitest run
- 620/620 tests passing