### PR TITLE
fix(cli): read version from src/version.ts instead of fragile ../package.json

### DIFF
--- a/openclaw-channel-dmwork/cli/index.ts
+++ b/openclaw-channel-dmwork/cli/index.ts
@@ -16,17 +16,14 @@ import { runUninstall } from "./uninstall.js";
 import { runRemoveAccount } from "./remove-account.js";
 import { ensureOpenClawCompat, PLUGIN_ID } from "./utils.js";
 import { getOpenClawVersionStrict, resolvePluginState } from "./openclaw-cli.js";
-import { createRequire } from "node:module";
+import { PLUGIN_VERSION } from "../src/version.js";
 
 const program = new Command();
-
-const _require = createRequire(import.meta.url);
-const _pkg = _require("../package.json");
 
 program
   .name("openclaw-channel-dmwork")
   .description("DMWork channel plugin CLI for OpenClaw")
-  .version(_pkg.version);
+  .version(PLUGIN_VERSION);
 
 // --- info ---
 program
@@ -56,7 +53,7 @@ program
     const g = "\x1b[32m";
     const r = "\x1b[0m";
 
-    console.log(`${b}openclaw-channel-dmwork-cli:${r} ${g}${_pkg.version}${r}`);
+    console.log(`${b}openclaw-channel-dmwork-cli:${r} ${g}${PLUGIN_VERSION}${r}`);
     console.log(`${b}openclaw:${r} ${g}${openclawVersion}${r}`);
     console.log(`${b}openclaw-channel-dmwork:${r} ${g}${installedVersion}${r}`);
     console.log(`${b}plugin package:${r} ${g}${PLUGIN_ID}${r}`);


### PR DESCRIPTION
## Summary

PR #228 合并后发 dev 版立刻炸：

\`\`\`
$ npx -y openclaw-channel-dmwork@dev install --dev
Error: Cannot find module '../package.json'
Require stack:
- .../node_modules/openclaw-channel-dmwork/dist/cli/index.js
    at ... line 17
\`\`\`

## 根因

`cli/index.ts` 里写的：

\`\`\`ts
const _require = createRequire(import.meta.url);
const _pkg = _require("../package.json");
\`\`\`

- **源码目录** `cli/index.ts` 的 `../package.json` → 根 package.json ✓
- **编译后** `dist/cli/index.js` 的 `../package.json` → `dist/package.json` ✗

`dist/package.json` 根本不存在。

## 为什么 v0.6.1 能跑

对比 v0.6.1 和 v0.6.2-dev 的 published tarball：

\`\`\`
0.6.1:   package/dist/package.json   ← 存在（来源不明）
0.6.2-dev: package/dist/package.json ← 没了
\`\`\`

v0.6.1 的 tarball 里**莫名其妙有一份 `dist/package.json` 拷贝**——不是 git 管的，不是 CI 脚本产生的，`prebuild` 还会 `rm -rf dist`。最可能是某次手工发布前谁 `cp` 过一次然后没清理，那个 artifact 一直阴差阳错地帮 CLI 续命。

这次 dev 发布少了这份偶然拷贝，潜伏了很久的 bug 终于浮出水面。

## 修复

根本不读 `package.json`。`src/version.ts` 早就由 prebuild script 从根 `package.json.version` 生成了 `PLUGIN_VERSION` 常量（`src/channel.ts` 早就在用），CLI 直接 import 就行：

\`\`\`ts
import { PLUGIN_VERSION } from "../src/version.js";
// ...
program.version(PLUGIN_VERSION);
\`\`\`

干掉 `createRequire` + `_require` + `_pkg`，彻底断掉脆弱的相对路径依赖。

## 验证

- [x] `node dist/cli/index.js --version` → `0.6.2`
- [x] `node dist/cli/index.js info` → version 正确显示
- [x] 638 tests + tsc --noEmit + build 全过
- [x] `npx openclaw-channel-dmwork@dev` 发布后应该能正常启动（等 CI 发 dev 包后再真机验证一次）

## 关联

Follow-up to #228. #228 里 build 层面 CI 已经绿，但 runtime CLI 启动这条路没被 CI 覆盖到（CI 只跑 type-check/test/build，没跑 `node dist/cli/index.js`），所以 merge 时没发现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)