### PR TITLE
fix: 子区 group.md 去重 & 注入方式统一

### DIFF
--- a/openclaw-channel-dmwork/index.ts
+++ b/openclaw-channel-dmwork/index.ts
@@ -10,6 +10,7 @@ import { execFileSync } from "node:child_process";
 import { dmworkPlugin } from "./src/channel.js";
 import { setDmworkRuntime } from "./src/runtime.js";
 import { getGroupMdForPrompt } from "./src/group-md.js";
+import { pendingInboundContext } from "./src/inbound.js";
 import {
   inProcessConfigReader,
   runDoctorChecks,
@@ -208,10 +209,27 @@ const plugin: {
 
     console.log('[dmwork] registering before_prompt_build hook');
     api.on('before_prompt_build', (_event, ctx) => {
-      const content = getGroupMdForPrompt(ctx);
-      if (!content) return;
-      const result = { prependContext: `[GROUP CONTEXT]\n${content}\n[/GROUP CONTEXT]` };
-      return result;
+      const sections: string[] = [];
+
+      // 1. Group/Thread MD — wrapped in [GROUP CONTEXT] block
+      const groupMdContent = getGroupMdForPrompt(ctx);
+      if (groupMdContent) {
+        sections.push(`[GROUP CONTEXT]\n${groupMdContent}\n[/GROUP CONTEXT]`);
+      }
+
+      // 2. Inbound context (member list + history) — outside [GROUP CONTEXT], keeps original format
+      const sessionKey = ctx.sessionKey;
+      if (sessionKey) {
+        const pending = pendingInboundContext.get(sessionKey);
+        if (pending) {
+          pendingInboundContext.delete(sessionKey);
+          if (pending.memberListPrefix) sections.push(pending.memberListPrefix);
+          if (pending.historyPrefix) sections.push(pending.historyPrefix);
+        }
+      }
+
+      if (sections.length === 0) return;
+      return { prependContext: sections.join('\n\n') };
     });
   },
 };

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -30,7 +30,7 @@ import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMe
 import type { MentionEntity } from "./types.js";
 import { handleDmworkMessageAction, parseTarget } from "./actions.js";
 import { createDmworkManagementTools } from "./agent-tools.js";
-import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds } from "./group-md.js";
+import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk } from "./group-md.js";
 import { registerOwnerUid } from "./owner-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
 import path from "node:path";
@@ -726,6 +726,18 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
               const md = await getGroupMd({ apiUrl: account.config.apiUrl, botToken: account.config.botToken!, groupNo: g.group_no, log });
               if (md.content) {
                 groupMdCache.set(g.group_no, { content: md.content, version: md.version });
+                writeGroupMdToDisk({
+                  accountId: account.accountId,
+                  groupNo: g.group_no,
+                  content: md.content,
+                  meta: {
+                    version: md.version,
+                    updated_at: null,
+                    updated_by: "prefetch",
+                    fetched_at: new Date().toISOString(),
+                    account_id: account.accountId,
+                  },
+                });
                 mdCount++;
               }
             } catch {

--- a/openclaw-channel-dmwork/src/group-md.test.ts
+++ b/openclaw-channel-dmwork/src/group-md.test.ts
@@ -634,9 +634,8 @@ describe("getGroupMdForPrompt (thread support)", () => {
   const groupNo = "grp_thread";
   const shortId = "thr_123";
 
-  it("should return group-level GROUP.md for thread sessionKey", () => {
+  it("should return empty string for thread when THREAD.md is empty", () => {
     registerGroupAccount(groupNo, accountId, agentId);
-    const content = "# Group Rules\nBe nice.";
     const meta: GroupMdMeta = {
       version: 1,
       updated_at: null,
@@ -644,17 +643,19 @@ describe("getGroupMdForPrompt (thread support)", () => {
       fetched_at: new Date().toISOString(),
       account_id: accountId,
     };
-    writeGroupMdToDisk({ accountId, groupNo, content, meta });
+    // Write an empty THREAD.md (simulates group_md_deleted writing empty content)
+    writeThreadMdToDisk({ accountId, groupNo, shortId, content: "", meta });
 
-    // Thread sessionKey contains "groupNo____shortId"
     const result = getGroupMdForPrompt({
       sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
       agentId,
     });
-    expect(result).toBe(content);
+    // readThreadMdFromDisk returns "" for empty file (not null),
+    // but the hook's `if (!content)` guard will filter it out — see risk 7.5
+    expect(result).toBe("");
   });
 
-  it("should return cascaded group + thread content when both exist", () => {
+  it("should return only thread content when both group and thread md exist", () => {
     registerGroupAccount(groupNo, accountId, agentId);
     const groupContent = "# Group Rules\nBe nice.";
     const threadContent = "# Sprint 42\nGoal: auth module";
@@ -673,13 +674,10 @@ describe("getGroupMdForPrompt (thread support)", () => {
       sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
       agentId,
     });
-    expect(result).not.toBeNull();
-    expect(result).toContain(groupContent);
-    expect(result).toContain("--- THREAD CONTEXT ---");
-    expect(result).toContain(threadContent);
+    expect(result).toBe(threadContent);
   });
 
-  it("should return only group content when thread md does not exist", () => {
+  it("should return null for thread when only group md exists (no fallback)", () => {
     registerGroupAccount(groupNo, accountId, agentId);
     const groupContent = "# Group only";
     const meta: GroupMdMeta = {
@@ -695,11 +693,10 @@ describe("getGroupMdForPrompt (thread support)", () => {
       sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
       agentId,
     });
-    expect(result).toBe(groupContent);
-    expect(result).not.toContain("--- THREAD CONTEXT ---");
+    expect(result).toBeNull();
   });
 
-  it("should return only thread content when group md does not exist", () => {
+  it("should return thread content directly when group md does not exist", () => {
     registerGroupAccount(groupNo, accountId, agentId);
     const threadContent = "# Thread only content";
     const meta: GroupMdMeta = {
@@ -715,9 +712,7 @@ describe("getGroupMdForPrompt (thread support)", () => {
       sessionKey: `agent:${agentId}:dmwork:group:${groupNo}____${shortId}`,
       agentId,
     });
-    expect(result).not.toBeNull();
-    expect(result).toContain("--- THREAD CONTEXT ---");
-    expect(result).toContain(threadContent);
+    expect(result).toBe(threadContent);
   });
 
   it("should return null when neither group nor thread md exist", () => {

--- a/openclaw-channel-dmwork/src/group-md.ts
+++ b/openclaw-channel-dmwork/src/group-md.ts
@@ -337,7 +337,8 @@ export async function handleGroupMdEvent(params: {
  * Get GROUP.md content for prompt injection.
  * Called by the before_prompt_build hook.
  * Only does disk reads — no network calls.
- * For thread sessions, returns cascaded group + thread content.
+ * Thread sessions: only return THREAD.md (no parent GROUP.md fallback).
+ * Group sessions: return GROUP.md.
  */
 export function getGroupMdForPrompt(ctx: {
   sessionKey?: string;
@@ -356,26 +357,13 @@ export function getGroupMdForPrompt(ctx: {
   const accountId = resolveAccountId(agentId, parentGroupNo);
   if (!accountId) return null;
 
-  // 1. Always read group-level GROUP.md
-  const groupMd = readGroupMdFromDisk(accountId, parentGroupNo);
-
-  // 2. If thread session, also read thread-level THREAD.md
-  let threadMd: string | null = null;
+  // Thread sessions: only return THREAD.md (no parent GROUP.md fallback)
   if (shortId) {
-    threadMd = readThreadMdFromDisk(accountId, parentGroupNo, shortId);
+    return readThreadMdFromDisk(accountId, parentGroupNo, shortId);
   }
 
-  // 3. Combine output
-  if (!groupMd && !threadMd) return null;
-
-  const parts: string[] = [];
-  if (groupMd) {
-    parts.push(groupMd);
-  }
-  if (threadMd) {
-    parts.push(`--- THREAD CONTEXT ---\n${threadMd}`);
-  }
-  return parts.join("\n\n");
+  // Group sessions: return GROUP.md
+  return readGroupMdFromDisk(accountId, parentGroupNo);
 }
 
 /**

--- a/openclaw-channel-dmwork/src/inbound.test.ts
+++ b/openclaw-channel-dmwork/src/inbound.test.ts
@@ -13,6 +13,7 @@ import {
   uploadAndSendMedia,
   downloadMediaToLocal,
   buildMemberListPrefix,
+  pendingInboundContext,
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids } from "./mention-utils.js";
@@ -1065,5 +1066,50 @@ describe("resolveMultipleForwardText with URL resolution", () => {
     expect(result).toContain("Test: [图片]");
     expect(result).toContain("Test: [文件: doc.pdf]");
     expect(result).not.toContain("https://");
+  });
+});
+
+describe("pendingInboundContext", () => {
+  beforeEach(() => {
+    pendingInboundContext.clear();
+  });
+
+  it("should store and retrieve context by sessionKey", () => {
+    const key = "dmwork:group:test123";
+    pendingInboundContext.set(key, {
+      historyPrefix: "history...",
+      memberListPrefix: "members...",
+    });
+    expect(pendingInboundContext.has(key)).toBe(true);
+    const entry = pendingInboundContext.get(key);
+    expect(entry?.historyPrefix).toBe("history...");
+    expect(entry?.memberListPrefix).toBe("members...");
+  });
+
+  it("should allow delete after read (consume-once pattern)", () => {
+    const key = "dmwork:group:consume";
+    pendingInboundContext.set(key, {
+      historyPrefix: "h",
+      memberListPrefix: "m",
+    });
+    const entry = pendingInboundContext.get(key);
+    pendingInboundContext.delete(key);
+    expect(entry).toBeDefined();
+    expect(pendingInboundContext.has(key)).toBe(false);
+  });
+
+  it("should keep separate entries for different sessionKeys", () => {
+    pendingInboundContext.set("key1", { historyPrefix: "h1", memberListPrefix: "" });
+    pendingInboundContext.set("key2", { historyPrefix: "", memberListPrefix: "m2" });
+    expect(pendingInboundContext.get("key1")?.historyPrefix).toBe("h1");
+    expect(pendingInboundContext.get("key2")?.memberListPrefix).toBe("m2");
+  });
+
+  it("should overwrite on repeated set for same key", () => {
+    const key = "dmwork:group:overwrite";
+    pendingInboundContext.set(key, { historyPrefix: "old", memberListPrefix: "" });
+    pendingInboundContext.set(key, { historyPrefix: "new", memberListPrefix: "ml" });
+    expect(pendingInboundContext.get(key)?.historyPrefix).toBe("new");
+    expect(pendingInboundContext.get(key)?.memberListPrefix).toBe("ml");
   });
 });

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -22,6 +22,10 @@ import { mkdir, unlink, readdir, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { randomUUID } from "node:crypto";
 
+// Pending inbound context for before_prompt_build hook injection.
+// handleInboundMessage writes here; the hook reads and clears per sessionKey.
+export const pendingInboundContext = new Map<string, { historyPrefix: string; memberListPrefix: string }>();
+
 // Defensive imports — these may not exist in older OpenClaw versions
 // History context managed manually for cross-SDK compatibility
 let clearHistoryEntriesIfEnabled: any;
@@ -1383,12 +1387,14 @@ export async function handleInboundMessage(params: {
     sessionKey: route.sessionKey,
   });
 
-  // Inject member list for group messages to help LLM learn @[uid:name] format
+  // memberListPrefix and historyPrefix are injected via before_prompt_build hook
+  // (not persisted to session history). Only quotePrefix stays in Body.
   const memberListPrefix = isGroup ? buildMemberListPrefix(uidToNameMap) : "";
+  if (historyPrefix || memberListPrefix) {
+    pendingInboundContext.set(route.sessionKey, { historyPrefix, memberListPrefix });
+  }
 
-  const finalBody = (memberListPrefix || historyPrefix || quotePrefix)
-    ? (memberListPrefix + historyPrefix + quotePrefix + rawBody)
-    : rawBody;
+  const finalBody = quotePrefix ? (quotePrefix + rawBody) : rawBody;
 
   const body = core.channel.reply.formatAgentEnvelope({
     channel: "DMWork",
@@ -1699,5 +1705,7 @@ export async function handleInboundMessage(params: {
       }
     }
     clearInterval(typingInterval);
+    // Safety net: clean up pending inbound context in case the hook didn't fire
+    pendingInboundContext.delete(route.sessionKey);
   }
 }

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1399,10 +1399,8 @@ export async function handleInboundMessage(params: {
     body: finalBody,
   });
 
-  // Inject GROUP.md as GroupSystemPrompt for group messages
-  const groupSystemPrompt = isGroup && groupMdCache && message.channel_id
-    ? groupMdCache.get(extractParentGroupNo(message.channel_id))?.content
-    : undefined;
+  // GROUP.md injection is handled exclusively by the before_prompt_build hook
+  // (see index.ts → getGroupMdForPrompt) — no longer set here to avoid duplication.
 
   // Resolve sender display name — async fallback for DM users not in cache
   let senderName = resolveSenderName(message.from_uid, uidToNameMap);
@@ -1452,7 +1450,7 @@ export async function handleInboundMessage(params: {
     MessageSid: String(message.message_id),
     Timestamp: message.timestamp ? message.timestamp * 1000 : undefined,
     GroupSubject: isGroup ? message.channel_id : undefined,
-    GroupSystemPrompt: groupSystemPrompt,
+    GroupSystemPrompt: undefined,
     Provider: "dmwork",
     Surface: "dmwork",
     OriginatingChannel: "dmwork",


### PR DESCRIPTION
## 问题

1. 子区（thread）构建 agent 上下文时，父群 group.md 被重复注入两次（`inbound.ts` GroupSystemPrompt + `index.ts` before_prompt_build hook）
2. 子区不需要父群的 group.md，但仍然 fallback 到父群
3. historyPrefix / memberListPrefix 直接拼进 finalBody，污染 session 历史

## 修复

### Commit 1: 子区 group.md 去重
- **inbound.ts**: 删除 `GroupSystemPrompt` 旧注入路径（设为 `undefined`）
- **group-md.ts**: `getGroupMdForPrompt` 子区无 THREAD.md 时返回 `null`，不 fallback 父群
- **channel.ts**: prefetch 启动时同步写磁盘，防止 hook 冷启动丢 context
- **group-md.test.ts**: 4 个测试用例期望值更新

### Commit 2: historyPrefix/memberListPrefix 改为 prependContext 注入
- **inbound.ts**: 新增 `pendingInboundContext` Map，historyPrefix/memberListPrefix 不再拼进 finalBody
- **index.ts**: before_prompt_build hook 扩展，从 Map 读取并拼入 prependContext
- **inbound.test.ts**: 新增 pendingInboundContext 相关测试

## 测试
- group-md.test.ts: 75 tests PASS
- inbound.test.ts: 83 tests PASS
- 本地部署验证通过

## 已知限制
prependContext 仍被 OpenClaw core 持久化到 session history（core 侧问题，不在本 PR 范围）