### PR TITLE
fix(dmwork): enable slash commands from chat

### DIFF
--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1429,9 +1429,10 @@ export async function handleInboundMessage(params: {
 
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
-    BodyForAgent: body,  // ← 关键！AI 实际读取的是这个字段！
+    BodyForAgent: body,
     RawBody: rawBody,
     CommandBody: rawBody,
+    CommandAuthorized: true,
     MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
     MediaUrls: (() => {
       // Only pass current message's local media path (no remote history URLs)


### PR DESCRIPTION
## Summary
- Add `CommandAuthorized: true` to DMWork inbound context so OpenClaw framework recognizes slash commands (`/new`, `/reset`, `/compact`, `/stop`, `/status`, `/help`) from DMWork chat messages
- Previously these commands were silently dropped due to missing authorization flag (Feishu plugin already had this, DMWork was missing it)

## Test plan
- [x] Send `/new` in DMWork DM → session resets, bot greets as new conversation
- [x] Send `/new` then ask "what did we just talk about" → bot has no previous context
- [x] Regular messages still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)