### PR TITLE
fix(dmwork): route threadId through message tool send path

### DIFF
--- a/openclaw-channel-dmwork/src/actions.test.ts
+++ b/openclaw-channel-dmwork/src/actions.test.ts
@@ -583,6 +583,154 @@ describe("handleDmworkMessageAction", () => {
   });
 
   // -----------------------------------------------------------------------
+  // send — threadId routing via resolveOutboundDmworkTarget
+  // -----------------------------------------------------------------------
+  describe("send — threadId routing", () => {
+    it("routes to CommunityTopic when threadId is provided", async () => {
+      registerBotGroupIds(["grp1"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      const result = await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "thread msg" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        threadId: "topicA",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("grp1____topicA");
+      expect(sentPayload.channel_type).toBe(ChannelType.CommunityTopic);
+    });
+
+    it("routes to parent group when threadId is absent", async () => {
+      registerBotGroupIds(["grp1"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      const result = await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "parent msg" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("grp1");
+      expect(sentPayload.channel_type).toBe(ChannelType.Group);
+    });
+
+    it("does NOT trigger parent-group warning when threadId is provided", async () => {
+      registerBotGroupIds(["grp1"]);
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
+      });
+      const logWarn = vi.fn();
+      const logInfo = vi.fn();
+
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "hi from thread" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        threadId: "topicA",
+        log: { warn: logWarn, info: logInfo } as any,
+      });
+
+      expect(logWarn).not.toHaveBeenCalled();
+      expect(logInfo).not.toHaveBeenCalled();
+    });
+
+    it("routes media-only message to CommunityTopic when threadId is provided", async () => {
+      registerBotGroupIds(["grp1"]);
+      const { uploadAndSendMedia } = await import("./inbound.js");
+      const uploadSpy = vi.mocked(uploadAndSendMedia);
+      uploadSpy.mockClear();
+
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      const result = await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", mediaUrl: "https://example.com/file.png" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        threadId: "topicA",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(uploadSpy).toHaveBeenCalledOnce();
+      expect(uploadSpy.mock.calls[0][0]).toMatchObject({
+        channelId: "grp1____topicA",
+        channelType: ChannelType.CommunityTopic,
+      });
+    });
+
+    it("does NOT inject ambient threadId when target is a different group", async () => {
+      registerBotGroupIds(["grp1", "otherGroup"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      const result = await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:otherGroup", message: "cross-group msg" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        threadId: "topicA",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("otherGroup");
+      expect(sentPayload.channel_type).toBe(ChannelType.Group);
+    });
+
+    it("merges threadId when target matches same parent group", async () => {
+      registerBotGroupIds(["grp1"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const { handleDmworkMessageAction } = await import("./actions.js");
+      const result = await handleDmworkMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "same-group msg" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        threadId: "topicA",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("grp1____topicA");
+      expect(sentPayload.channel_type).toBe(ChannelType.CommunityTopic);
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // read action
   // -----------------------------------------------------------------------
   describe("read — same-channel group messages", () => {

--- a/openclaw-channel-dmwork/src/actions.ts
+++ b/openclaw-channel-dmwork/src/actions.ts
@@ -217,11 +217,12 @@ export async function handleDmworkMessageAction(params: {
   uidToNameMap?: Map<string, string>;
   groupMdCache?: Map<string, { content: string; version: number }>;
   currentChannelId?: string;
+  threadId?: string | number | null;
   requesterSenderId?: string;
   accountId?: string;
   log?: LogSink;
 }): Promise<MessageActionResult> {
-  const { action, args, apiUrl, botToken, memberMap, uidToNameMap, groupMdCache, currentChannelId, requesterSenderId, accountId, log } =
+  const { action, args, apiUrl, botToken, memberMap, uidToNameMap, groupMdCache, currentChannelId, threadId, requesterSenderId, accountId, log } =
     params;
 
   if (!botToken) {
@@ -230,7 +231,7 @@ export async function handleDmworkMessageAction(params: {
 
   switch (action) {
     case "send":
-      return handleSend({ args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, log });
+      return handleSend({ args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, threadId, log });
     case "read":
       return handleRead({ args, apiUrl, botToken, uidToNameMap, currentChannelId, requesterSenderId, accountId, log });
     case "search":
@@ -263,9 +264,10 @@ async function handleSend(params: {
   memberMap?: Map<string, string>;
   uidToNameMap?: Map<string, string>;
   currentChannelId?: string;
+  threadId?: string | number | null;
   log?: LogSink;
 }): Promise<MessageActionResult> {
-  const { args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, log } = params;
+  const { args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, threadId, log } = params;
 
   const target = args.target as string | undefined;
   if (!target) {
@@ -285,7 +287,22 @@ async function handleSend(params: {
     };
   }
 
-  const { channelId, channelType } = parseTarget(target, currentChannelId, getKnownGroupIds());
+  let effectiveThreadId: typeof threadId = threadId;
+  if (effectiveThreadId != null && currentChannelId) {
+    const SEP = "____";
+    const currentParent = currentChannelId.includes(SEP)
+      ? currentChannelId.slice(0, currentChannelId.indexOf(SEP))
+      : currentChannelId;
+    const targetRaw = target.replace(/^(group:|channel:)/, "");
+    const targetParent = targetRaw.includes(SEP)
+      ? targetRaw.slice(0, targetRaw.indexOf(SEP))
+      : targetRaw;
+    if (targetParent !== currentParent) {
+      effectiveThreadId = undefined;
+    }
+  }
+
+  const { channelId, channelType } = resolveOutboundDmworkTarget(target, effectiveThreadId);
 
   // UX warning for a specific foot-gun on the message-tool path (#232 review):
   // the agent is replying inside a sub-topic (session's currentChannelId carries

--- a/openclaw-channel-dmwork/src/channel.ts
+++ b/openclaw-channel-dmwork/src/channel.ts
@@ -341,6 +341,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
         uidToNameMap,
         groupMdCache,
         currentChannelId: ctx.toolContext?.currentChannelId ?? undefined,
+        threadId: ctx.toolContext?.threadId ?? ctx.params?.threadId ?? undefined,
         requesterSenderId: ctx.requesterSenderId ?? undefined,
         accountId,
         log: ctx.log,


### PR DESCRIPTION
## Summary

Fix thread message delivery failure: messages sent via the message tool's `handleAction → handleSend` path ignored `threadId`, causing them to land in the parent group instead of the target sub-topic.

## Root Cause

PR #232 fixed the outbound adapter path (`sendText`/`sendMedia`) but missed the message tool path. `handleSend` used `parseTarget(target)` which has no concept of `threadId`, so thread-targeted messages were always routed to `channelType=2` (Group) instead of `channelType=5` (CommunityTopic).

## Changes

- **channel.ts**: Pass `ctx.toolContext.threadId` through to `handleDmworkMessageAction`
- **actions.ts**: 
  - Add `threadId` to `handleDmworkMessageAction` params and forward to `handleSend`
  - Replace `parseTarget()` with `resolveOutboundDmworkTarget()` (already handles threadId merge)
  - Add cross-group guard: only apply ambient threadId when target's parent group matches the current thread context's parent — prevents accidental routing to `otherGroup____threadId`

## Tests

6 new integration tests:
1. threadId routes to CommunityTopic (channelType=5)
2. No threadId falls back to Group (channelType=2)
3. Parent-group UX warning does not fire when threadId is present
4. Media-only messages route correctly with threadId
5. Cross-group send does NOT inject ambient threadId
6. Same-group send correctly merges threadId

All 694 tests pass.

Closes #234