### PR TITLE
chore(security): scrub internal domain for OCTO open-source snapshot

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,7 +11,7 @@
 
 If you discover a security vulnerability, please report it responsibly:
 
-1. **Email:** Send details to [security@dmwork.org](mailto:security@dmwork.org)
+1. **Email:** Send details to [security@mlamp.cn](mailto:security@mlamp.cn)
 2. **Do not** open a public GitHub issue for security vulnerabilities
 
 ### What to include


### PR DESCRIPTION
Part of YUJ-337 scrub chain.

Single-line change: replace internal email `security@dmwork.org` with `security@mlamp.cn` in `.github/SECURITY.md:14` so the deny-list `internal-domain` rule (which matches `@dmwork.org`) no longer hard-fails the `octo-adapters v0.1.0-alpha.1` dry-run.

Rationale (Yu / Coda):
- Internal email (mlamp.cn domain) is fine for internal repo.
- Open-source mirror overlay separately uses `security@octo.dev` — inner/outer split stays clean.

No other refactor / formatting / lint touched.
