### PR TITLE
chore(security): switch to unified octo.dev contact

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,7 +11,7 @@
 
 If you discover a security vulnerability, please report it responsibly:
 
-1. **Email:** Send details to [security@mlamp.cn](mailto:security@mlamp.cn)
+1. **Email:** Send details to [security@octo.dev](mailto:security@octo.dev)
 2. **Do not** open a public GitHub issue for security vulnerabilities
 
 ### What to include


### PR DESCRIPTION
Part of YUJ-337 scrub chain (supersedes YUJ-338).

Single-line change: switch SECURITY.md contact email to the unified `security@octo.dev` (same domain as the already-published release author `contributors@octo.dev`). `mlamp.cn` hit the deny-list in YUJ-338; `octo.dev` is the agreed unified policy going forward.

Diff:
```
.github/SECURITY.md:14
- 1. **Email:** Send details to [security@mlamp.cn](mailto:security@mlamp.cn)
+ 1. **Email:** Send details to [security@octo.dev](mailto:security@octo.dev)
```

- Base: `develop`
- Scope: docs-only, 1 line → `/codex` skipped per ≤20-line docs rule
- After merge: YUJ-337 will rerun dry-run with the new contact (expected clean)
