### PR TITLE
feat(dmwork): persona-clone adapter passthrough (onBehalfOf → on_behalf_of)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- openclaw-channel-dmwork: new optional account config `onBehalfOf`. When set, the adapter forwards `on_behalf_of` on every `/v1/bot/sendMessage` request so the bot can post as a real user under a Persona Clone (OBO) grant. Unset → identical behavior to before (field omitted from request body).
+
 ## [0.3.6] - 2026-03-14
 
 ### Changed

--- a/openclaw-channel-dmwork/README.md
+++ b/openclaw-channel-dmwork/README.md
@@ -90,6 +90,7 @@ Configuration fields per account:
 - `wsUrl` (optional): DMWORK WebSocket URL. Auto-detected if omitted.
 - `requireMention` (optional): Only respond when @mentioned in groups
 - `historyLimit` (optional): Group chat history message limit (default: 20)
+- `onBehalfOf` (optional): Real user UID this bot sends on behalf of (Persona Clone / OBO). When set, every outbound message includes `on_behalf_of` and is delivered as that user. Requires an active server-side OBO grant; otherwise the server returns 403. Leave empty/unset for normal bot behavior.
 
 ## What it does
 

--- a/openclaw-channel-dmwork/src/accounts.ts
+++ b/openclaw-channel-dmwork/src/accounts.ts
@@ -21,6 +21,7 @@ export type ResolvedDmworkAccount = {
     requireMention?: boolean;
     historyLimit?: number;  // 群聊历史消息条数限制
     historyPromptTemplate?: string;  // Template for group history context injection
+    onBehalfOf?: string;  // Persona Clone / OBO: real user UID to send on behalf of
   };
 };
 
@@ -87,6 +88,7 @@ export function resolveDmworkAccount(params: {
       requireMention: accountConfig.requireMention ?? channel.requireMention,
       historyLimit: accountConfig.historyLimit ?? channel.historyLimit ?? 20,
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
+      onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
     },
   };
 }

--- a/openclaw-channel-dmwork/src/api-fetch.test.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.test.ts
@@ -1201,3 +1201,102 @@ describe("sendMessage — mentionAll serialization", () => {
     expect(sentBody.payload.mention).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// sendMessage / sendMediaMessage — onBehalfOf (Persona Clone / OBO) passthrough
+// ---------------------------------------------------------------------------
+describe("sendMessage — onBehalfOf passthrough", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("onBehalfOf 设置后请求体应包含 on_behalf_of", async () => {
+    let sentBody: any = null;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      sentBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { sendMessage } = await import("./api-fetch.js");
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      content: "代发的回复",
+      onBehalfOf: "yu_uid",
+    });
+
+    expect(sentBody.on_behalf_of).toBe("yu_uid");
+    // 兼容性: payload 内部结构不变
+    expect(sentBody.channel_id).toBe("group1");
+    expect(sentBody.payload.content).toBe("代发的回复");
+  });
+
+  it("onBehalfOf 未设置 / 空串时请求体不应包含该字段（向后兼容）", async () => {
+    let bodies: any[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(init?.body as string));
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { sendMessage } = await import("./api-fetch.js");
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      content: "normal",
+    });
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      content: "normal",
+      onBehalfOf: "",
+    });
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).not.toHaveProperty("on_behalf_of");
+    expect(bodies[1]).not.toHaveProperty("on_behalf_of");
+  });
+
+  it("sendMediaMessage 也应透传 on_behalf_of", async () => {
+    let sentBody: any = null;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      sentBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { sendMediaMessage } = await import("./api-fetch.js");
+    await sendMediaMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      type: MessageType.Image,
+      url: "https://cdn.example.com/img.png",
+      width: 100,
+      height: 100,
+      onBehalfOf: "yu_uid",
+    });
+
+    expect(sentBody.on_behalf_of).toBe("yu_uid");
+  });
+});

--- a/openclaw-channel-dmwork/src/api-fetch.ts
+++ b/openclaw-channel-dmwork/src/api-fetch.ts
@@ -68,6 +68,7 @@ export async function sendMediaMessage(params: {
   height?: number;
   mentionUids?: string[];
   mentionEntities?: MentionEntity[];
+  onBehalfOf?: string;
   signal?: AbortSignal;
 }): Promise<void> {
   const payload: Record<string, unknown> = {
@@ -102,6 +103,7 @@ export async function sendMediaMessage(params: {
   await postJson(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
     channel_id: params.channelId,
     channel_type: params.channelType,
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
     payload,
   }, params.signal);
 }
@@ -206,6 +208,7 @@ export async function sendMessage(params: {
   mentionEntities?: MentionEntity[];
   mentionAll?: boolean;
   replyMsgId?: string;
+  onBehalfOf?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
@@ -237,6 +240,7 @@ export async function sendMessage(params: {
   return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
     channel_id: params.channelId,
     channel_type: params.channelType,
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
     payload,
   }, params.signal);
 }

--- a/openclaw-channel-dmwork/src/config-schema.ts
+++ b/openclaw-channel-dmwork/src/config-schema.ts
@@ -13,6 +13,7 @@ export interface DmworkAccountConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
+  onBehalfOf?: string;  // 该 bot 代理发送的真人 uid。设置后,所有 outbound 消息以该 uid 身份发出。
 }
 
 export interface DmworkConfig {
@@ -28,6 +29,7 @@ export interface DmworkConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
+  onBehalfOf?: string;  // 该 bot 代理发送的真人 uid。设置后,所有 outbound 消息以该 uid 身份发出。
   accounts?: Record<string, DmworkAccountConfig | undefined>;
 }
 
@@ -52,6 +54,7 @@ export const DmworkConfigJsonSchema = {
       botUid: { type: "string" },
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
+      onBehalfOf: { type: "string" },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -69,6 +72,7 @@ export const DmworkConfigJsonSchema = {
             botUid: { type: "string" },
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
+            onBehalfOf: { type: "string" },
           },
         },
       },

--- a/openclaw-channel-dmwork/src/inbound.ts
+++ b/openclaw-channel-dmwork/src/inbound.ts
@@ -92,9 +92,10 @@ export async function uploadAndSendMedia(params: {
   botToken: string;
   channelId: string;
   channelType: ChannelType;
+  onBehalfOf?: string;
   log?: ChannelLogSink;
 }): Promise<void> {
-  const { mediaUrl, apiUrl, botToken, channelId, channelType, log } = params;
+  const { mediaUrl, apiUrl, botToken, channelId, channelType, onBehalfOf, log } = params;
 
   const { createReadStream: fsCreateReadStream, statSync: fsStatSync, createWriteStream: fsCreateWriteStream } = await import("node:fs");
   const { basename, join: pathJoin } = await import("node:path");
@@ -199,6 +200,7 @@ export async function uploadAndSendMedia(params: {
       size: fileSize,
       width,
       height,
+      ...(onBehalfOf ? { onBehalfOf } : {}),
     });
   } finally {
     if (tempPath) await fsUnlink(tempPath).catch(() => {});
@@ -1520,6 +1522,7 @@ export async function handleInboundMessage(params: {
               botToken: account.config.botToken ?? "",
               channelId: replyChannelId,
               channelType: replyChannelType,
+              ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
               log,
             });
           } catch (err) {
@@ -1674,6 +1677,7 @@ export async function handleInboundMessage(params: {
           ...(replyMentionUids.length > 0 ? { mentionUids: replyMentionUids } : {}),
           ...(replyMentionEntities.length > 0 ? { mentionEntities: replyMentionEntities } : {}),
           mentionAll: hasAtAll || undefined,
+          ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
         });
 
         // Save draft for subsequent edit-dedup
@@ -1699,6 +1703,7 @@ export async function handleInboundMessage(params: {
             channelId: replyChannelId,
             channelType: replyChannelType,
             content: "⚠️ 抱歉，处理您的消息时遇到了问题，请稍后重试。",
+            ...(account.config.onBehalfOf ? { onBehalfOf: account.config.onBehalfOf } : {}),
           });
         } catch (sendErr) {
           log?.error?.(`dmwork: failed to send error message: ${String(sendErr)}`);


### PR DESCRIPTION
## Summary

PR-B of RFC `persona-clone` (§6 Adapter). Adds optional account config
`onBehalfOf` to `openclaw-channel-dmwork`. When set, every outbound
`/v1/bot/sendMessage` request body carries `on_behalf_of=<uid>` so the
bot posts as the configured real user under a server-side Persona Clone
(OBO) grant.

Scoped strictly to the adapter subdir per RFC §6 / §8. Backend protocol
(PR-A) and web UI (PR-C) are out of scope.

Fixes #34

## Diff stats

```
 CHANGELOG.md                                  |  3 +
 openclaw-channel-dmwork/README.md             |  1 +
 openclaw-channel-dmwork/src/accounts.ts       |  2 +
 openclaw-channel-dmwork/src/api-fetch.test.ts | 99 +++++++++++++++++++++++++++
 openclaw-channel-dmwork/src/api-fetch.ts      |  4 ++
 openclaw-channel-dmwork/src/config-schema.ts  |  4 ++
 openclaw-channel-dmwork/src/inbound.ts        |  7 +-
 7 files changed, 119 insertions(+), 1 deletion(-)
```

Core implementation: ~10 LOC. Rest is the test file + docs.

## What changed

- `config-schema.ts` — new optional `onBehalfOf?: string` on both
  `DmworkAccountConfig` and `DmworkConfig`, plus JSON-Schema entry under
  the per-account properties block.
- `accounts.ts` — surface `onBehalfOf` on
  `ResolvedDmworkAccount.config`, falling back from account → channel.
- `api-fetch.ts` — `sendMessage()` and `sendMediaMessage()` accept an
  optional `onBehalfOf` and conditionally include `on_behalf_of` in the
  POST body (omitted when undefined or empty string).
- `inbound.ts` — three send call sites (text reply, error reply, media
  upload) now forward `account.config.onBehalfOf`.
- `README.md` + `CHANGELOG.md` — brief entries.
- `api-fetch.test.ts` — 3 new tests (set / unset / media passthrough).

## Compatibility

When `onBehalfOf` is unset or empty:
- The request body is **byte-identical** to `main`.
- Existing bots see no behavior change.

When `onBehalfOf` is set but backend hasn't merged PR-A
(`Mininglamp-OSS/octo-server#81`):
- Backend silently ignores the unknown field → bot still sends as
  itself, no error. Backward compatible from both sides.

## Before / after request body

**Before** (and after, when `onBehalfOf` unset):

```json
POST /v1/bot/sendMessage
{
  "channel_id": "g_abc",
  "channel_type": 1,
  "payload": { "type": 1, "content": "hi" }
}
```

**After** (when `onBehalfOf="yu_uid"` and a server-side grant is active):

```json
POST /v1/bot/sendMessage
{
  "channel_id": "g_abc",
  "channel_type": 1,
  "on_behalf_of": "yu_uid",
  "payload": { "type": 1, "content": "hi" }
}
```

## Test results

```
Test Files  20 passed (20)
     Tests  602 passed (602)
```

`npm run type-check` clean. No existing test changes.

## Review tier

`low-risk` — single subdir, no auth/schema/infra, ~10 LOC core, fully
backward compatible. ReviewBot codex-review optional.
