### PR TITLE
fix(cli): self-heal plugin enabled after OpenClaw upgrade + complete groupId/content descriptions

### DIFF
--- a/openclaw-channel-dmwork/cli/doctor.ts
+++ b/openclaw-channel-dmwork/cli/doctor.ts
@@ -223,6 +223,10 @@ export async function runDoctorChecks(params: {
   }
 
   // 2. Plugin enabled
+  // After OpenClaw major upgrades, plugins.entries.<id>.enabled may be reset on
+  // third-party plugins. Doctor surfaces this as a WARN (not FAIL) with a one-liner
+  // fix command, so users don't have to dig through config to figure out why the bot
+  // went silent.
   if (!params.inProcess) {
     const enabled = reader.get(
       "plugins.entries.openclaw-channel-dmwork.enabled",
@@ -234,10 +238,21 @@ export async function runDoctorChecks(params: {
         configSet("plugins.entries.openclaw-channel-dmwork.enabled", "true");
         checks.push({ name: "Plugin enabled", status: "FIXED", detail: "Enabled" });
       } catch {
-        checks.push({ name: "Plugin enabled", status: "FAIL", detail: "No (auto-fix failed)" });
+        checks.push({
+          name: "Plugin enabled",
+          status: "FAIL",
+          detail:
+            "No (auto-fix failed; run `openclaw plugins enable openclaw-channel-dmwork`)",
+        });
       }
     } else {
-      checks.push({ name: "Plugin enabled", status: "FAIL", detail: "No" });
+      checks.push({
+        name: "Plugin enabled",
+        status: "WARN",
+        detail:
+          "No — installed but disabled. Run `openclaw-channel-dmwork doctor --fix` " +
+          "or `openclaw plugins enable openclaw-channel-dmwork`.",
+      });
     }
   }
 

--- a/openclaw-channel-dmwork/cli/install.test.ts
+++ b/openclaw-channel-dmwork/cli/install.test.ts
@@ -175,4 +175,51 @@ describe("runInstall — update scenario", () => {
     expect(pluginsInstallSpec(calls)).toBe("openclaw-channel-dmwork");
     expect(didCallGatewayRestart(calls)).toBe(true);
   });
+
+  it("already target version + entries.enabled=false: self-heals enabled, no install, no restart", async () => {
+    // Regression: install used to early-return on already-at-target, bypassing
+    // the self-heal that re-enables the plugin after OpenClaw major upgrades
+    // reset entries.<id>.enabled.
+    const fs = await import("node:fs");
+    const mockReadFileSync = vi.mocked(fs.readFileSync);
+    const mockWriteFileSync = vi.mocked(fs.writeFileSync);
+
+    mockReadFileSync.mockImplementation((path) => {
+      if (String(path).endsWith("openclaw.json")) {
+        return JSON.stringify({
+          plugins: {
+            entries: { "openclaw-channel-dmwork": { enabled: false } },
+            installs: {
+              "openclaw-channel-dmwork": { source: "npm", version: "0.6.0" },
+            },
+          },
+        });
+      }
+      return "{}";
+    });
+
+    const { runInstall } = await loadInstall();
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const a = args as string[];
+      if (a[0] === "config" && a[1] === "file") return "/home/user/.openclaw/openclaw.json";
+      if (a[0] === "--version") return "OpenClaw 2026.4.15\n";
+      if (a[0] === "plugins" && a[1] === "inspect") {
+        return JSON.stringify({ plugin: { id: "openclaw-channel-dmwork", version: "0.6.0", enabled: false } });
+      }
+      if (a[0] === "view") return "0.6.0\n";
+      return "";
+    });
+
+    await runInstall({ force: false, dev: false });
+
+    const calls = getCalledArgs();
+    expect(didCallPluginsInstall(calls)).toBe(false);
+    expect(didCallGatewayRestart(calls)).toBe(false);
+
+    // Self-heal must have written a config with enabled: true
+    const writes = mockWriteFileSync.mock.calls.map((c) => String(c[1]));
+    const enabledWrite = writes.find((w) => w.includes('"enabled": true'));
+    expect(enabledWrite).toBeDefined();
+  });
 });

--- a/openclaw-channel-dmwork/cli/install.ts
+++ b/openclaw-channel-dmwork/cli/install.ts
@@ -16,6 +16,7 @@ import {
   cleanupBrokenInstall,
   deleteLegacyBackup,
   detectScenario,
+  ensurePluginEnabled,
   ensurePluginsAllow,
   gatewayRestart,
   getConfigFilePathSafe,
@@ -87,15 +88,15 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       const targetVersion = getLatestNpmVersion(tag);
 
       if (!targetVersion) {
-        // Cannot determine target — skip install and restart
+        // Cannot determine target — skip install and restart, but still self-heal config below
         console.log(`Cannot reach npm registry to check ${tag} version.`);
         console.log(`Current version: v${currentVersion}`);
-        return;
+        break;
       }
 
       if (currentVersion === targetVersion) {
         console.log(`DMWork plugin v${currentVersion} is already the target version${opts.dev ? " (dev)" : ""}. No update needed.`);
-        return; // Nothing changed — skip gateway restart
+        break; // No install/restart needed, but self-heal still runs (didChange stays false)
       }
 
       console.log(`Updating DMWork plugin: v${currentVersion} → v${targetVersion}${opts.dev ? " (dev)" : ""}...`);
@@ -125,6 +126,14 @@ export async function runInstall(opts: InstallOptions): Promise<void> {
       didChange = true;
       break;
   }
+
+  // Self-heal config — runs even when no install happened (already-at-target case).
+  // After OpenClaw major upgrades (4.x → 5.x), plugins.entries.<id>.enabled has been
+  // observed to be reset to false on third-party plugins, leaving the plugin installed
+  // but inactive. This restores it without requiring users to run
+  // `openclaw plugins enable openclaw-channel-dmwork` manually.
+  ensurePluginsAllow();
+  ensurePluginEnabled();
 
   if (!didChange) return;
 

--- a/openclaw-channel-dmwork/cli/openclaw-cli.ts
+++ b/openclaw-channel-dmwork/cli/openclaw-cli.ts
@@ -927,6 +927,36 @@ export function ensurePluginsAllow(): void {
   } catch { /* best effort */ }
 }
 
+/**
+ * Ensure plugins.entries.openclaw-channel-dmwork.enabled === true.
+ *
+ * Why: OpenClaw 4.x → 5.x major upgrades have been observed to reset
+ * `plugins.entries.<id>.enabled` for third-party plugins, leaving the
+ * plugin installed but inactive. install calls this to self-heal so users
+ * don't have to manually run `openclaw plugins enable ...`.
+ *
+ * (doctor surfaces the same issue but uses its own `openclaw config set` path
+ * via --fix, so it does not call this helper directly.)
+ *
+ * Idempotent and best-effort: returns true if entry is now (or was already)
+ * enabled, false on any I/O error.
+ */
+export function ensurePluginEnabled(): boolean {
+  try {
+    const cfg = readConfigFromFile();
+    if (!cfg) return false;
+    const plugins = (cfg.plugins ??= {});
+    const entries = (plugins.entries ??= {});
+    const entry = (entries["openclaw-channel-dmwork"] ??= {});
+    if (entry.enabled === true) return true;
+    entry.enabled = true;
+    writeConfigAtomic(cfg);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // pluginsUpdateCompat
 // ---------------------------------------------------------------------------

--- a/openclaw-channel-dmwork/src/agent-tools.ts
+++ b/openclaw-channel-dmwork/src/agent-tools.ts
@@ -122,12 +122,17 @@ export function createDmworkManagementTools(params: {
           groupId: {
             type: "string",
             description:
-              "The group_no (group ID). Required for group-info, group-members, group-md-read, group-md-update.",
+              "The group_no (group ID). Required for all group-level actions " +
+              "(group-info, group-members, group-md-read, group-md-update, update-group, " +
+              "add-members, remove-members) and all thread actions " +
+              "(create-thread, list-threads, get-thread, delete-thread, list-thread-members, " +
+              "join-thread, leave-thread, thread-md-read, thread-md-update). " +
+              "Not required for: list-groups, search-members, create-group, voice-context-*.",
           },
           content: {
             type: "string",
             description:
-              "The new content. Required for group-md-update and voice-context-update.",
+              "The new content. Required for group-md-update, thread-md-update, and voice-context-update.",
           },
           keyword: {
             type: "string",


### PR DESCRIPTION
## Summary

修复一对升级时静默失效的问题 + 补全 LLM tool schema 描述。

### 1. CLI 自愈：升级 OpenClaw 后插件 disabled (octo #2 / #3)

**问题**：OpenClaw 4.x → 5.x 升级会把第三方插件的 `plugins.entries.openclaw-channel-dmwork.enabled` 重置为 false。bot 静默掉线，用户必须手动跑 `openclaw plugins enable openclaw-channel-dmwork` 才能恢复。

**修复**：
- 新增 `ensurePluginEnabled()` helper（仿 `ensurePluginsAllow()` 的 best-effort/idempotent 范式）
- `install.ts` 末尾无条件调用 self-heal —— 即使是 already-at-target 路径（最常见的"重跑 install 自救"场景）。原本两处早退 `return` 改为 `break`
- `doctor.ts` 的 "Plugin enabled" 失败提示从 FAIL 改为 WARN + 给出可执行命令；--fix 路径不变

### 2. agent-tools schema 补全 (octo #4 / GH #237)

**问题**：`groupId` description 只列了 4 个 group-level action，但运行时实际要求 16 个 action 都传 groupId。LLM 看 schema 第一次必失败、第二次 retry 才成功 —— 每次 thread/group-mgmt 操作都浪费一次 tool call。

**修复**：
- `groupId` description 列全 7 个 group-level + 9 个 thread action，并加 \"Not required for\" 否定列表
- `content` description 顺手补 `thread-md-update`（同样问题，runtime 要求但 schema 没说）

## Test Plan

- [x] \`npx tsc --noEmit\` 通过
- [x] \`npm test\` 全套 22 文件 / 695 passed（含一个新增 regression test：already-target + enabled=false → 写回 enabled=true 且不重启 gateway）
- [x] \`npm run build\` 通过
- [ ] reviewer 验证：本地把 \`plugins.entries.openclaw-channel-dmwork.enabled\` 手动改成 false → \`openclaw doctor\` 看到 WARN + 命令；跑 \`npx openclaw-channel-dmwork install\` 看到 enabled 被写回 true 且不重启 gateway

## Refs

- octo-issues #2: install 末尾自动 enable 插件
- octo-issues #3: doctor 检测「已安装但 disabled」
- octo-issues #4: agent-tools.ts groupId description 缺失
- GitHub dmwork-org/dmwork-adapters#237 (groupId description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)