### PR TITLE
fix(dmwork): 完善斜杠命令权限控制与群聊支持

### DIFF
--- a/openclaw-channel-dmwork/src/inbound.test.ts
+++ b/openclaw-channel-dmwork/src/inbound.test.ts
@@ -13,6 +13,8 @@ import {
   uploadAndSendMedia,
   downloadMediaToLocal,
   buildMemberListPrefix,
+  resolveCommandBody,
+  resolveCommandAuthorized,
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids } from "./mention-utils.js";
@@ -1065,5 +1067,48 @@ describe("resolveMultipleForwardText with URL resolution", () => {
     expect(result).toContain("Test: [图片]");
     expect(result).toContain("Test: [文件: doc.pdf]");
     expect(result).not.toContain("https://");
+  });
+});
+
+// ─── Slash command authorization & body resolution ───────────────────────────
+
+describe("resolveCommandBody", () => {
+  it("DM: keeps raw body as-is", () => {
+    expect(resolveCommandBody("/new", false, false)).toBe("/new");
+  });
+
+  it("group + explicit @bot: strips @mention prefix", () => {
+    expect(resolveCommandBody("@ona /new", true, true)).toBe("/new");
+  });
+
+  it("group + @all (not explicit bot mention): keeps raw body", () => {
+    expect(resolveCommandBody("@all /new", true, false)).toBe("@all /new");
+  });
+
+  it("group + no mention: keeps raw body", () => {
+    expect(resolveCommandBody("/new", true, false)).toBe("/new");
+  });
+});
+
+describe("resolveCommandAuthorized", () => {
+  it("DM: anyone can execute commands", () => {
+    expect(resolveCommandAuthorized(false, false, false)).toBe(true);
+    expect(resolveCommandAuthorized(false, true, false)).toBe(true);
+  });
+
+  it("group: owner + explicit @bot → authorized", () => {
+    expect(resolveCommandAuthorized(true, true, true)).toBe(true);
+  });
+
+  it("group: non-owner + explicit @bot → not authorized", () => {
+    expect(resolveCommandAuthorized(true, false, true)).toBe(false);
+  });
+
+  it("group: owner + @all (no explicit bot mention) → not authorized", () => {
+    expect(resolveCommandAuthorized(true, true, false)).toBe(false);
+  });
+
+  it("group: non-owner + no mention → not authorized", () => {
+    expect(resolveCommandAuthorized(true, false, false)).toBe(false);
   });
 });

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -936,6 +936,25 @@ export function buildMemberListPrefix(uidToNameMap: Map<string, string>): string
   return `[Group Info] This group has ${uidToNameMap.size} members. Use the group management tool to look up member info when needed. When mentioning a group member, use the format @[uid:displayName].\n\n`;
 }
 
+/**
+ * Strip @mention prefix from raw message text for command detection.
+ * Only strips when bot is explicitly mentioned (not @all).
+ */
+export function resolveCommandBody(rawBody: string, isGroup: boolean, isExplicitBotMention: boolean): string {
+  if (isGroup && isExplicitBotMention) {
+    return rawBody.replace(/^@\S+\s*/, "").trim();
+  }
+  return rawBody;
+}
+
+/**
+ * Determine if the sender is authorized to execute slash commands.
+ * DM: anyone can execute. Group: owner + explicit @bot mention required.
+ */
+export function resolveCommandAuthorized(isGroup: boolean, isOwnerUser: boolean, isExplicitBotMention: boolean): boolean {
+  return !isGroup || (isOwnerUser && isExplicitBotMention);
+}
+
 export async function handleInboundMessage(params: {
   account: ResolvedDmworkAccount;
   message: BotMessage;
@@ -1186,13 +1205,15 @@ export async function handleInboundMessage(params: {
     await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", log });
   }
 
-  // Compute isMentioned at top level so it's available for WasMentioned in finalizeInboundContext
+  // Compute mention flags — separate "reply gating" from "command gating"
   let isMentioned = false;
+  let isExplicitBotMention = false;
   if (isGroup) {
     const mentionUids = extractMentionUids(message.payload?.mention);
     const mentionAllRaw = message.payload?.mention?.all;
     const mentionAll: boolean = mentionAllRaw === true || mentionAllRaw === 1;
     isMentioned = mentionAll || mentionUids.includes(botUid);
+    isExplicitBotMention = mentionUids.includes(botUid);
   }
 
   if (isGroup && requireMention) {
@@ -1428,17 +1449,16 @@ export async function handleInboundMessage(params: {
     }
   }
 
-  // Strip @mention prefix for command detection in group chat
-  const commandBody = isGroup
-    ? rawBody.replace(/^@\S+\s*/, "").trim()
-    : rawBody;
+  const commandBody = resolveCommandBody(rawBody, isGroup, isExplicitBotMention);
+  const commandAuthorized = resolveCommandAuthorized(isGroup, isOwner(account.accountId, message.from_uid), isExplicitBotMention);
 
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
     BodyForAgent: body,
     RawBody: rawBody,
     CommandBody: commandBody,
-    CommandAuthorized: !isGroup || isOwner(account.accountId, message.from_uid),
+    BodyForCommands: commandBody,
+    CommandAuthorized: commandAuthorized,
     MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
     MediaUrls: (() => {
       // Only pass current message's local media path (no remote history URLs)

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -17,6 +17,7 @@ import {
 } from "./mention-utils.js";
 import type { MentionPayload, MentionEntity } from "./types.js";
 import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate, extractParentGroupNo, extractThreadShortId, ensureThreadMd, handleThreadMdEvent } from "./group-md.js";
+import { isOwner } from "./owner-registry.js";
 import { createWriteStream } from "node:fs";
 import { mkdir, unlink, readdir, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
@@ -1437,7 +1438,7 @@ export async function handleInboundMessage(params: {
     BodyForAgent: body,
     RawBody: rawBody,
     CommandBody: commandBody,
-    CommandAuthorized: true,
+    CommandAuthorized: !isGroup || isOwner(account.accountId, message.from_uid),
     MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
     MediaUrls: (() => {
       // Only pass current message's local media path (no remote history URLs)

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -1427,11 +1427,16 @@ export async function handleInboundMessage(params: {
     }
   }
 
+  // Strip @mention prefix for command detection in group chat
+  const commandBody = isGroup
+    ? rawBody.replace(/^@\S+\s*/, "").trim()
+    : rawBody;
+
   const ctxPayload = core.channel.reply.finalizeInboundContext({
     Body: body,
     BodyForAgent: body,
     RawBody: rawBody,
-    CommandBody: rawBody,
+    CommandBody: commandBody,
     CommandAuthorized: true,
     MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
     MediaUrls: (() => {


### PR DESCRIPTION
## Summary
- 群聊命令去掉 @mention 前缀，让框架能识别 `/new`、`/reset` 等命令
- 群聊命令权限：只有 bot owner 显式 @bot 时才能执行，@所有人不触发
- 私聊：任何人都能执行命令
- 抽出 `resolveCommandBody`/`resolveCommandAuthorized` 纯函数
- 加入 `BodyForCommands` 对齐其他渠道插件
- 补充 9 个测试用例，覆盖所有场景

## Test plan
- [x] 私聊 `/new`：执行
- [x] 群聊 owner `@bot /new`：执行
- [x] 群聊非 owner `@bot /new`：不执行
- [x] 群聊 owner `@所有人 /new`：不执行
- [x] 单元测试全部通过（92 tests）