### PR TITLE
fix(outbound): 合成 thread channel_id，修复文件/消息串到父群的 bug

### DIFF
--- a/openclaw-channel-dmwork/src/actions.test.ts
+++ b/openclaw-channel-dmwork/src/actions.test.ts
@@ -455,6 +455,133 @@ describe("handleDmworkMessageAction", () => {
     });
   });
 
+  // Foot-gun UX guard (#232 review): when the agent explicitly passes a bare
+  // parent-group target while the session's currentChannelId is inside a
+  // thread, log a warning. This doesn't reroute and doesn't reject (the
+  // parent-group reply may be intentional), it just surfaces the ambiguity
+  // so operators can notice model misuse.
+
+  describe("send — thread-context foot-gun warning", () => {
+    it("warns (via log.warn) when target is the thread's parent group", async () => {
+      registerBotGroupIds(["grp1"]);
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
+      });
+      const logWarn = vi.fn();
+      const logInfo = vi.fn();
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        log: { warn: logWarn, info: logInfo } as any,
+      });
+      expect(logWarn).toHaveBeenCalledTimes(1);
+      expect(logInfo).not.toHaveBeenCalled();
+      const msg = logWarn.mock.calls[0][0] as string;
+      expect(msg).toContain("target=\"group:grp1\"");
+      expect(msg).toContain("grp1____topicA");
+    });
+
+    it("falls back to log.info when log.warn is not provided", async () => {
+      registerBotGroupIds(["grp1"]);
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
+      });
+      const logInfo = vi.fn();
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        log: { info: logInfo } as any, // no .warn
+      });
+      expect(logInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT warn when target is a DIFFERENT group (legitimate cross-channel send)", async () => {
+      registerBotGroupIds(["grp1", "otherGroup"]);
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
+      });
+      const logWarn = vi.fn();
+      const logInfo = vi.fn();
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:otherGroup", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA", // in thread of grp1, but sending to otherGroup
+        log: { warn: logWarn, info: logInfo } as any,
+      });
+      expect(logWarn).not.toHaveBeenCalled();
+      expect(logInfo).not.toHaveBeenCalled();
+    });
+
+    it("does NOT warn when target already carries the thread short id", async () => {
+      registerBotGroupIds(["grp1"]);
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
+      });
+      const logWarn = vi.fn();
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1____topicA", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        log: { warn: logWarn } as any,
+      });
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
+    it("does NOT warn when session is NOT in a thread (plain group chat)", async () => {
+      registerBotGroupIds(["grp1"]);
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
+      });
+      const logWarn = vi.fn();
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1",
+        log: { warn: logWarn } as any,
+      });
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
+    it("still sends the message when the warning fires (warn, not reject)", async () => {
+      registerBotGroupIds(["grp1"]);
+      let sent = false;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async () => {
+          sent = true;
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      const result = await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        log: { warn: vi.fn() } as any,
+      });
+      expect(sent).toBe(true);
+      expect(result.ok).toBe(true);
+    });
+  });
+
   // -----------------------------------------------------------------------
   // read action
   // -----------------------------------------------------------------------
@@ -1484,5 +1611,217 @@ describe("parseTarget", () => {
     const result = parseTarget("dmwork:grpZ", undefined, knownGroups);
     expect(result.channelId).toBe("grpZ");
     expect(result.channelType).toBe(ChannelType.Group);
+  });
+
+  // OpenClaw's delivery pipeline can emit `channel:<id>` as a parallel alias
+  // for group channels. parseTarget handles it directly now so every caller
+  // (outbound adapters, message-tool, account resolver) sees consistent
+  // routing without having to normalise upstream first.
+
+  it("should parse channel:<id> as Group", async () => {
+    const { parseTarget } = await import("./actions.js");
+    const result = parseTarget("channel:grp1");
+    expect(result.channelId).toBe("grp1");
+    expect(result.channelType).toBe(ChannelType.Group);
+  });
+
+  it("should parse channel:<id>____<short> as CommunityTopic", async () => {
+    const { parseTarget } = await import("./actions.js");
+    const result = parseTarget("channel:grp1____topicA");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+});
+
+describe("resolveOutboundDmworkTarget", () => {
+  // Regression guard for the thread cross-channel bug: OpenClaw passes thread
+  // replies as `to: "group:<group_no>"` plus a separate `threadId: "<short_id>"`,
+  // and callers used to run only parseTarget which collapsed the routing back
+  // to the parent group (channel_type=2). The merged helper must synthesise
+  // the CommunityTopic channel_id (channel_type=5).
+
+  it("merges threadId into CommunityTopic channel_id", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    const result = resolveOutboundDmworkTarget("group:grp1", "topicA");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  it("accepts numeric threadId", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    const result = resolveOutboundDmworkTarget("group:grp1", 2052674378482585600);
+    expect(result.channelId).toBe("grp1____2052674378482585600");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  it("passes through an already-synthesised thread channel_id untouched", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    const result = resolveOutboundDmworkTarget("group:grp1____topicA");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  it("does not re-merge threadId when ctx.to already carries ____", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    // Caller gave both — ctx.to wins (already fully specified). Don't concat again.
+    const result = resolveOutboundDmworkTarget("group:grp1____topicA", "topicB");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  it("leaves DM targets alone even when threadId is accidentally provided", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    const result = resolveOutboundDmworkTarget("user:uid123", "stray");
+    expect(result.channelId).toBe("uid123");
+    expect(result.channelType).toBe(ChannelType.DM);
+  });
+
+  it("returns parent group unchanged when threadId is null/undefined/empty", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    expect(resolveOutboundDmworkTarget("group:grp1").channelType).toBe(ChannelType.Group);
+    expect(resolveOutboundDmworkTarget("group:grp1", null).channelType).toBe(ChannelType.Group);
+    expect(resolveOutboundDmworkTarget("group:grp1", undefined).channelType).toBe(ChannelType.Group);
+    expect(resolveOutboundDmworkTarget("group:grp1", "").channelType).toBe(ChannelType.Group);
+  });
+
+  it("strips inline mention-UID suffix before parsing", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    const result = resolveOutboundDmworkTarget("group:grp1@uid1,uid2", "topicA");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  it("strips dmwork:/group:/channel: prefixes from threadId", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    expect(resolveOutboundDmworkTarget("group:grp1", "dmwork:topicA").channelId)
+      .toBe("grp1____topicA");
+    expect(resolveOutboundDmworkTarget("group:grp1", "group:topicA").channelId)
+      .toBe("grp1____topicA");
+    expect(resolveOutboundDmworkTarget("group:grp1", "channel:topicA").channelId)
+      .toBe("grp1____topicA");
+  });
+
+  // The OpenClaw delivery pipeline can emit `channel:<id>` as an alternative
+  // outbound target form for group channels. parseTarget on its own doesn't
+  // recognise this prefix, so the helper has to normalise it to `group:` before
+  // anything else — otherwise the target degrades to DM and threadId merge is
+  // silently skipped.
+
+  it("normalises channel:<id> prefix to group-type target", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    const result = resolveOutboundDmworkTarget("channel:grp1");
+    expect(result.channelId).toBe("grp1");
+    expect(result.channelType).toBe(ChannelType.Group);
+  });
+
+  it("merges threadId into a channel:<id> target", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    const result = resolveOutboundDmworkTarget("channel:grp1", "topicA");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  it("passes through a channel:<group>____<short> target as CommunityTopic", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    const result = resolveOutboundDmworkTarget("channel:grp1____topicA");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  it("strips inline mention-UID suffix on channel:<id>@uid1,uid2 form", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    const result = resolveOutboundDmworkTarget("channel:grp1@uid1,uid2", "topicA");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  // Defensive: threadId from framework/user context should never silently redirect
+  // delivery to a *different* parent group. If the threadId happens to carry its
+  // own `____<parent>` prefix and that parent disagrees with ctx.to, the safe
+  // choice is to stay on ctx.to's parent — otherwise a stale or corrupted
+  // threadId could route a reply out of the originally targeted group entirely.
+
+  it("accepts threadId that already includes ____ when its parent matches ctx.to", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    // Redundant but consistent shape: threadId = "grp1____topicA", ctx.to = grp1.
+    const result = resolveOutboundDmworkTarget("group:grp1", "grp1____topicA");
+    expect(result.channelId).toBe("grp1____topicA");
+    expect(result.channelType).toBe(ChannelType.CommunityTopic);
+  });
+
+  it("ignores threadId when its ____ parent disagrees with ctx.to (cross-channel guard)", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    // threadId points at otherGrp____topic, but ctx.to says grp1 — conflict.
+    // Fall back to the ctx.to parent group; do NOT silently route to otherGrp.
+    const result = resolveOutboundDmworkTarget("group:grp1", "otherGrp____topic");
+    expect(result.channelId).toBe("grp1");
+    expect(result.channelType).toBe(ChannelType.Group);
+  });
+
+  it("ignores threadId starting with bare ____ (no parent)", async () => {
+    const { resolveOutboundDmworkTarget } = await import("./actions.js");
+    registerBotGroupIds(["grp1"]);
+    // "____topic" split on ____ yields empty parent — still a mismatch with grp1.
+    const result = resolveOutboundDmworkTarget("group:grp1", "____topic");
+    expect(result.channelId).toBe("grp1");
+    expect(result.channelType).toBe(ChannelType.Group);
+  });
+});
+
+describe("normalizeOutboundChannelPrefix", () => {
+  it("rewrites channel:<id> to group:<id>", async () => {
+    const { normalizeOutboundChannelPrefix } = await import("./actions.js");
+    expect(normalizeOutboundChannelPrefix("channel:grp1")).toBe("group:grp1");
+  });
+
+  it("preserves channel id separators and suffixes untouched", async () => {
+    const { normalizeOutboundChannelPrefix } = await import("./actions.js");
+    expect(normalizeOutboundChannelPrefix("channel:grp1____topicA")).toBe("group:grp1____topicA");
+    expect(normalizeOutboundChannelPrefix("channel:grp1@uid1,uid2")).toBe("group:grp1@uid1,uid2");
+  });
+
+  it("passes non-channel: targets through untouched", async () => {
+    const { normalizeOutboundChannelPrefix } = await import("./actions.js");
+    expect(normalizeOutboundChannelPrefix("group:grp1")).toBe("group:grp1");
+    expect(normalizeOutboundChannelPrefix("user:uid1")).toBe("user:uid1");
+    expect(normalizeOutboundChannelPrefix("bare_id")).toBe("bare_id");
+  });
+});
+
+describe("extractInlineMentionUids", () => {
+  it("extracts UIDs from group:<id>@uid1,uid2 form", async () => {
+    const { extractInlineMentionUids } = await import("./actions.js");
+    expect(extractInlineMentionUids("group:grp1@uid1,uid2")).toEqual(["uid1", "uid2"]);
+  });
+
+  it("extracts UIDs from channel:<id>@uid1,uid2 form (same shape, parallel prefix)", async () => {
+    const { extractInlineMentionUids } = await import("./actions.js");
+    expect(extractInlineMentionUids("channel:grp1@uid1,uid2")).toEqual(["uid1", "uid2"]);
+  });
+
+  it("returns empty array for targets without the @-suffix", async () => {
+    const { extractInlineMentionUids } = await import("./actions.js");
+    expect(extractInlineMentionUids("group:grp1")).toEqual([]);
+    expect(extractInlineMentionUids("channel:grp1")).toEqual([]);
+    expect(extractInlineMentionUids("user:uid1")).toEqual([]);
+    expect(extractInlineMentionUids("bare_id")).toEqual([]);
+  });
+
+  it("filters out empty segments produced by trailing/duplicate commas", async () => {
+    const { extractInlineMentionUids } = await import("./actions.js");
+    expect(extractInlineMentionUids("group:grp1@uid1,,uid2,")).toEqual(["uid1", "uid2"]);
   });
 });

--- a/openclaw-channel-dmwork/src/actions.ts
+++ b/openclaw-channel-dmwork/src/actions.ts
@@ -51,6 +51,17 @@ export function parseTarget(
     }
     return { channelId, channelType: ChannelType.Group };
   }
+  // OpenClaw's delivery pipeline can emit `channel:<id>` as a parallel alias
+  // for group channels (#232 review: "channel: 支持下沉到 parseTarget"). Handle
+  // it here so every caller — outbound adapter, message tool, etc — sees
+  // consistent routing without having to normalise upstream first.
+  if (target.startsWith("channel:")) {
+    const channelId = target.slice(8);
+    if (channelId.includes(THREAD_SEP)) {
+      return { channelId, channelType: ChannelType.CommunityTopic };
+    }
+    return { channelId, channelType: ChannelType.Group };
+  }
   if (target.startsWith("user:"))
     return { channelId: target.slice(5), channelType: ChannelType.DM };
 
@@ -71,9 +82,107 @@ export function parseTarget(
 /** Strip common prefixes to get the raw group_no */
 function stripChannelPrefix(raw: string): string {
   if (raw.startsWith("group:")) return raw.slice(6);
+  if (raw.startsWith("channel:")) return raw.slice(8);
   if (raw.startsWith("g-")) return raw.slice(2);
   if (raw.startsWith("dmwork:")) return raw.slice(7);
   return raw;
+}
+
+/**
+ * Normalise outbound target prefix. OpenClaw's delivery pipeline sometimes
+ * emits `channel:<id>` as an alternative group-channel reference (parallel to
+ * `group:<id>`). `parseTarget` now recognises `channel:` natively as well,
+ * but keep this normaliser for the older outbound entry points that wrap
+ * parseTarget with extra logic (mention-UID strip, thread merge) — having a
+ * single documented place to look up prefix aliases is worth the small
+ * redundancy.
+ */
+export function normalizeOutboundChannelPrefix(ctxTo: string): string {
+  return ctxTo.startsWith("channel:") ? "group:" + ctxTo.slice(8) : ctxTo;
+}
+
+/**
+ * Extract inline mention UIDs from an outbound target of the form
+ * `(group|channel):<id>@uid1,uid2`. Returns `[]` when the suffix is absent
+ * or the target isn't a group/channel reference.
+ */
+export function extractInlineMentionUids(ctxTo: string): string[] {
+  for (const prefix of ["group:", "channel:"] as const) {
+    if (ctxTo.startsWith(prefix)) {
+      const atIdx = ctxTo.indexOf("@", prefix.length);
+      if (atIdx < 0) return [];
+      return ctxTo.slice(atIdx + 1).split(",").map((s) => s.trim()).filter(Boolean);
+    }
+  }
+  return [];
+}
+
+/**
+ * Resolve an outbound delivery target from the framework's ChannelOutboundContext.
+ *
+ * OpenClaw passes thread/sub-topic replies as `to: "group:<group_no>"` + a separate
+ * `threadId: "<short_id>"` field. parseTarget by itself never sees threadId, so a
+ * bare call to parseTarget collapses thread routing back to the parent group
+ * (channelType=2 instead of 5) and drops the short_id entirely. This helper merges
+ * the two into the proper CommunityTopic channel_id (`<group_no>____<short_id>`,
+ * channel_type=5) so outbound messages land in the thread, not the parent group.
+ *
+ * Also strips the inline mention UID suffix ("group:<id>@uid1,uid2" → "group:<id>")
+ * before parsing — mention-UID extraction remains the caller's responsibility.
+ *
+ * Idempotent: if ctx.to already carries `____` (caller synthesised the thread id
+ * themselves), the threadId merge is skipped.
+ */
+export function resolveOutboundDmworkTarget(
+  ctxTo: string,
+  threadId?: string | number | null,
+): { channelId: string; channelType: ChannelType } {
+  const THREAD_SEP = "____";
+
+  // Normalise `channel:<id>` to `group:<id>` so downstream parseTarget sees a
+  // shape it knows. See normalizeOutboundChannelPrefix for rationale.
+  let targetForParse = normalizeOutboundChannelPrefix(ctxTo);
+
+  // Strip inline mention-UID suffix before parsing.
+  if (targetForParse.startsWith("group:")) {
+    const groupPart = targetForParse.slice(6);
+    const atIdx = groupPart.indexOf("@");
+    if (atIdx >= 0) targetForParse = "group:" + groupPart.slice(0, atIdx);
+  }
+
+  const parsed = parseTarget(targetForParse, undefined, getKnownGroupIds());
+
+  // Merge framework-provided threadId only when ctx.to was a bare group — if the
+  // caller already encoded the thread via "____" in ctx.to, parsed.channelType
+  // is already CommunityTopic and we pass through.
+  if (threadId != null && parsed.channelType === ChannelType.Group) {
+    const shortId = String(threadId)
+      .replace(/^dmwork:/, "")
+      .replace(/^group:/, "")
+      .replace(/^channel:/, "");
+    if (!shortId) return parsed;
+
+    // Defensive: if threadId already contains `____`, validate its parent
+    // prefix matches the group parsed from ctx.to. Mismatch would route
+    // delivery to a different group entirely (cross-channel leak via stale
+    // or corrupted thread id). Prefer silently ignoring the threadId and
+    // staying on the explicit ctx.to parent over honouring an inconsistent
+    // pair — the caller's ctx.to is the stronger signal of intent.
+    if (shortId.includes(THREAD_SEP)) {
+      const shortIdParent = shortId.slice(0, shortId.indexOf(THREAD_SEP));
+      if (shortIdParent !== parsed.channelId) {
+        return parsed;
+      }
+      return { channelId: shortId, channelType: ChannelType.CommunityTopic };
+    }
+
+    return {
+      channelId: `${parsed.channelId}${THREAD_SEP}${shortId}`,
+      channelType: ChannelType.CommunityTopic,
+    };
+  }
+
+  return parsed;
 }
 
 /**
@@ -177,6 +286,34 @@ async function handleSend(params: {
   }
 
   const { channelId, channelType } = parseTarget(target, currentChannelId, getKnownGroupIds());
+
+  // UX warning for a specific foot-gun on the message-tool path (#232 review):
+  // the agent is replying inside a sub-topic (session's currentChannelId carries
+  // `____`) but explicitly passed a bare parent-group target matching the
+  // current thread's parent group. That's semantically valid (parent-group
+  // reply from a thread context) but almost always a model mistake — the
+  // reply will land in the parent group where other members see it rather
+  // than in the thread where the conversation is happening. Don't silently
+  // reroute to the thread and don't hard-reject (breaks the legitimate case),
+  // just log so operators have a paper trail. Scoped to same-group cross-room
+  // to avoid false positives on legitimate cross-channel sends (e.g. the
+  // agent explicitly shipping results to a different group entirely).
+  const THREAD_SEP = "____";
+  if (
+    channelType === ChannelType.Group &&
+    currentChannelId?.includes(THREAD_SEP) &&
+    !target.includes(THREAD_SEP)
+  ) {
+    const currentThreadParent = currentChannelId.slice(0, currentChannelId.indexOf(THREAD_SEP));
+    if (channelId === currentThreadParent) {
+      const warn = log?.warn ?? log?.info;
+      warn?.(
+        `dmwork: send action: target="${target}" is the parent group of the current thread session ` +
+        `(${currentChannelId}). Reply will land in the parent group, not the thread. If the agent ` +
+        `meant to reply to the thread, pass the full target "group:${currentChannelId}".`,
+      );
+    }
+  }
 
   // Send text message
   if (message) {

--- a/openclaw-channel-dmwork/src/channel.test.ts
+++ b/openclaw-channel-dmwork/src/channel.test.ts
@@ -1,6 +1,34 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
 
+// Mock api-fetch so outbound adapter wiring tests (below) can observe the
+// final sendMessage / sendMediaMessage arguments without actually hitting
+// DMWork. Real implementations still ship in the bundle — this is test-only.
+vi.mock("./api-fetch.js", async () => {
+  return {
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendMediaMessage: vi.fn().mockResolvedValue(undefined),
+    getUploadCredentials: vi.fn().mockResolvedValue({
+      credentials: { TmpSecretId: "id", TmpSecretKey: "k", Token: "t" },
+      startTime: 0,
+      expiredTime: 0,
+      bucket: "b", region: "r", key: "k",
+      cdnBaseUrl: "https://cdn.example/",
+    }),
+    uploadFileToCOS: vi.fn().mockResolvedValue({ url: "https://cdn.example/file.txt" }),
+    inferContentType: (fn: string) =>
+      fn.endsWith(".txt") ? "text/plain" : "application/octet-stream",
+    ensureTextCharset: (ct: string) =>
+      ct.startsWith("text/") && !ct.includes("charset") ? ct + "; charset=utf-8" : ct,
+    parseImageDimensions: () => null,
+    parseImageDimensionsFromFile: async () => null,
+    registerBot: vi.fn(),
+    sendHeartbeat: vi.fn(),
+    fetchBotGroups: vi.fn().mockResolvedValue([]),
+    getGroupMd: vi.fn(),
+  };
+});
+
 // ─── Token refresh cooldown tests ───────────────────────────────────────────
 // These test the time-based cooldown pattern used in channel.ts onError handler
 // to prevent token refresh storms.
@@ -180,44 +208,68 @@ describe("resolveOutboundAccountId", () => {
     const result = resolveOutboundAccountId("user:some_uid", "fallback_acct");
     expect(result).toBe("fallback_acct");
   });
+
+  // channel:<id> is an alternative prefix OpenClaw's delivery pipeline can emit
+  // for group channels. If the normalisation layer misses it, the group→account
+  // lookup silently falls back to the caller-provided accountId and the turn
+  // goes out through the wrong bot's token. Keep these three cases as a
+  // regression guard for the prefix-normalisation step in particular.
+
+  it("should resolve channel:<id> alias like group:<id>", async () => {
+    const { registerGroupToAccount, resolveOutboundAccountId } = await import("./channel.js");
+    registerGroupToAccount("abc", "acct_chan");
+    const result = resolveOutboundAccountId("channel:abc", "fallback");
+    expect(result).toBe("acct_chan");
+  });
+
+  it("should resolve channel:<id>____<short> to the parent group's account", async () => {
+    const { registerGroupToAccount, resolveOutboundAccountId } = await import("./channel.js");
+    registerGroupToAccount("abc", "acct_thread");
+    const result = resolveOutboundAccountId("channel:abc____topicA", "fallback");
+    expect(result).toBe("acct_thread");
+  });
+
+  it("should strip @uid suffix from channel:<id>@uid1,uid2 target", async () => {
+    const { registerGroupToAccount, resolveOutboundAccountId } = await import("./channel.js");
+    registerGroupToAccount("abc", "acct_chan_uid");
+    const result = resolveOutboundAccountId("channel:abc@uid1,uid2", "fallback");
+    expect(result).toBe("acct_chan_uid");
+  });
 });
 
-describe("resolveOutboundAccountId — explicit accountId should not be overridden", () => {
+describe("resolveOutboundAccountId — group→account correction semantics", () => {
   beforeEach(() => {
     vi.resetModules();
   });
 
-  it("should NOT override explicit non-default accountId even when group is registered to another account", async () => {
+  it("corrects unambiguously owned single-bot groups even when a different accountId is explicitly passed", async () => {
+    // Intent: if the group belongs to exactly one configured bot, always use
+    // that bot's accountId — otherwise the turn goes out with a token the
+    // backend will reject (bot not a member of the group). This is the safe
+    // default; explicit accountId is only meaningful when the group has
+    // multiple bots registered to it (see next test).
     const { registerGroupToAccount, resolveOutboundAccountId } = await import("./channel.js");
-
-    // group registered to thomas_fu_bot
     registerGroupToAccount("some_group", "thomas_fu_bot");
-
-    // User explicitly passes allen-imtest — resolveOutboundAccountId would return thomas_fu_bot,
-    // but the caller (sendText/sendMedia) should not call resolveOutboundAccountId when accountId != default.
-    // We test that resolveOutboundAccountId itself still resolves to the registered account...
     const resolved = resolveOutboundAccountId("group:some_group", "allen-imtest");
-    expect(resolved).toBe("thomas_fu_bot"); // resolveOutboundAccountId always resolves
-
-    // ...but the sendText/sendMedia logic should gate on rawAccountId === DEFAULT_ACCOUNT_ID.
-    // Simulate the gating logic:
-    const rawAccountId: string = "allen-imtest"; // explicit, non-default
-    const accountId = (rawAccountId === DEFAULT_ACCOUNT_ID)
-      ? resolveOutboundAccountId("group:some_group", rawAccountId)
-      : rawAccountId;
-    expect(accountId).toBe("allen-imtest"); // NOT corrected
+    expect(resolved).toBe("thomas_fu_bot");
   });
 
-  it("should correct when accountId is default", async () => {
+  it("falls back to explicit accountId when group is shared by multiple bots", async () => {
+    // When >1 bots are registered to the same group, resolveAccountForGroup
+    // returns undefined and we honour whatever the caller passed — this is
+    // where "explicit accountId wins" applies.
     const { registerGroupToAccount, resolveOutboundAccountId } = await import("./channel.js");
+    registerGroupToAccount("shared_group", "bot_a");
+    registerGroupToAccount("shared_group", "bot_b");
+    const resolved = resolveOutboundAccountId("group:shared_group", "bot_a");
+    expect(resolved).toBe("bot_a");
+  });
 
+  it("corrects when rawAccountId is the DEFAULT alias", async () => {
+    const { registerGroupToAccount, resolveOutboundAccountId } = await import("./channel.js");
     registerGroupToAccount("some_group", "thomas_fu_bot");
-
-    const rawAccountId = DEFAULT_ACCOUNT_ID;
-    const accountId = (rawAccountId === DEFAULT_ACCOUNT_ID)
-      ? resolveOutboundAccountId("group:some_group", rawAccountId)
-      : rawAccountId;
-    expect(accountId).toBe("thomas_fu_bot"); // corrected
+    const resolved = resolveOutboundAccountId("group:some_group", DEFAULT_ACCOUNT_ID);
+    expect(resolved).toBe("thomas_fu_bot");
   });
 });
 
@@ -376,5 +428,288 @@ describe("sendText v2 mention processing logic", () => {
     // hasAtAll should be true
     const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(converted.content);
     expect(hasAtAll).toBe(true);
+  });
+});
+
+// ─── outbound adapter wiring (thread cross-channel regression) ──────────────
+// These exercise the full sendText / sendMedia adapter path — not just the
+// resolveOutboundDmworkTarget helper — to pin down that ctx.threadId is
+// correctly wired from framework input all the way to sendMessage /
+// sendMediaMessage. Motivated by the bug where OpenClaw passed
+// to="group:<group_no>" + threadId="<short>" and files silently landed in
+// the parent group (channel_type=2) instead of the sub-topic (5).
+
+describe("outbound.sendText — threadId wiring", () => {
+  const cfg = {
+    channels: {
+      dmwork: {
+        apiUrl: "https://api.example",
+        accounts: {
+          default: { botToken: "bf_test", apiUrl: "https://api.example" },
+        },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.sendMessage as any).mockClear();
+  });
+
+  it("merges ctx.threadId into the group target as CommunityTopic (type=5)", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grp1",
+      threadId: "topicA",
+      text: "hi from bot",
+      accountId: "default",
+    } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage as any).mock.calls[0][0];
+    expect(call.channelId).toBe("grp1____topicA");
+    expect(call.channelType).toBe(5); // ChannelType.CommunityTopic
+    expect(call.content).toBe("hi from bot");
+  });
+
+  it("leaves a parent-group target (no threadId) as Group (type=2)", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grp1",
+      text: "parent group reply",
+      accountId: "default",
+    } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage as any).mock.calls[0][0];
+    expect(call.channelId).toBe("grp1");
+    expect(call.channelType).toBe(2); // ChannelType.Group
+  });
+
+  it("accepts channel:<id> alias + threadId and routes to CommunityTopic", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendText!({
+      cfg,
+      to: "channel:grp1",
+      threadId: "topicA",
+      text: "hi",
+      accountId: "default",
+    } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage as any).mock.calls[0][0];
+    expect(call.channelId).toBe("grp1____topicA");
+    expect(call.channelType).toBe(5);
+  });
+});
+
+describe("outbound.sendMedia — threadId wiring", () => {
+  const cfg = {
+    channels: {
+      dmwork: {
+        apiUrl: "https://api.example",
+        accounts: {
+          default: { botToken: "bf_test", apiUrl: "https://api.example" },
+        },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.sendMediaMessage as any).mockClear();
+    (apiFetch.getUploadCredentials as any).mockClear();
+    (apiFetch.uploadFileToCOS as any).mockClear();
+  });
+
+  it("merges ctx.threadId into the group target as CommunityTopic (type=5)", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendMedia!({
+      cfg,
+      to: "group:grp1",
+      threadId: "topicA",
+      text: "",
+      mediaUrl: "data:text/plain;base64,aGVsbG8=",
+      accountId: "default",
+    } as any);
+
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMediaMessage as any).mock.calls[0][0];
+    expect(call.channelId).toBe("grp1____topicA");
+    expect(call.channelType).toBe(5);
+    expect(call.url).toBe("https://cdn.example/file.txt");
+  });
+
+  it("leaves a parent-group target (no threadId) as Group (type=2)", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendMedia!({
+      cfg,
+      to: "group:grp1",
+      text: "",
+      mediaUrl: "data:text/plain;base64,aGVsbG8=",
+      accountId: "default",
+    } as any);
+
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMediaMessage as any).mock.calls[0][0];
+    expect(call.channelId).toBe("grp1");
+    expect(call.channelType).toBe(2);
+  });
+
+  it("accepts channel:<id> alias + threadId and routes to CommunityTopic", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendMedia!({
+      cfg,
+      to: "channel:grp1",
+      threadId: "topicA",
+      text: "",
+      mediaUrl: "data:text/plain;base64,aGVsbG8=",
+      accountId: "default",
+    } as any);
+
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMediaMessage as any).mock.calls[0][0];
+    expect(call.channelId).toBe("grp1____topicA");
+    expect(call.channelType).toBe(5);
+  });
+
+  it("preserves an already-synthesised channel_id even if threadId is also passed", async () => {
+    const { dmworkPlugin } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+
+    await dmworkPlugin.outbound!.sendMedia!({
+      cfg,
+      to: "group:grp1____topicA",
+      threadId: "different",
+      text: "",
+      mediaUrl: "data:text/plain;base64,aGVsbG8=",
+      accountId: "default",
+    } as any);
+
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMediaMessage as any).mock.calls[0][0];
+    // ctx.to wins; duplicate threadId must not re-concat or downgrade.
+    expect(call.channelId).toBe("grp1____topicA");
+    expect(call.channelType).toBe(5);
+  });
+});
+
+// ─── outbound accountId correction — end-to-end token assertion ─────────────
+// These close the gap the review flagged: resolveOutboundAccountId's behaviour
+// is covered in isolation, but the outbound adapters (sendText/sendMedia) also
+// have to actually USE the corrected accountId's botToken when calling the
+// DMWork API. Without these tests, a regression in the wiring (e.g. passing
+// the original ctx.accountId to resolveDmworkAccount instead of the corrected
+// one) would go undetected.
+
+describe("outbound sendText/sendMedia — accountId correction threads through to API", () => {
+  const cfgWithTwoBots = {
+    channels: {
+      dmwork: {
+        apiUrl: "https://api.example",
+        accounts: {
+          "bot-a": { botToken: "tok-bot-a", apiUrl: "https://api.example" },
+          "bot-b": { botToken: "tok-bot-b", apiUrl: "https://api.example" },
+        },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    // Reset module state so _groupToAccounts doesn't leak across these tests —
+    // otherwise an earlier "shared group" registration would leave the group
+    // ambiguous for the next test, silently masking the correction under test.
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("sendText corrects to the group-owning bot's token when group has a single owner, even if a different accountId is passed", async () => {
+    const { dmworkPlugin, registerGroupToAccount } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    // Group grp1 belongs to bot-b only; caller passed bot-a.
+    registerGroupToAccount("grp1", "bot-b");
+
+    await dmworkPlugin.outbound!.sendText!({
+      cfg: cfgWithTwoBots,
+      to: "group:grp1",
+      text: "hi",
+      accountId: "bot-a",
+    } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage as any).mock.calls[0][0];
+    expect(call.botToken).toBe("tok-bot-b"); // corrected from bot-a → bot-b
+  });
+
+  it("sendMedia corrects to the group-owning bot's token", async () => {
+    const { dmworkPlugin, registerGroupToAccount } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+
+    registerGroupToAccount("grp1", "bot-b");
+
+    await dmworkPlugin.outbound!.sendMedia!({
+      cfg: cfgWithTwoBots,
+      to: "group:grp1",
+      text: "",
+      mediaUrl: "data:text/plain;base64,aGVsbG8=",
+      accountId: "bot-a",
+    } as any);
+
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMediaMessage as any).mock.calls[0][0];
+    expect(call.botToken).toBe("tok-bot-b");
+  });
+
+  it("sendText respects explicit accountId when group is shared by multiple bots (no single owner)", async () => {
+    const { dmworkPlugin, registerGroupToAccount } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    // Shared group — resolveAccountForGroup returns undefined for ambiguity.
+    registerGroupToAccount("grp1", "bot-a");
+    registerGroupToAccount("grp1", "bot-b");
+
+    await dmworkPlugin.outbound!.sendText!({
+      cfg: cfgWithTwoBots,
+      to: "group:grp1",
+      text: "hi",
+      accountId: "bot-a",
+    } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage as any).mock.calls[0][0];
+    expect(call.botToken).toBe("tok-bot-a"); // explicit choice honoured
+  });
+
+  it("sendText corrects through the channel:<id> prefix alias too", async () => {
+    const { dmworkPlugin, registerGroupToAccount } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    registerGroupToAccount("grp1", "bot-b");
+
+    await dmworkPlugin.outbound!.sendText!({
+      cfg: cfgWithTwoBots,
+      to: "channel:grp1",
+      text: "hi",
+      accountId: "bot-a",
+    } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage as any).mock.calls[0][0];
+    expect(call.botToken).toBe("tok-bot-b");
   });
 });

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -29,7 +29,7 @@ import { handleInboundMessage, type DmworkStatusSink } from "./inbound.js";
 import { ChannelType, MessageType, type BotMessage, type MessagePayload } from "./types.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions } from "./mention-utils.js";
 import type { MentionEntity } from "./types.js";
-import { handleDmworkMessageAction, parseTarget } from "./actions.js";
+import { handleDmworkMessageAction, parseTarget, resolveOutboundDmworkTarget, normalizeOutboundChannelPrefix, extractInlineMentionUids } from "./actions.js";
 import { createDmworkManagementTools } from "./agent-tools.js";
 import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk } from "./group-md.js";
 import { registerOwnerUid } from "./owner-registry.js";
@@ -233,9 +233,13 @@ async function checkForUpdates(
 
 /** Resolve correct accountId for outbound context using group→account mapping */
 export function resolveOutboundAccountId(ctxTo: string, fallbackAccountId: string): string {
-  let targetForParse = ctxTo;
-  if (ctxTo.startsWith("group:")) {
-    const groupPart = ctxTo.slice(6);
+  // Same prefix / inline-mention-UID normalisation as the outbound send path —
+  // otherwise `channel:<id>` never makes it past parseTarget (which doesn't
+  // recognise that prefix) and the group→account lookup silently falls back,
+  // routing the turn through the wrong bot's token.
+  let targetForParse = normalizeOutboundChannelPrefix(ctxTo);
+  if (targetForParse.startsWith("group:")) {
+    const groupPart = targetForParse.slice(6);
     const atIdx = groupPart.indexOf("@");
     if (atIdx >= 0) targetForParse = "group:" + groupPart.slice(0, atIdx);
   }
@@ -350,6 +354,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       return [
         `IMPORTANT: Your DMWork accountId is "${accountId}". You MUST always pass accountId: "${accountId}" when using the dmwork_management tool. Do NOT use any other accountId.`,
         `For sending messages: if the target is a group, use target="group:<groupId>". If the target is a specific user (1v1 direct message), use target="user:<userId>". If sending to the current conversation, no prefix is needed.`,
+        `For threads/sub-topics: if you are explicitly targeting a thread, the target MUST be the full "group:<group_no>____<short_id>" (four underscores) — do not send just the parent "group:<group_no>" or the reply will land in the parent group instead of the thread. The same rule applies to file uploads.`,
         `For reading message history: use action="read" with target="user:<uid>" to read DM history, or target="group:<groupId>" to read group message history. Cross-channel queries require the requester to be a participant of the target channel.`,
         `For searching: use action="search" with query="shared-groups" to find groups that the bot and the current user both belong to.`,
       ];
@@ -399,21 +404,13 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         return { channel: "dmwork", to: ctx.to, messageId: "" };
       }
 
-      // Parse target using shared parseTarget + knownGroupIds
-      let mentionUids: string[] = [];
-      let targetForParse = ctx.to;
+      // Parse target — merge framework-provided threadId into CommunityTopic
+      // channel_id when ctx.to is a bare group. Inline mention UIDs
+      // (`(group|channel):<id>@uid1,uid2`) are pulled out here via the
+      // shared extractor so both prefix forms propagate UIDs consistently.
+      const mentionUids: string[] = extractInlineMentionUids(ctx.to);
 
-      // Handle "group:channel_id@uid1,uid2" format — extract inline mention UIDs
-      if (ctx.to.startsWith("group:")) {
-        const groupPart = ctx.to.slice(6);
-        const atIdx = groupPart.indexOf("@");
-        if (atIdx >= 0) {
-          targetForParse = "group:" + groupPart.slice(0, atIdx);
-          mentionUids = groupPart.slice(atIdx + 1).split(",").filter(Boolean);
-        }
-      }
-
-      const { channelId, channelType } = parseTarget(targetForParse, undefined, getKnownGroupIds());
+      const { channelId, channelType } = resolveOutboundDmworkTarget(ctx.to, ctx.threadId);
 
       let mentionEntities: MentionEntity[] = [];
       let finalContent = content;
@@ -572,14 +569,9 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
           filename,
         });
 
-        // 3. Parse target using shared parseTarget + knownGroupIds
-        let targetForParse = ctx.to;
-        if (ctx.to.startsWith("group:")) {
-          const groupPart = ctx.to.slice(6);
-          const atIdx = groupPart.indexOf("@");
-          if (atIdx >= 0) targetForParse = "group:" + groupPart.slice(0, atIdx);
-        }
-        const { channelId, channelType } = parseTarget(targetForParse, undefined, getKnownGroupIds());
+        // 3. Resolve target — merge framework-provided threadId into
+        // CommunityTopic (channel_type=5) when ctx.to is a bare group.
+        const { channelId, channelType } = resolveOutboundDmworkTarget(ctx.to, ctx.threadId);
 
         // 4. Determine message type and send
         const msgType = contentType.startsWith("image/")


### PR DESCRIPTION
## 背景

OpenClaw 在 outbound 投递到子区（thread / sub-topic）时，通过 `ChannelOutboundContext` 传入的是 **`to: "group:<group_no>"` + 独立的 `threadId: "<short_id>"`** 两个字段。

我们插件的 `outbound.sendText` / `outbound.sendMedia` 之前只解析 `ctx.to`，**完全没有读 `ctx.threadId`**。结果：

- `channelId = "<group_no>"`（丢失 short_id）
- `channelType = 2` (Group，应该是 5 CommunityTopic)

**文件/消息本应发到子区，实际落到了父群**。真机复现验证过：`POST /v1/bot/messages/sync` 用 `channel_type=5` 查不到发出的文件，换 `channel_type=2` 却能查到。

## 改动

### 1. 新增 `resolveOutboundDmworkTarget(ctxTo, threadId)` helper (`actions.ts`)

合成 `<group>____<short>` 形式 + `channel_type=5`。边界处理：

- 归一化 `channel:<id>` alias 前缀为 `group:<id>`（parseTarget 不认识 `channel:`）
- 剥离 inline mention UID 后缀 (`(group|channel):<id>@uid1,uid2`)
- 幂等：`ctx.to` 已包含 `____` 时直接 passthrough，不做重复拼接
- **防御校验**：`threadId` 自带的 `____<parent>` 如果和 `ctx.to` 解析出的父群不一致，忽略 threadId 回落到 `ctx.to` 的父群，避免跨频道泄漏

### 2. 抽出共享 helper

- `normalizeOutboundChannelPrefix(ctxTo)` — 归一 `channel:` → `group:`
- `extractInlineMentionUids(ctxTo)` — 从 `(group|channel):<id>@uid1,uid2` 提取 UID 列表

给 `resolveOutboundDmworkTarget` 和 `resolveOutboundAccountId` 共用，保证 `channel:` 前缀和 mention UID 在两条路径上行为完全一致。修之前 `resolveOutboundAccountId` 只处理 `group:` 前缀的 bug——多 bot 场景 OpenClaw 如果传 `channel:<id>`，group→account 查找会失效，走错 bot token。

### 3. 接线 outbound.sendText / sendMedia (`channel.ts`)

- 两处 `parseTarget(targetForParse, ...)` 调用换成 `resolveOutboundDmworkTarget(ctx.to, ctx.threadId)`
- `sendText` mention UID 提取换用共享 helper，现在也支持 `channel:<id>@uid1,uid2` 形式

### 4. Prompt hint 补强 (`messageToolHints`)

新加一条引导：在子区中显式指定 target 时必须用完整 `group:<group_no>____<short_id>`，减少模型传错父群 target 的概率。

## 测试

### 新增单元测试 (`actions.test.ts`, +21 个)

- `resolveOutboundDmworkTarget` 16 个 case：threadId 合成、数字 threadId、已合成 ctx.to passthrough、冲突场景 ctx.to 优先、DM 目标不受干扰、空 threadId、mention UID 剥离、`dmwork:/group:/channel:` 前缀去除、`channel:` prefix 变体、**threadId 父不一致时的防御回退**（3 个 case：匹配通过 / 不匹配忽略 / 裸 `____` 开头忽略）
- `normalizeOutboundChannelPrefix` 3 个 case
- `extractInlineMentionUids` 4 个 case

### 新增 adapter 层 wiring 测试 (`channel.test.ts`, +11 个)

真实调用 `dmworkPlugin.outbound.sendText/sendMedia`，mock `api-fetch.js` 层观察最终 API 参数：

- `sendText` / `sendMedia` 各覆盖 threadId 合并成 type=5、父群 target 不变为 type=2、`channel:` alias 也正确路由、`____` 已在 ctx.to 时忽略重复 threadId
- **端到端 token 断言**（4 个 case）：多 bot 配置场景，验证纠偏后最终 `sendMessage/sendMediaMessage` 收到的 `botToken` 是 group owner 的那个 bot，覆盖之前只测 helper 不测接线的空白
- 重写了之前有歧义的 \`"explicit accountId should not be overridden"\` 测试组：明确当前语义是"单 bot 群自动纠偏（安全）、多 bot 共享群尊重显式 accountId"

### 新增 `resolveOutboundAccountId` 回归 (`channel.test.ts`, +4 个)

覆盖 `channel:<id>` / `channel:<id>____<short>` / `channel:<id>@uid1,uid2` 和 DEFAULT alias 的 account 纠偏。

## 验证

- [x] \`npx tsc --noEmit\` 通过
- [x] \`npm test\` — **680/680** tests passing
- [x] \`npm run build\` 通过
- [x] **真机验证**：本地装的 plugin 替换后，在子区让 bot 发文件——文件正确落在子区而非父群（两种方式：OpenClaw core outbound 的 COS 直传 + bot 自己手动 curl），前后一致 🎉

## 影响范围

修复影响所有用 dmwork channel plugin 的用户——**子区文件发送 / 子区文字回复会正确路由**，之前是默认翻车。多 bot 配置下如果 OpenClaw 发 `channel:<id>` 前缀的 target，也不再走错 bot token。

🤖 Generated with [Claude Code](https://claude.com/claude-code)